### PR TITLE
fix: force terminal repaint and PTY resize on session switch

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -147,8 +147,18 @@
 
     // Refit when becoming visible (display: none -> block doesn't trigger ResizeObserver)
     mutationObserver = new MutationObserver(() => {
-      if (containerEl && containerEl.offsetParent !== null && fitAddon) {
+      if (containerEl && containerEl.offsetParent !== null && fitAddon && term) {
         fitAddon.fit();
+        // Force full repaint — canvas content may be stale after display:none
+        term.refresh(0, term.rows - 1);
+        // Notify PTY of dimensions so the program gets SIGWINCH and redraws its TUI
+        invoke("resize_pty", {
+          sessionId,
+          rows: term.rows,
+          cols: term.cols,
+        }).catch((err: unknown) => {
+          console.error("Failed to resize PTY:", err);
+        });
       }
     });
     if (containerEl?.parentElement) {


### PR DESCRIPTION
## Summary
- When navigating away from a codex session and back, the terminal drawing was garbled
- Root cause: the MutationObserver only called `fitAddon.fit()` when a terminal became visible, but didn't force a canvas repaint or notify the PTY backend
- Now also calls `term.refresh()` for a full repaint and `resize_pty` to send SIGWINCH so TUI programs (like codex) redraw their interface

## Test plan
- [ ] Start a codex session, navigate to another session, navigate back — terminal should render cleanly
- [ ] Verify claude sessions also render correctly after switching
- [ ] Resize window while on a different session, switch back — dimensions should be correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)