### PR TITLE
fix: hide summary pane when terminal is focused

### DIFF
--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -27,8 +27,13 @@
     return unsub;
   });
 
+  let focusedSessionId: string | null = $state(null);
+
   $effect(() => {
-    const unsub = focusTarget.subscribe((v) => { isFocused = v?.type === "terminal"; });
+    const unsub = focusTarget.subscribe((v) => {
+      isFocused = v?.type === "terminal";
+      focusedSessionId = v?.type === "session" ? v.sessionId : null;
+    });
     return unsub;
   });
 
@@ -45,7 +50,9 @@
 <div class="terminal-manager" class:focused={isFocused} onfocusin={handleFocusIn}>
   {#each allSessionIds as sessionId (sessionId)}
     <div class="terminal-wrapper" class:visible={activeSession === sessionId}>
-      <SummaryPane {sessionId} />
+      {#if focusedSessionId === sessionId}
+        <SummaryPane {sessionId} />
+      {/if}
       <div class="terminal-inner">
         <Terminal {sessionId} bind:this={terminalComponents[sessionId]} />
       </div>


### PR DESCRIPTION
## Summary
- Summary pane now only shows when the session is focused in the sidebar
- Disappears when focus moves to the terminal (Enter or click)

## Test plan
- [ ] Focus session in sidebar → summary pane visible
- [ ] Press Enter to focus terminal → summary pane disappears
- [ ] Navigate back to sidebar → summary pane reappears

Generated with [Claude Code](https://claude.com/claude-code)