### PR TITLE
feat: add `l` key shortcut to load task in issue picker

### DIFF
--- a/src/lib/IssuePickerModal.svelte
+++ b/src/lib/IssuePickerModal.svelte
@@ -76,6 +76,7 @@
         e.stopPropagation();
         selectedIndex = (selectedIndex - 1 + itemCount) % itemCount;
         break;
+      case "l":
       case "Enter":
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- Adds `l` as a vim-style keyboard shortcut to confirm task selection in the IssuePickerModal, alongside existing `Enter` key
- Complements existing `j`/`k` navigation for a consistent vim keybinding experience

## Test Plan
- [ ] Open issue picker modal when creating a new session
- [ ] Navigate with `j`/`k`, press `l` to confirm selection
- [ ] Verify `Enter` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)