### PR TITLE
test: add 45 new Rust unit tests across all modules

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1375,4 +1375,131 @@ mod tests {
     fn test_parse_github_issue_url_invalid() {
         assert!(parse_github_issue_url("not a url").is_err());
     }
+
+    // --- render_agents_md tests ---
+
+    #[test]
+    fn test_render_agents_md_replaces_name() {
+        let result = render_agents_md("my-project");
+        assert!(result.starts_with("# my-project"));
+        assert!(!result.contains("{name}"));
+    }
+
+    #[test]
+    fn test_render_agents_md_empty_name() {
+        let result = render_agents_md("");
+        assert!(result.starts_with("# \n"));
+    }
+
+    // --- find_main_branch_oid tests ---
+
+    #[test]
+    fn test_find_main_branch_oid_with_main_branch() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(tmp.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[]).unwrap();
+
+        // After init + commit, HEAD points to a branch — find_main_branch_oid should find it
+        let oid = find_main_branch_oid(&repo);
+        assert!(oid.is_some());
+    }
+
+    #[test]
+    fn test_find_main_branch_oid_no_main_or_master() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(tmp.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let oid = repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[]).unwrap();
+
+        // Rename the default branch to something other than main/master
+        let commit = repo.find_commit(oid).unwrap();
+        repo.branch("develop", &commit, false).unwrap();
+        // Delete the original branch by setting HEAD to develop
+        repo.set_head("refs/heads/develop").unwrap();
+        if let Ok(mut branch) = repo.find_branch("main", git2::BranchType::Local) {
+            let _ = branch.delete();
+        }
+        if let Ok(mut branch) = repo.find_branch("master", git2::BranchType::Local) {
+            let _ = branch.delete();
+        }
+
+        let result = find_main_branch_oid(&repo);
+        assert!(result.is_none());
+    }
+
+    // --- CommitInfo serialization ---
+
+    #[test]
+    fn test_commit_info_serialization() {
+        let info = CommitInfo {
+            hash: "abc1234".to_string(),
+            message: "fix: resolve bug".to_string(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hash"], "abc1234");
+        assert_eq!(parsed["message"], "fix: resolve bug");
+    }
+
+    // --- additional validate_project_name edge cases ---
+
+    #[test]
+    fn test_project_name_with_spaces_is_valid() {
+        // Spaces are not explicitly rejected
+        assert!(validate_project_name("my project").is_ok());
+    }
+
+    #[test]
+    fn test_project_name_with_hyphens_and_underscores() {
+        assert!(validate_project_name("my-cool_project-2").is_ok());
+    }
+
+    #[test]
+    fn test_project_name_single_char() {
+        assert!(validate_project_name("a").is_ok());
+    }
+
+    // --- parse_github_nwo edge cases ---
+
+    #[test]
+    fn test_parse_github_nwo_ssh_no_git_suffix() {
+        // SSH URL without .git suffix
+        assert_eq!(
+            parse_github_nwo("git@github.com:owner/repo").unwrap(),
+            "owner/repo"
+        );
+    }
+
+    #[test]
+    fn test_parse_github_nwo_empty_string() {
+        assert!(parse_github_nwo("").is_err());
+    }
+
+    // --- parse_github_issue_url edge cases ---
+
+    #[test]
+    fn test_parse_github_issue_url_large_number() {
+        assert_eq!(
+            parse_github_issue_url("https://github.com/owner/repo/issues/99999").unwrap(),
+            99999
+        );
+    }
+
+    #[test]
+    fn test_parse_github_issue_url_zero() {
+        assert_eq!(
+            parse_github_issue_url("https://github.com/owner/repo/issues/0").unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_parse_github_issue_url_empty() {
+        assert!(parse_github_issue_url("").is_err());
+    }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -192,4 +192,47 @@ mod tests {
         assert_eq!(dirs[0].name, "alpha");
         assert_eq!(dirs[1].name, "beta");
     }
+
+    #[test]
+    fn test_config_path_returns_expected() {
+        let base = Path::new("/tmp/test-base");
+        assert_eq!(config_path(base), PathBuf::from("/tmp/test-base/config.json"));
+    }
+
+    #[test]
+    fn test_load_config_invalid_json() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(config_path(tmp.path()), "not valid json").unwrap();
+        let result = load_config(tmp.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_list_directories_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        let dirs = list_directories(tmp.path()).unwrap();
+        assert!(dirs.is_empty());
+    }
+
+    #[test]
+    fn test_generate_names_via_cli_empty_description() {
+        let result = generate_names_via_cli("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_generate_names_via_cli_whitespace_only() {
+        let result = generate_names_via_cli("   ");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_generate_names_via_cli_too_long() {
+        let long = "a".repeat(501);
+        let result = generate_names_via_cli(&long);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("too long"));
+    }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -194,4 +194,91 @@ mod tests {
         let session: SessionConfig = serde_json::from_str(json).expect("deserialize");
         assert!(session.github_issue.is_none());
     }
+
+    #[test]
+    fn test_session_config_initial_prompt_defaults_to_none() {
+        let json = r#"{"id":"550e8400-e29b-41d4-a716-446655440000","label":"session-1","worktree_path":null,"worktree_branch":null,"archived":false}"#;
+        let session: SessionConfig = serde_json::from_str(json).expect("deserialize");
+        assert!(session.initial_prompt.is_none());
+    }
+
+    #[test]
+    fn test_session_config_initial_prompt_roundtrip() {
+        let session = SessionConfig {
+            id: Uuid::new_v4(),
+            label: "session-1".to_string(),
+            worktree_path: None,
+            worktree_branch: None,
+            archived: false,
+            kind: "claude".to_string(),
+            github_issue: None,
+            initial_prompt: Some("fix the bug".to_string()),
+        };
+        let json = serde_json::to_string(&session).expect("serialize");
+        let deserialized: SessionConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized.initial_prompt.as_deref(), Some("fix the bug"));
+    }
+
+    #[test]
+    fn test_merge_response_pr_created_serialization() {
+        let response = MergeResponse::PrCreated {
+            url: "https://github.com/owner/repo/pull/1".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "pr_created");
+        assert_eq!(parsed["url"], "https://github.com/owner/repo/pull/1");
+    }
+
+    #[test]
+    fn test_merge_response_rebase_conflicts_serialization() {
+        let response = MergeResponse::RebaseConflicts;
+        let json = serde_json::to_string(&response).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "rebase_conflicts");
+    }
+
+    #[test]
+    fn test_session_status_serialization() {
+        let running = SessionStatus::Running;
+        let idle = SessionStatus::Idle;
+        let running_json = serde_json::to_string(&running).unwrap();
+        let idle_json = serde_json::to_string(&idle).unwrap();
+        assert_eq!(running_json, "\"Running\"");
+        assert_eq!(idle_json, "\"Idle\"");
+    }
+
+    #[test]
+    fn test_github_issue_with_labels() {
+        let issue = GithubIssue {
+            number: 42,
+            title: "Bug fix".to_string(),
+            url: "https://github.com/owner/repo/issues/42".to_string(),
+            labels: vec![
+                GithubLabel { name: "bug".to_string() },
+                GithubLabel { name: "priority".to_string() },
+            ],
+        };
+        let json = serde_json::to_string(&issue).unwrap();
+        let deserialized: GithubIssue = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.labels.len(), 2);
+        assert_eq!(deserialized.labels[0].name, "bug");
+        assert_eq!(deserialized.labels[1].name, "priority");
+    }
+
+    #[test]
+    fn test_session_info_serialization_roundtrip() {
+        let info = SessionInfo {
+            id: Uuid::new_v4(),
+            label: "session-1".to_string(),
+            project_id: Uuid::new_v4(),
+            worktree_path: Some("/tmp/wt".to_string()),
+            worktree_branch: Some("session-1".to_string()),
+            status: SessionStatus::Running,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let deserialized: SessionInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, info.id);
+        assert_eq!(deserialized.status, SessionStatus::Running);
+    }
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -450,4 +450,19 @@ mod tests {
         let result = manager.close_session(invalid_id);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_session_ids_empty_manager() {
+        let manager = PtyManager::new();
+        assert!(manager.session_ids().is_empty());
+    }
+
+    #[test]
+    fn test_send_raw_to_invalid_session_returns_error() {
+        let mut manager = PtyManager::new();
+        let invalid_id = Uuid::new_v4();
+        let result = manager.send_raw_to_session(invalid_id, b"hello");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("session not found"));
+    }
 }

--- a/src-tauri/src/session_args.rs
+++ b/src-tauri/src/session_args.rs
@@ -124,4 +124,30 @@ mod tests {
         // Only the 4 permission args, no positional prompt
         assert_eq!(codex_args.len(), 4);
     }
+
+    #[test]
+    fn unknown_command_produces_empty_args() {
+        let session_id = Uuid::new_v4();
+        let args = build_session_args("unknown-tool", session_id, false, None);
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn unknown_command_with_continue_only_has_continue() {
+        let session_id = Uuid::new_v4();
+        let args = build_session_args("unknown-tool", session_id, true, None);
+        assert_eq!(args, vec!["--continue".to_string()]);
+    }
+
+    #[test]
+    fn claude_args_continue_plus_prompt() {
+        let session_id = Uuid::new_v4();
+        let args = build_session_args("claude", session_id, true, Some("do stuff"));
+        assert_eq!(args[0], "--continue");
+        assert_eq!(args[1], "--settings");
+        // args[2] is settings JSON
+        assert_eq!(args[3], "--append-system-prompt");
+        assert_eq!(args[4], "do stuff");
+        assert_eq!(args[5], "do stuff"); // positional prompt at end
+    }
 }

--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -186,4 +186,27 @@ mod tests {
         assert!(parse_status_message("unknown:550e8400-e29b-41d4-a716-446655440000").is_none());
         assert!(parse_status_message("").is_none());
     }
+
+    #[test]
+    fn test_socket_path_returns_expected() {
+        assert_eq!(socket_path(), "/tmp/the-controller.sock");
+    }
+
+    #[test]
+    fn test_hook_settings_json_contains_socket_path() {
+        let id = uuid::Uuid::new_v4();
+        let json = hook_settings_json(id);
+        assert!(json.contains("/tmp/the-controller.sock"));
+    }
+
+    #[test]
+    fn test_parse_status_message_with_extra_colons() {
+        // UUID contains hyphens not colons, but test split_once behavior
+        // "working:550e8400-e29b-41d4-a716-446655440000" should work
+        let msg = "working:550e8400-e29b-41d4-a716-446655440000";
+        let result = parse_status_message(msg);
+        assert!(result.is_some());
+        let (status, _) = result.unwrap();
+        assert_eq!(status, "working");
+    }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -274,4 +274,73 @@ mod tests {
         storage.delete_project_dir(project.id).expect("delete");
         assert!(storage.load_project(project.id).is_err());
     }
+
+    #[test]
+    fn test_ensure_dirs_creates_projects_directory() {
+        let tmp = TempDir::new().unwrap();
+        let storage = Storage::new(tmp.path().to_path_buf());
+        storage.ensure_dirs().expect("ensure_dirs");
+        assert!(tmp.path().join("projects").is_dir());
+    }
+
+    #[test]
+    fn test_project_dir_format() {
+        let tmp = TempDir::new().unwrap();
+        let storage = Storage::new(tmp.path().to_path_buf());
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let dir = storage.project_dir(id);
+        assert!(dir.ends_with("projects/550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_delete_nonexistent_project_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+        let id = Uuid::new_v4();
+        // Deleting a project that was never saved should succeed (idempotent)
+        assert!(storage.delete_project_dir(id).is_ok());
+    }
+
+    #[test]
+    fn test_base_dir_returns_correct_path() {
+        let tmp = TempDir::new().unwrap();
+        let storage = Storage::new(tmp.path().to_path_buf());
+        assert_eq!(storage.base_dir(), tmp.path().to_path_buf());
+    }
+
+    #[test]
+    fn test_save_and_get_agents_md_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+        let project = make_project("test-project", "/tmp/nonexistent-repo");
+        let id = project.id;
+
+        storage.save_agents_md(id, "# My Agents\nContent here").unwrap();
+
+        // get_agents_md falls back to config dir when repo doesn't exist
+        let content = storage.get_agents_md(&project).unwrap();
+        assert_eq!(content, "# My Agents\nContent here");
+    }
+
+    #[test]
+    fn test_load_nonexistent_project_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+        let id = Uuid::new_v4();
+        assert!(storage.load_project(id).is_err());
+    }
+
+    #[test]
+    fn test_save_project_overwrites_existing() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+        let mut project = make_project("test-project", "/tmp/repo");
+
+        storage.save_project(&project).expect("first save");
+        project.name = "updated-name".to_string();
+        storage.save_project(&project).expect("second save");
+
+        let loaded = storage.load_project(project.id).expect("load");
+        assert_eq!(loaded.name, "updated-name");
+    }
 }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -357,4 +357,40 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "unborn_branch");
     }
+
+    #[test]
+    fn test_is_rebase_in_progress_false_for_regular_dir() {
+        let tmp = TempDir::new().expect("create temp dir");
+        assert!(!WorktreeManager::is_rebase_in_progress(
+            tmp.path().to_str().unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_is_rebase_in_progress_false_for_clean_repo() {
+        let (_tmp, repo_path) = setup_test_repo();
+        assert!(!WorktreeManager::is_rebase_in_progress(&repo_path));
+    }
+
+    #[test]
+    fn test_remove_worktree_nonexistent_path_prunes_reference() {
+        let (_tmp, repo_path) = setup_test_repo();
+        // Removing a worktree that doesn't exist on disk should not error
+        let result = WorktreeManager::remove_worktree(
+            "/tmp/nonexistent-worktree-path",
+            &repo_path,
+            "nonexistent-branch",
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_detect_main_branch_on_empty_repo_errors() {
+        let tmp = TempDir::new().expect("create temp dir");
+        let repo_path = tmp.path().to_str().unwrap().to_string();
+        Repository::init(&repo_path).expect("init repo");
+        // No commits = unborn HEAD, detect_main_branch should error
+        let result = WorktreeManager::detect_main_branch(&repo_path);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 45 new Rust unit tests across all 8 source modules, expanding coverage from 55 to 100 unit tests (112 total with integration tests)
- Tests cover previously untested pure functions (`render_agents_md`, `find_main_branch_oid`, `CommitInfo` serialization), model serialization (`MergeResponse`, `SessionStatus`, `SessionInfo`, `GithubLabel`), edge cases for existing functions, and storage/config helpers
- All tests are pure unit tests requiring no Tauri runtime, using `tempfile` for filesystem operations

## Test plan

- [x] `cargo test` passes: 100 unit + 12 integration = 112 tests, all green
- [x] No new dependencies added
- [x] Tests follow existing patterns and conventions

closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)