### PR TITLE
fix: scope drag-drop image paste to active session only

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -6,6 +6,7 @@
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { makeCustomKeyHandler } from "./terminal-keys";
   import { clipboardHasImage } from "./clipboard";
+  import { activeSessionId } from "./stores";
   import "@xterm/xterm/css/xterm.css";
 
   interface Props {
@@ -131,8 +132,14 @@
       unlistenStatus = fn;
     });
 
-    // Listen for drag-and-drop file events (from Finder)
+    // Listen for drag-and-drop file events (from Finder).
+    // Gate on active session — this is a window-level event so all
+    // mounted Terminal instances receive it; only the active one should act.
     listen<{ paths: string[] }>("tauri://drag-drop", async (event) => {
+      let active: string | null = null;
+      activeSessionId.subscribe((v) => { active = v; })();
+      if (active !== sessionId) return;
+
       const imagePath = event.payload.paths.find(isImageFile);
       if (imagePath) {
         try {


### PR DESCRIPTION
## Summary
- **Root cause**: `tauri://drag-drop` is a window-level event, so all mounted `Terminal` instances received it and wrote dropped images to their PTYs — causing images to appear in every session, not just the active one
- **Fix**: Gate the drag-drop handler on `activeSessionId` so only the active terminal processes the event

## Test plan
- [ ] Drop an image onto the terminal with multiple sessions open — only the active session should receive the paste
- [ ] Verify Cmd-V image paste still works correctly
- [ ] Existing tests pass (112/112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)