### PR TITLE
fix: scroll selected issue into view on j/k navigation

### DIFF
--- a/src/lib/IssuePickerModal.svelte
+++ b/src/lib/IssuePickerModal.svelte
@@ -55,6 +55,14 @@
     }
   }
 
+  function scrollSelectedIntoView() {
+    // Wait a tick for Svelte to update the DOM with the new selected class
+    requestAnimationFrame(() => {
+      const el = document.querySelector('.issue-list .issue-btn.selected');
+      el?.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
       e.preventDefault();
@@ -70,11 +78,13 @@
         e.preventDefault();
         e.stopPropagation();
         selectedIndex = (selectedIndex + 1) % itemCount;
+        scrollSelectedIntoView();
         break;
       case "k":
         e.preventDefault();
         e.stopPropagation();
         selectedIndex = (selectedIndex - 1 + itemCount) % itemCount;
+        scrollSelectedIntoView();
         break;
       case "l":
       case "Enter":


### PR DESCRIPTION
## Summary
- Adds `scrollIntoView({ block: 'nearest' })` when navigating the issue picker with `j`/`k` keys
- Fixes the last issue being invisible when scrolled to via keyboard

## Test plan
- [ ] Open issue picker with enough issues to overflow (>50vh)
- [ ] Press `k` to wrap to the last item — verify it scrolls into view
- [ ] Press `j`/`k` repeatedly — verify selection stays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)