### PR TITLE
ui: move 'No issue' to last in issue picker list

### DIFF
--- a/src/lib/IssuePickerModal.svelte
+++ b/src/lib/IssuePickerModal.svelte
@@ -23,7 +23,7 @@
   let error: string | null = $state(null);
   let selectedIndex = $state(0);
 
-  // Total items: "No issue" (index 0) + issues
+  // Total items: issues + "No issue" (last)
   let itemCount = $derived(issues.length + 1);
 
   onMount(() => {
@@ -48,10 +48,10 @@
   });
 
   function confirm() {
-    if (selectedIndex === 0) {
+    if (selectedIndex === issues.length) {
       onSkip();
     } else {
-      onSelect(issues[selectedIndex - 1]);
+      onSelect(issues[selectedIndex]);
     }
   }
 
@@ -96,19 +96,19 @@
       <div class="status error">{error}</div>
     {:else}
       <ul class="issue-list">
-        <li>
-          <button class="issue-btn no-issue" class:selected={selectedIndex === 0} onclick={onSkip}>
-            No issue
-          </button>
-        </li>
         {#each issues as issue, i}
           <li>
-            <button class="issue-btn" class:selected={selectedIndex === i + 1} onclick={() => onSelect(issue)}>
+            <button class="issue-btn" class:selected={selectedIndex === i} onclick={() => onSelect(issue)}>
               <span class="issue-number">#{issue.number}</span>
               <span class="issue-title">{issue.title}</span>
             </button>
           </li>
         {/each}
+        <li>
+          <button class="issue-btn no-issue" class:selected={selectedIndex === issues.length} onclick={onSkip}>
+            No issue
+          </button>
+        </li>
       </ul>
     {/if}
   </div>


### PR DESCRIPTION
## Summary
- Moves the "No issue" option from the top to the bottom of the issue picker modal list
- Updates index logic so issues use indices `0..n-1` and "No issue" is at index `n`

## Test plan
- [ ] Open the issue picker modal and verify "No issue" appears last
- [ ] Verify keyboard navigation (j/k) works correctly with the new ordering
- [ ] Verify selecting an issue and selecting "No issue" both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)