### PR TITLE
fix: gate terminal input during init to prevent spurious newlines

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -22,6 +22,11 @@
   let unlistenOutput: UnlistenFn | undefined;
   let unlistenStatus: UnlistenFn | undefined;
 
+  // Gate: suppress onData forwarding during initialization to prevent
+  // xterm.js auto-responses to terminal queries (DA, DSR) from being
+  // sent to the PTY as input. See GitHub issue #49.
+  let inputReady = false;
+
   async function handleImagePaste(
     writeToPty: (data: string) => Promise<unknown>,
   ) {
@@ -68,23 +73,31 @@
     // Handle keys that xterm.js doesn't natively support
     term.attachCustomKeyEventHandler(
       makeCustomKeyHandler(
-        (data) => invoke("send_raw_to_pty", { sessionId, data }),
+        (data) => {
+          if (!inputReady) return;
+          invoke("send_raw_to_pty", { sessionId, data });
+        },
         {
           onImagePaste: () => {
+            if (!inputReady) return;
             handleImagePaste(writeToPty);
           },
         },
       ),
     );
 
-    // Connect user input to PTY
+    // Connect user input to PTY (gated until initialization settles)
     term.onData((data: string) => {
+      if (!inputReady) return;
       writeToPty(data).catch((err) => {
         console.error("Failed to write to PTY:", err);
       });
     });
 
-    // Listen for PTY output (base64-encoded)
+    // Listen for PTY output (base64-encoded).
+    // After the listener is set up, allow a brief window for tmux's
+    // initial terminal queries and xterm auto-responses to settle,
+    // then enable input forwarding.
     listen<string>(`pty-output:${sessionId}`, (event) => {
       if (term) {
         const bytes = Uint8Array.from(atob(event.payload), (c) =>
@@ -94,6 +107,9 @@
       }
     }).then((fn) => {
       unlistenOutput = fn;
+      setTimeout(() => {
+        inputReady = true;
+      }, 100);
     });
 
     // Listen for session status changes


### PR DESCRIPTION
## Summary
- After restart, xterm.js may auto-respond to terminal capability queries (DA, DSR) sent by tmux during reattachment, causing 1-2 newlines to be injected into sessions
- Adds an `inputReady` gate in `Terminal.svelte` that suppresses all input forwarding (`onData`, `send_raw_to_pty`, paste) for 100ms after the PTY output listener is established
- This gives the tmux attachment and terminal query/response cycle time to settle before user input is forwarded

closes #49

## Test plan
- [x] All 112 frontend tests pass
- [x] All 12 Rust integration tests pass
- [ ] Manual: restart app with active sessions, verify no spurious newlines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)