### PR TITLE
fix: session exits immediately when assigned a GitHub issue

### DIFF
--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -85,7 +85,7 @@ impl PtyManager {
             cmd.arg("--settings");
             cmd.arg(settings_json);
             if let Some(prompt) = initial_prompt {
-                cmd.arg("--prompt");
+                cmd.arg("--append-system-prompt");
                 cmd.arg(prompt);
             }
         }

--- a/src-tauri/src/tmux.rs
+++ b/src-tauri/src/tmux.rs
@@ -44,7 +44,7 @@ impl TmuxManager {
             args.push("--settings");
             args.push(&settings_json);
             if let Some(prompt) = initial_prompt {
-                args.push("--prompt");
+                args.push("--append-system-prompt");
                 args.push(prompt);
             }
         }


### PR DESCRIPTION
## Summary
- `--prompt` is not a valid `claude` CLI flag — it was likely interpreted as `-p/--print` (non-interactive mode), causing sessions to exit immediately when a GitHub issue was assigned
- Changed to `--append-system-prompt` which injects issue context into the system prompt while keeping the session interactive
- Fixed in both direct PTY (`pty_manager.rs`) and tmux (`tmux.rs`) code paths

## Test plan
- [ ] Create a new session with a GitHub issue assigned → session should stay alive and show issue context
- [ ] Create a new session without an issue → should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)