### PR TITLE
feat: merge session branch via 'm' key with rebase + PR flow

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
 use crate::config;
@@ -347,6 +347,11 @@ pub fn create_session(
         let label = next_session_label(&project.sessions);
         (project.repo_path.clone(), label, storage.base_dir(), project.name.clone())
     };
+
+    // Sync main branch before creating worktree so session starts from latest
+    if let Err(e) = WorktreeManager::sync_main(&repo_path) {
+        eprintln!("Warning: failed to sync main branch: {}", e);
+    }
 
     // Create worktree under ~/.the-controller/worktrees/{project_name}/{label}/
     let worktree_dir = base_dir
@@ -740,6 +745,103 @@ pub async fn list_github_issues(repo_path: String) -> Result<Vec<crate::models::
             .map_err(|e| format!("Failed to parse gh output: {}", e))?;
 
     Ok(issues)
+}
+
+const MAX_MERGE_RETRIES: u32 = 5;
+const REBASE_POLL_INTERVAL_SECS: u64 = 3;
+
+#[tauri::command]
+pub async fn merge_session_branch(
+    state: State<'_, AppState>,
+    app_handle: AppHandle,
+    project_id: String,
+    session_id: String,
+) -> Result<crate::models::MergeResponse, String> {
+    let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let session_uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    let (repo_path, worktree_path, branch_name) = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        let project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
+        let session = project
+            .sessions
+            .iter()
+            .find(|s| s.id == session_uuid)
+            .ok_or_else(|| "Session not found".to_string())?;
+        let wt_path = session
+            .worktree_path
+            .clone()
+            .ok_or_else(|| "Session has no worktree".to_string())?;
+        let branch = session
+            .worktree_branch
+            .clone()
+            .ok_or_else(|| "Session has no branch".to_string())?;
+        (project.repo_path.clone(), wt_path, branch)
+    };
+
+    for attempt in 0..MAX_MERGE_RETRIES {
+        let rp = repo_path.clone();
+        let wt = worktree_path.clone();
+        let br = branch_name.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            if WorktreeManager::is_rebase_in_progress(&wt) {
+                // Rebase still in progress from a previous attempt — wait
+                Ok(crate::worktree::MergeResult::RebaseConflicts)
+            } else {
+                WorktreeManager::merge_via_pr(&rp, &wt, &br)
+            }
+        })
+        .await
+        .map_err(|e| format!("Task failed: {}", e))??;
+
+        match result {
+            crate::worktree::MergeResult::PrCreated(url) => {
+                return Ok(crate::models::MergeResponse::PrCreated { url });
+            }
+            crate::worktree::MergeResult::RebaseConflicts => {
+                // Send a prompt to Claude to resolve conflicts
+                let prompt = if attempt == 0 {
+                    "There are rebase conflicts that need to be resolved. Please check `git status` to see the conflicting files, resolve all conflicts, then run `git add .` and `git rebase --continue`. Do NOT abort the rebase.\n"
+                } else {
+                    "There are new rebase conflicts after syncing with upstream. Please check `git status`, resolve all conflicts, then run `git add .` and `git rebase --continue`. Do NOT abort the rebase.\n"
+                };
+                {
+                    let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
+                    let _ = pty_manager.write_to_session(session_uuid, prompt.as_bytes());
+                }
+
+                // Emit status event so frontend can show progress
+                let _ = app_handle.emit("merge-status", format!(
+                    "Rebase conflicts (attempt {}/{}). Claude is resolving...",
+                    attempt + 1, MAX_MERGE_RETRIES
+                ));
+
+                // Poll until rebase is no longer in progress
+                let wt_poll = worktree_path.clone();
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_secs(REBASE_POLL_INTERVAL_SECS)).await;
+                    let wt_check = wt_poll.clone();
+                    let still_rebasing = tokio::task::spawn_blocking(move || {
+                        WorktreeManager::is_rebase_in_progress(&wt_check)
+                    })
+                    .await
+                    .map_err(|e| format!("Task failed: {}", e))?;
+                    if !still_rebasing {
+                        break;
+                    }
+                }
+
+                // Loop back — will sync main and rebase again
+                continue;
+            }
+        }
+    }
+
+    Err(format!(
+        "Merge failed after {} attempts due to recurring conflicts",
+        MAX_MERGE_RETRIES
+    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
             commands::generate_project_names,
             commands::scaffold_project,
             commands::list_github_issues,
+            commands::merge_session_branch,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -56,6 +56,15 @@ pub struct GithubLabel {
     pub name: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum MergeResponse {
+    #[serde(rename = "pr_created")]
+    PrCreated { url: String },
+    #[serde(rename = "rebase_conflicts")]
+    RebaseConflicts,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,5 +1,14 @@
 use git2::Repository;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Result of a merge attempt.
+pub enum MergeResult {
+    /// PR created successfully — contains the PR URL.
+    PrCreated(String),
+    /// Rebase has conflicts — worktree left in conflicted state for Claude to resolve.
+    RebaseConflicts,
+}
 
 pub struct WorktreeManager;
 
@@ -59,6 +68,145 @@ impl WorktreeManager {
             .map_err(|e| format!("failed to create worktree: {}", e))?;
 
         Ok(worktree_dir.to_path_buf())
+    }
+
+    /// Detect the main branch name (main or master) for a repository.
+    pub fn detect_main_branch(repo_path: &str) -> Result<String, String> {
+        let repo = Repository::open(repo_path)
+            .map_err(|e| format!("failed to open repo: {}", e))?;
+
+        for name in &["main", "master"] {
+            if repo.find_branch(name, git2::BranchType::Local).is_ok() {
+                return Ok(name.to_string());
+            }
+        }
+
+        // Fall back to whatever HEAD points to
+        let head = repo.head().map_err(|e| format!("failed to get HEAD: {}", e))?;
+        if let Some(shorthand) = head.shorthand() {
+            return Ok(shorthand.to_string());
+        }
+
+        Err("Could not detect main branch".to_string())
+    }
+
+    /// Sync the main branch by pulling from remote.
+    /// Runs `git pull` in the repo directory.
+    pub fn sync_main(repo_path: &str) -> Result<(), String> {
+        let output = Command::new("git")
+            .args(["pull"])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|e| format!("failed to run git pull: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Ignore "no remote" errors — local-only repos are fine
+            if stderr.contains("No remote") || stderr.contains("no tracking information") {
+                return Ok(());
+            }
+            return Err(format!("git pull failed: {}", stderr.trim()));
+        }
+        Ok(())
+    }
+
+    /// Merge a session branch into main via rebase + GitHub PR.
+    ///
+    /// Steps:
+    /// 1. Sync main (git pull)
+    /// 2. Rebase session branch onto main
+    /// 3. If conflicts, leave worktree in conflicted state (caller sends prompt to Claude)
+    /// 4. Push branch to remote
+    /// 5. Create PR via gh CLI
+    pub fn merge_via_pr(
+        repo_path: &str,
+        worktree_path: &str,
+        branch_name: &str,
+    ) -> Result<MergeResult, String> {
+        let main_branch = Self::detect_main_branch(repo_path)?;
+
+        // 1. Sync main
+        Self::sync_main(repo_path)?;
+
+        // 2. Rebase session branch onto main
+        let rebase_output = Command::new("git")
+            .args(["rebase", &main_branch])
+            .current_dir(worktree_path)
+            .output()
+            .map_err(|e| format!("failed to run git rebase: {}", e))?;
+
+        if !rebase_output.status.success() {
+            // Leave the rebase in progress — don't abort.
+            // Caller will send a prompt to Claude in the session to resolve conflicts.
+            return Ok(MergeResult::RebaseConflicts);
+        }
+
+        // 3. Push branch to remote
+        Self::push_and_create_pr(worktree_path, branch_name)
+    }
+
+    /// Push branch and create a PR. Called after a clean rebase (or after
+    /// Claude resolves conflicts and the user retries 'm').
+    pub fn push_and_create_pr(
+        worktree_path: &str,
+        branch_name: &str,
+    ) -> Result<MergeResult, String> {
+        // Push branch to remote
+        let push_output = Command::new("git")
+            .args(["push", "-u", "origin", branch_name, "--force-with-lease"])
+            .current_dir(worktree_path)
+            .output()
+            .map_err(|e| format!("failed to run git push: {}", e))?;
+
+        if !push_output.status.success() {
+            let stderr = String::from_utf8_lossy(&push_output.stderr);
+            return Err(format!("Push failed: {}", stderr.trim()));
+        }
+
+        // Create PR via gh CLI
+        let pr_output = Command::new("gh")
+            .args(["pr", "create", "--fill", "--head", branch_name])
+            .current_dir(worktree_path)
+            .output()
+            .map_err(|e| format!("failed to run gh pr create: {}", e))?;
+
+        if !pr_output.status.success() {
+            let stderr = String::from_utf8_lossy(&pr_output.stderr);
+            // If PR already exists, try to get its URL
+            if stderr.contains("already exists") {
+                let view_output = Command::new("gh")
+                    .args(["pr", "view", branch_name, "--json", "url", "-q", ".url"])
+                    .current_dir(worktree_path)
+                    .output()
+                    .map_err(|e| format!("failed to get existing PR: {}", e))?;
+
+                if view_output.status.success() {
+                    let url = String::from_utf8_lossy(&view_output.stdout).trim().to_string();
+                    return Ok(MergeResult::PrCreated(url));
+                }
+            }
+            return Err(format!("PR creation failed: {}", stderr.trim()));
+        }
+
+        let pr_url = String::from_utf8_lossy(&pr_output.stdout).trim().to_string();
+        Ok(MergeResult::PrCreated(pr_url))
+    }
+
+    /// Check if a worktree is in the middle of a rebase.
+    pub fn is_rebase_in_progress(worktree_path: &str) -> bool {
+        let git_dir = Path::new(worktree_path).join(".git");
+        // Worktrees use a .git file pointing to the real git dir
+        if git_dir.is_file() {
+            if let Ok(content) = std::fs::read_to_string(&git_dir) {
+                if let Some(real_dir) = content.strip_prefix("gitdir: ") {
+                    let real_dir = real_dir.trim();
+                    return Path::new(real_dir).join("rebase-merge").exists()
+                        || Path::new(real_dir).join("rebase-apply").exists();
+                }
+            }
+        }
+        // Fallback: check directly
+        git_dir.join("rebase-merge").exists() || git_dir.join("rebase-apply").exists()
     }
 
     /// Remove a worktree by deleting its directory and pruning the worktree reference.
@@ -172,6 +320,26 @@ mod tests {
             result.unwrap_err().contains("already exists"),
             "error should mention 'already exists'"
         );
+    }
+
+    #[test]
+    fn test_detect_main_branch() {
+        let (_tmp, repo_path) = setup_test_repo();
+        // Default branch from init + commit on HEAD is typically "main" or "master"
+        let branch = WorktreeManager::detect_main_branch(&repo_path).expect("detect main branch");
+        assert!(
+            branch == "main" || branch == "master",
+            "expected 'main' or 'master', got '{}'",
+            branch
+        );
+    }
+
+    #[test]
+    fn test_sync_main_local_only_repo() {
+        let (_tmp, repo_path) = setup_test_repo();
+        // sync_main on a repo with no remote should succeed (no-op)
+        let result = WorktreeManager::sync_main(&repo_path);
+        assert!(result.is_ok(), "sync_main should succeed on local-only repo: {:?}", result);
     }
 
     #[test]

--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -16,6 +16,7 @@
     { key: "d", description: "Delete focused item (session or project)" },
     { key: "a", description: "Archive focused item (session or project)" },
     { key: "A", description: "View archived projects" },
+    { key: "m", description: "Merge session branch (create PR)" },
     { key: "f", description: "Find project (fuzzy finder)" },
     { key: "n", description: "New project" },
     { key: "s", description: "Toggle sidebar" },

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -345,6 +345,11 @@
           dispatchAction({ type: "create-session", projectId: currentFocus.projectId });
         }
         return true;
+      case "m":
+        if (currentFocus?.type === "session") {
+          dispatchAction({ type: "merge-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
+        }
+        return true;
       case "s":
         sidebarVisible.update(v => !v);
         return true;

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -136,6 +136,24 @@ describe('HotkeyManager', () => {
       unsub();
     });
 
+    it('m dispatches merge-session when session focused', () => {
+      focusTarget.set({ type: 'session', sessionId: 'sess-1', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('m');
+      expect(captured).toEqual({ type: 'merge-session', sessionId: 'sess-1', projectId: 'proj-1' });
+      unsub();
+    });
+
+    it('m does nothing when project focused', () => {
+      focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('m');
+      expect(captured).toBeNull();
+      unsub();
+    });
+
     it('modifier keys alone do not dispatch', () => {
       const initial = get(activeSessionId);
       pressKey('Shift');

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -27,6 +27,8 @@
   let deleteSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let archiveSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let archiveProjectTarget: Project | null = $state(null);
+  let mergeSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
+  let mergeInProgress = $state(false);
   let isArchiveView = $state(false);
   let archivedProjectList: Project[] = $state([]);
 
@@ -212,6 +214,18 @@
         }
         case "toggle-archive-view": {
           archiveView.update(v => !v);
+          break;
+        }
+        case "merge-session": {
+          const proj = projectList.find((p) => p.id === action.projectId);
+          const sess = proj?.sessions.find((s) => s.id === action.sessionId);
+          if (sess) {
+            mergeSessionTarget = {
+              sessionId: action.sessionId,
+              projectId: action.projectId,
+              label: sess.label,
+            };
+          }
           break;
         }
       }
@@ -421,6 +435,35 @@
       await loadProjects();
     } catch (e) {
       showToast(String(e), "error");
+    }
+  }
+
+  async function mergeSession(projectId: string, sessionId: string) {
+    mergeInProgress = true;
+
+    // Focus the terminal so user can watch Claude resolve conflicts if any
+    activeSessionId.set(sessionId);
+    setTimeout(() => {
+      hotkeyAction.set({ type: "focus-terminal" });
+      setTimeout(() => hotkeyAction.set(null), 0);
+    }, 50);
+
+    // Listen for intermediate merge status events
+    let unlistenStatus: (() => void) | null = null;
+    listen<string>("merge-status", (event) => {
+      showToast(event.payload, "info");
+    }).then(fn => { unlistenStatus = fn; });
+
+    try {
+      const result: { type: string; url?: string } = await invoke("merge_session_branch", { projectId, sessionId });
+      if (result.type === "pr_created") {
+        showToast(`PR created: ${result.url}`, "info");
+      }
+    } catch (e) {
+      showToast(String(e), "error");
+    } finally {
+      mergeInProgress = false;
+      unlistenStatus?.();
     }
   }
 
@@ -635,6 +678,21 @@
         archiveProjectTarget = null;
       }}
       onClose={() => (archiveProjectTarget = null)}
+    />
+  {/if}
+
+  {#if mergeSessionTarget}
+    <ConfirmModal
+      title="Merge Session Branch"
+      message={`Create PR to merge "${mergeSessionTarget.label}" into main?${mergeInProgress ? " Merging..." : ""}`}
+      confirmLabel="Merge"
+      onConfirm={() => {
+        if (mergeSessionTarget && !mergeInProgress) {
+          mergeSession(mergeSessionTarget.projectId, mergeSessionTarget.sessionId);
+        }
+        mergeSessionTarget = null;
+      }}
+      onClose={() => (mergeSessionTarget = null)}
     />
   {/if}
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -42,6 +42,7 @@ export type HotkeyAction =
   | { type: "unarchive-session"; sessionId: string; projectId: string }
   | { type: "unarchive-project"; projectId: string }
   | { type: "toggle-archive-view" }
+  | { type: "merge-session"; sessionId: string; projectId: string }
   | null;
 
 export const hotkeyAction = writable<HotkeyAction>(null);


### PR DESCRIPTION
## Summary
- Adds 'm' keybinding on focused sessions to merge branch into main via rebase + GitHub PR
- On rebase conflicts, prompts Claude in the session terminal to resolve, polls until done, and auto-retries (up to 5 attempts)
- Syncs main branch (`git pull`) before creating new session worktrees so they start from latest

Closes #9

## Test plan
- [x] Rust tests pass (46 tests)
- [x] Frontend tests pass (111 tests, including 2 new for 'm' key)
- [ ] Manual: press 'm' on a session with commits, verify PR is created
- [ ] Manual: verify rebase conflict flow prompts Claude and auto-retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)