### PR TITLE
docs: add development setup with tmux config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ A desktop app for orchestrating multiple Claude Code terminal sessions.
 
 Built with Tauri v2 + Svelte 5 + Rust.
 
+## Development Setup
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) + Tauri v2
+- [Node.js](https://nodejs.org/) + npm
+- tmux (`brew install tmux`)
+
+### tmux Configuration
+
+If you use Claude Code inside tmux to develop this project, add the following to `~/.tmux.conf` to fix scrambled output when scrolling:
+
+```
+set -g mouse on
+set -g status off
+```
+
+Reload with `tmux source-file ~/.tmux.conf`.
+
+Without `mouse on`, trackpad scrolling sends raw escape sequences to Claude Code's TUI, producing garbled output in the scrollback buffer. `status off` hides the tmux status bar for a cleaner UI.
+
 ## Demo Ideas
 
 - **Meta-programming lightshow:** Ask the editor to turn its background blue, then red, then yellow. Then ask it to cycle through the colors on intervals like a lightshow. The controller is editing itself in real-time.


### PR DESCRIPTION
## Summary
- Add Development Setup section to README with prerequisites and tmux configuration
- Documents `set -g mouse on` fix for scrambled scrollback when using Claude Code inside tmux

## Test plan
- [x] Verified `set -g mouse on` fixes trackpad scroll garbling in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)