### PR TITLE
refactor: m hotkey writes merge command to PTY

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -287,8 +287,8 @@
         }
         return true;
       case "m":
-        if (currentFocus?.type === "session") {
-          dispatchAction({ type: "merge-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
+        if (activeId) {
+          invoke("write_to_pty", { sessionId: activeId, data: "create pr, merge, sync local master\n" });
         }
         return true;
       case "s":

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -136,22 +136,12 @@ describe('HotkeyManager', () => {
       unsub();
     });
 
-    it('m dispatches merge-session when session focused', () => {
-      focusTarget.set({ type: 'session', sessionId: 'sess-1', projectId: 'proj-1' });
-      let captured: any = null;
-      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+    it('m writes merge command to PTY when session is active', () => {
       pressKey('m');
-      expect(captured).toEqual({ type: 'merge-session', sessionId: 'sess-1', projectId: 'proj-1' });
-      unsub();
-    });
-
-    it('m does nothing when project focused', () => {
-      focusTarget.set({ type: 'project', projectId: 'proj-1' });
-      let captured: any = null;
-      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
-      pressKey('m');
-      expect(captured).toBeNull();
-      unsub();
+      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+        sessionId: 'sess-1',
+        data: 'create pr, merge, sync local master\n',
+      });
     });
 
     it('modifier keys alone do not dispatch', () => {


### PR DESCRIPTION
## Summary
- Changed `m` hotkey to write `create pr, merge, sync local master` directly to the active session's PTY instead of dispatching a `merge-session` action
- Lets the Claude session handle the full merge workflow autonomously
- Updated tests to verify the new PTY write behavior

## Test plan
- [x] All 60 HotkeyManager tests pass
- [ ] Press `m` with an active session and verify the command appears in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)