### PR TITLE
feat: add session summary pane with prompt and commit progress

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -427,6 +427,7 @@ pub fn create_session(
             archived: false,
             kind: kind.clone(),
             github_issue,
+            initial_prompt: initial_prompt.clone(),
         };
         project.sessions.push(session_config);
         storage.save_project(&project).map_err(|e| e.to_string())?;
@@ -1095,6 +1096,91 @@ pub async fn copy_image_file_to_clipboard(app: AppHandle, path: String) -> Resul
         .map_err(|e| format!("Failed to write image to clipboard: {e}"))
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CommitInfo {
+    pub hash: String,
+    pub message: String,
+}
+
+#[tauri::command]
+pub fn get_session_commits(
+    state: State<AppState>,
+    project_id: String,
+    session_id: String,
+) -> Result<Vec<CommitInfo>, String> {
+    let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let session_uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    let storage = state.storage.lock().map_err(|e| e.to_string())?;
+    let project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
+
+    let session = project
+        .sessions
+        .iter()
+        .find(|s| s.id == session_uuid)
+        .ok_or_else(|| "Session not found".to_string())?;
+
+    let worktree_path = match &session.worktree_path {
+        Some(p) => p.clone(),
+        None => return Ok(vec![]),
+    };
+
+    let repo = git2::Repository::discover(&worktree_path)
+        .map_err(|e| format!("Failed to open repo: {e}"))?;
+
+    // Walk commits on the session branch that aren't on the main branch.
+    // The session branch name matches the session label.
+    let head = repo.head().map_err(|e| format!("No HEAD: {e}"))?;
+    let head_commit = head.peel_to_commit().map_err(|e| e.to_string())?;
+
+    // Find the merge base with the default branch (master or main)
+    let main_oid = find_main_branch_oid(&repo);
+
+    let mut revwalk = repo.revwalk().map_err(|e| e.to_string())?;
+    revwalk.push(head_commit.id()).map_err(|e| e.to_string())?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL).map_err(|e| e.to_string())?;
+
+    let mut commits = Vec::new();
+    for oid in revwalk {
+        let oid = oid.map_err(|e| e.to_string())?;
+        // Stop at merge base (commits shared with main)
+        if let Some(main) = main_oid {
+            if oid == main {
+                break;
+            }
+            if let Ok(base) = repo.merge_base(oid, main) {
+                if base == oid {
+                    break;
+                }
+            }
+        }
+        let commit = repo.find_commit(oid).map_err(|e| e.to_string())?;
+        let message = commit.summary().unwrap_or("").to_string();
+        // Skip the initial worktree commit
+        if message.starts_with("Initial commit") {
+            continue;
+        }
+        let hash = format!("{}", &oid.to_string()[..7]);
+        commits.push(CommitInfo { hash, message });
+        if commits.len() >= 20 {
+            break;
+        }
+    }
+
+    Ok(commits)
+}
+
+fn find_main_branch_oid(repo: &git2::Repository) -> Option<git2::Oid> {
+    for name in &["refs/heads/master", "refs/heads/main"] {
+        if let Ok(reference) = repo.find_reference(name) {
+            if let Ok(commit) = reference.peel_to_commit() {
+                return Some(commit.id());
+            }
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1155,6 +1241,7 @@ mod tests {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -1164,6 +1251,7 @@ mod tests {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
         ];
         assert_eq!(next_session_label(&sessions), "session-3");
@@ -1181,6 +1269,7 @@ mod tests {
                 archived: true,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -1190,6 +1279,7 @@ mod tests {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -1199,6 +1289,7 @@ mod tests {
                 archived: true,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
         ];
         // Max is session-3, so next is session-4
@@ -1216,6 +1307,7 @@ mod tests {
             archived: false,
             kind: "claude".to_string(),
             github_issue: None,
+            initial_prompt: None,
         }];
         assert_eq!(next_session_label(&sessions), "session-4");
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() {
             commands::remove_github_label,
             commands::merge_session_branch,
             commands::copy_image_file_to_clipboard,
+            commands::get_session_commits,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -23,6 +23,8 @@ pub struct SessionConfig {
     pub kind: String,
     #[serde(default)]
     pub github_issue: Option<GithubIssue>,
+    #[serde(default)]
+    pub initial_prompt: Option<String>,
 }
 
 fn default_kind() -> String {
@@ -87,6 +89,7 @@ mod tests {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             }],
         };
 
@@ -138,6 +141,7 @@ mod tests {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             }],
         };
 
@@ -173,6 +177,7 @@ mod tests {
                 url: "https://github.com/kwannoel/the-controller/issues/22".to_string(),
                 labels: vec![],
             }),
+            initial_prompt: None,
         };
         let json = serde_json::to_string(&session).expect("serialize");
         let deserialized: SessionConfig = serde_json::from_str(&json).expect("deserialize");

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -183,6 +183,7 @@ mod tests {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             }],
         }
     }

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -39,6 +39,7 @@ fn test_project_lifecycle() {
         archived: false,
         kind: "claude".to_string(),
         github_issue: None,
+        initial_prompt: None,
     });
     storage.save_project(&project).expect("save with session");
 
@@ -119,6 +120,7 @@ fn test_sessions_persist_across_restarts() {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -128,6 +130,7 @@ fn test_sessions_persist_across_restarts() {
                 archived: false,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -137,6 +140,7 @@ fn test_sessions_persist_across_restarts() {
                 archived: true,
                 kind: "claude".to_string(),
                 github_issue: None,
+                initial_prompt: None,
             },
         ],
     };
@@ -241,6 +245,7 @@ fn test_worktrees_persist_across_restarts() {
             archived: false,
             kind: "claude".to_string(),
             github_issue: None,
+            initial_prompt: None,
         }],
     };
     storage.save_project(&project).expect("save project");
@@ -278,6 +283,7 @@ fn test_migrate_worktree_paths_renames_uuid_dir() {
             archived: false,
             kind: "claude".to_string(),
             github_issue: None,
+            initial_prompt: None,
         }],
     };
     storage.save_project(&project).expect("save project");
@@ -321,6 +327,7 @@ fn test_migrate_worktree_paths_noop_when_no_uuid_dir() {
             archived: false,
             kind: "claude".to_string(),
             github_issue: None,
+            initial_prompt: None,
         }],
     };
     storage.save_project(&project).expect("save project");
@@ -369,6 +376,7 @@ fn test_migrate_worktree_paths_noop_on_name_collision() {
             archived: false,
             kind: "claude".to_string(),
             github_issue: None,
+            initial_prompt: None,
         }],
     };
     storage.save_project(&project).expect("save project");

--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { onDestroy } from "svelte";
+  import { projects, sessionStatuses, type Project, type SessionStatus } from "./stores";
+
+  interface Props {
+    sessionId: string;
+  }
+
+  let { sessionId }: Props = $props();
+
+  interface CommitInfo {
+    hash: string;
+    message: string;
+  }
+
+  let projectList: Project[] = $state([]);
+  let statuses: Map<string, SessionStatus> = $state(new Map());
+  let commits: CommitInfo[] = $state([]);
+
+  $effect(() => {
+    const unsub = projects.subscribe((v) => { projectList = v; });
+    return unsub;
+  });
+
+  $effect(() => {
+    const unsub = sessionStatuses.subscribe((v) => { statuses = v; });
+    return unsub;
+  });
+
+  let session = $derived(
+    projectList.flatMap((p) =>
+      p.sessions.map((s) => ({ ...s, projectId: p.id }))
+    ).find((s) => s.id === sessionId) ?? null
+  );
+
+  let status = $derived(statuses.get(sessionId) ?? "idle");
+
+  function fetchCommits() {
+    if (!session) return;
+    invoke<CommitInfo[]>("get_session_commits", {
+      projectId: session.projectId,
+      sessionId: session.id,
+    }).then((result) => {
+      commits = result;
+    }).catch(() => {
+      // Ignore errors (e.g., no repo yet)
+    });
+  }
+
+  // Fetch commits on mount and when session changes
+  $effect(() => {
+    if (session) fetchCommits();
+  });
+
+  // Refresh commits when session transitions to idle (likely just committed)
+  let prevStatus: SessionStatus | null = $state(null);
+  $effect(() => {
+    if (prevStatus === "working" && status === "idle") {
+      // Delay slightly to let git finish writing
+      setTimeout(fetchCommits, 1000);
+    }
+    prevStatus = status;
+  });
+
+  // Also listen for status hook events to catch transitions
+  let unlistenHook: UnlistenFn | undefined;
+  $effect(() => {
+    listen<string>(`session-status-hook:${sessionId}`, (event) => {
+      if (event.payload === "idle") {
+        setTimeout(fetchCommits, 1000);
+      }
+    }).then((fn) => { unlistenHook = fn; });
+
+    return () => { unlistenHook?.(); };
+  });
+</script>
+
+{#if session}
+  <div class="summary-pane">
+    <div class="summary-row">
+      <span class="label">PROMPT</span>
+      <span class="value prompt-text">
+        {#if session.initial_prompt}
+          {session.initial_prompt}
+        {:else if session.github_issue}
+          #{session.github_issue.number}: {session.github_issue.title}
+        {:else}
+          <span class="muted">No prompt</span>
+        {/if}
+      </span>
+    </div>
+    <div class="summary-row progress-row">
+      <span class="label">DONE</span>
+      {#if commits.length > 0}
+        <ul class="commit-list">
+          {#each commits as commit (commit.hash)}
+            <li class="commit-item">
+              <span class="commit-hash">{commit.hash}</span>
+              <span class="commit-msg">{commit.message}</span>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <span class="muted">No commits yet</span>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .summary-pane {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 12px;
+    background: #181825;
+    border-bottom: 1px solid #313244;
+    font-size: 12px;
+    flex-shrink: 0;
+    max-height: 120px;
+    overflow-y: auto;
+  }
+
+  .summary-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .progress-row {
+    align-items: flex-start;
+  }
+
+  .label {
+    color: #6c7086;
+    font-weight: 600;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    flex-shrink: 0;
+    width: 42px;
+  }
+
+  .value {
+    color: #cdd6f4;
+    min-width: 0;
+  }
+
+  .prompt-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .muted {
+    color: #6c7086;
+    font-style: italic;
+  }
+
+  .commit-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    min-width: 0;
+  }
+
+  .commit-item {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    line-height: 1.5;
+  }
+
+  .commit-hash {
+    color: #89b4fa;
+    font-family: monospace;
+    font-size: 11px;
+    flex-shrink: 0;
+  }
+
+  .commit-msg {
+    color: #cdd6f4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Terminal from "./Terminal.svelte";
+  import SummaryPane from "./SummaryPane.svelte";
   import { projects, activeSessionId, hotkeyAction, focusTarget, type Project } from "./stores";
 
   let projectList: Project[] = $state([]);
@@ -44,7 +45,10 @@
 <div class="terminal-manager" class:focused={isFocused} onfocusin={handleFocusIn}>
   {#each allSessionIds as sessionId (sessionId)}
     <div class="terminal-wrapper" class:visible={activeSession === sessionId}>
-      <Terminal {sessionId} bind:this={terminalComponents[sessionId]} />
+      <SummaryPane {sessionId} />
+      <div class="terminal-inner">
+        <Terminal {sessionId} bind:this={terminalComponents[sessionId]} />
+      </div>
     </div>
   {/each}
 
@@ -74,10 +78,17 @@
     position: absolute;
     inset: 0;
     display: none;
+    flex-direction: column;
   }
 
   .terminal-wrapper.visible {
-    display: block;
+    display: flex;
+  }
+
+  .terminal-inner {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .empty-state {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -15,6 +15,7 @@ export interface SessionConfig {
   archived: boolean;
   kind: string;
   github_issue: GithubIssue | null;
+  initial_prompt: string | null;
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary
- Adds a summary pane at the top of each terminal session showing initial prompt and implementation progress
- Progress shows actual git commits on the session's worktree branch (not just status indicators)
- Auto-refreshes when session transitions from working to idle

## Test plan
- [x] All 67 Rust tests pass
- [x] Frontend builds cleanly
- [ ] Manual: create session with GitHub issue — verify prompt row shows issue title
- [ ] Manual: make commits in session worktree — verify DONE row lists commit messages
- [ ] Manual: verify pane auto-refreshes after Claude finishes working

Generated with [Claude Code](https://claude.com/claude-code)