### PR TITLE
tune: increase session auto-focus dwell time to 5s

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -22,7 +22,7 @@
   let lastEscapeTime = 0;
 
   const DOUBLE_ESCAPE_MS = 300;
-  const DWELL_FOCUS_MS = 2000;
+  const DWELL_FOCUS_MS = 5000;
   let dwellTimer: ReturnType<typeof setTimeout> | null = null;
 
   function clearDwellTimer() {


### PR DESCRIPTION
## Summary
- Increase sidebar dwell-focus timer from 2s to 5s to reduce unwanted terminal auto-focus when navigating

## Test plan
- [ ] Navigate sidebar with j/k — terminal should not auto-focus until 5s of inactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)