### PR TITLE
feat: auto-start assistant work when session has GitHub issue

### DIFF
--- a/src-tauri/src/session_args.rs
+++ b/src-tauri/src/session_args.rs
@@ -9,6 +9,9 @@ const CODEX_FULL_PERMISSION_ARGS: [&str; 4] = [
 
 /// Build command-line arguments for spawned assistant sessions.
 /// Keeps Claude-specific hooks and applies full permissions for Codex.
+/// When an `initial_prompt` is provided (e.g. from a GitHub issue), it is
+/// injected as system context AND as a positional user prompt so the
+/// assistant starts working immediately without waiting for user input.
 pub fn build_session_args(
     command: &str,
     session_id: Uuid,
@@ -35,6 +38,12 @@ pub fn build_session_args(
             args.extend(CODEX_FULL_PERMISSION_ARGS.iter().map(|s| s.to_string()));
         }
         _ => {}
+    }
+
+    // Positional prompt (must come after all flags) so the assistant
+    // begins working immediately when an issue is attached.
+    if let Some(prompt) = initial_prompt {
+        args.push(prompt.to_string());
     }
 
     args
@@ -84,5 +93,35 @@ mod tests {
         assert!(parsed.get("hooks").is_some());
         assert_eq!(args[2], "--append-system-prompt");
         assert_eq!(args[3], "fix this");
+        // Positional prompt at end so claude auto-starts
+        assert_eq!(args[4], "fix this");
+    }
+
+    #[test]
+    fn codex_args_include_positional_prompt_when_issue_attached() {
+        let session_id = Uuid::new_v4();
+        let args = build_session_args("codex", session_id, false, Some("fix this"));
+        assert_eq!(
+            args,
+            vec![
+                "--sandbox".to_string(),
+                "danger-full-access".to_string(),
+                "--ask-for-approval".to_string(),
+                "never".to_string(),
+                "fix this".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn no_positional_prompt_when_no_issue() {
+        let session_id = Uuid::new_v4();
+        let claude_args = build_session_args("claude", session_id, false, None);
+        // Only --settings and its value, no positional prompt
+        assert_eq!(claude_args.len(), 2);
+
+        let codex_args = build_session_args("codex", session_id, false, None);
+        // Only the 4 permission args, no positional prompt
+        assert_eq!(codex_args.len(), 4);
     }
 }


### PR DESCRIPTION
## Summary
- Pass issue context as a positional prompt argument (in addition to `--append-system-prompt` for Claude) so both Claude and Codex begin working immediately when a session is spawned with a GitHub issue
- Previously, the issue was only injected as system prompt context, requiring the user to type something to kick off work
- Codex now also receives the issue context (previously it was ignored entirely)

## Test plan
- [x] Unit tests for claude with issue, codex with issue, and no-issue cases all pass
- [x] All 12 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)