### PR TITLE
fix: focus new project in sidebar after loading

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -592,8 +592,10 @@
       onSelect={async (entry) => {
         showFuzzyFinder = false;
         try {
-          await invoke("load_project", { name: entry.name, repoPath: entry.path });
+          const project = await invoke<Project>("load_project", { name: entry.name, repoPath: entry.path });
           await loadProjects();
+          expandedProjects.update(s => { const next = new Set(s); next.add(project.id); return next; });
+          focusTarget.set({ type: "project", projectId: project.id });
         } catch (e) {
           showToast(String(e), "error");
         }
@@ -604,9 +606,11 @@
 
   {#if showNewProjectModal}
     <NewProjectModal
-      onCreated={async () => {
+      onCreated={async (project) => {
         showNewProjectModal = false;
         await loadProjects();
+        expandedProjects.update(s => { const next = new Set(s); next.add(project.id); return next; });
+        focusTarget.set({ type: "project", projectId: project.id });
       }}
       onClose={() => (showNewProjectModal = false)}
     />


### PR DESCRIPTION
## Summary
- After loading a project via FuzzyFinder or creating one via NewProjectModal, the new project is now expanded and focused in the sidebar
- Uses existing `focusTarget` and `expandedProjects` stores — no new infrastructure needed

closes #47

## Test plan
- [ ] Load a project via FuzzyFinder (Ctrl+P) — verify sidebar focuses and expands the new project
- [ ] Create a project via NewProjectModal — verify sidebar focuses and expands the new project

🤖 Generated with [Claude Code](https://claude.com/claude-code)