### PR TITLE
perf: remove redundant git pull from session creation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -383,11 +383,6 @@ pub fn create_session(
         (project.repo_path.clone(), label, storage.base_dir(), project.name.clone())
     };
 
-    // Sync main branch before creating worktree so session starts from latest
-    if let Err(e) = WorktreeManager::sync_main(&repo_path) {
-        eprintln!("Warning: failed to sync main branch: {}", e);
-    }
-
     // Create worktree under ~/.the-controller/worktrees/{project_name}/{label}/
     let worktree_dir = base_dir
         .join("worktrees")


### PR DESCRIPTION
## Summary
- Removed synchronous `git pull` (via `sync_main`) from `create_session` that blocked every session spawn with a network call
- This sync is redundant because `merge_via_pr` already syncs main before rebasing at PR time

## Test plan
- [x] All 12 Rust tests pass
- [ ] Create a session with "no issue" — should spin up noticeably faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)