### PR TITLE
feat: add encrypted secret backup mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+        "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
@@ -1412,6 +1413,15 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.2.tgz",
       "integrity": "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
+      "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +101,18 @@ dependencies = [
  "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -247,6 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -473,6 +535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -646,6 +719,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -714,6 +796,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1343,6 +1426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2515,6 +2617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2730,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2861,6 +2980,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3233,6 +3364,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3726,6 +3881,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,6 +4154,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,17 +4352,21 @@ dependencies = [
 name = "the-controller"
 version = "0.2.0"
 dependencies = [
+ "aes-gcm",
+ "argon2",
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "git2",
  "image",
  "portable-pty",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tempfile",
  "tokio",
@@ -4605,6 +4810,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,10 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-clipboard-manager = "2.3.2"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
+tauri-plugin-dialog = "2"
+aes-gcm = "0.10"
+argon2 = "0.5"
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
     "opener:default",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-read-image",
-    "clipboard-manager:allow-write-image"
+    "clipboard-manager:allow-write-image",
+    "dialog:allow-save",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -1,0 +1,319 @@
+use std::collections::HashMap;
+
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use argon2::Argon2;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+use crate::models::Project;
+use crate::storage::Storage;
+
+const BACKUP_VERSION: u32 = 1;
+const MAGIC: &[u8; 4] = b"TCBK";
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+const KEY_LEN: usize = 32;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BackupPayload {
+    version: u32,
+    created_at: String,
+    projects: Vec<Project>,
+    agents: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub enum BackupError {
+    Io(std::io::Error),
+    Encryption(String),
+    InvalidFormat(String),
+    WrongPassphrase,
+}
+
+impl std::fmt::Display for BackupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BackupError::Io(e) => write!(f, "IO error: {}", e),
+            BackupError::Encryption(e) => write!(f, "Encryption error: {}", e),
+            BackupError::InvalidFormat(e) => write!(f, "Invalid backup format: {}", e),
+            BackupError::WrongPassphrase => write!(f, "Wrong passphrase or corrupted backup"),
+        }
+    }
+}
+
+impl From<std::io::Error> for BackupError {
+    fn from(e: std::io::Error) -> Self {
+        BackupError::Io(e)
+    }
+}
+
+fn derive_key(passphrase: &str, salt: &[u8]) -> Result<[u8; KEY_LEN], BackupError> {
+    let mut key = [0u8; KEY_LEN];
+    Argon2::default()
+        .hash_password_into(passphrase.as_bytes(), salt, &mut key)
+        .map_err(|e| BackupError::Encryption(format!("Key derivation failed: {}", e)))?;
+    Ok(key)
+}
+
+fn encrypt(plaintext: &[u8], passphrase: &str) -> Result<Vec<u8>, BackupError> {
+    let mut salt = [0u8; SALT_LEN];
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut salt);
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+    let key = derive_key(passphrase, &salt)?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| BackupError::Encryption(format!("Cipher init failed: {}", e)))?;
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| BackupError::Encryption("Encryption failed".to_string()))?;
+
+    // Format: MAGIC(4) + version(4) + salt(16) + nonce(12) + ciphertext(variable)
+    let mut output = Vec::with_capacity(4 + 4 + SALT_LEN + NONCE_LEN + ciphertext.len());
+    output.extend_from_slice(MAGIC);
+    output.extend_from_slice(&BACKUP_VERSION.to_le_bytes());
+    output.extend_from_slice(&salt);
+    output.extend_from_slice(&nonce_bytes);
+    output.extend_from_slice(&ciphertext);
+
+    Ok(output)
+}
+
+fn decrypt(data: &[u8], passphrase: &str) -> Result<Vec<u8>, BackupError> {
+    let header_len = 4 + 4 + SALT_LEN + NONCE_LEN;
+    if data.len() < header_len {
+        return Err(BackupError::InvalidFormat("File too short".to_string()));
+    }
+
+    if &data[0..4] != MAGIC {
+        return Err(BackupError::InvalidFormat("Invalid magic bytes".to_string()));
+    }
+
+    let version = u32::from_le_bytes(
+        data[4..8]
+            .try_into()
+            .map_err(|_| BackupError::InvalidFormat("Invalid version".to_string()))?,
+    );
+    if version != BACKUP_VERSION {
+        return Err(BackupError::InvalidFormat(format!(
+            "Unsupported backup version: {}",
+            version
+        )));
+    }
+
+    let salt = &data[8..8 + SALT_LEN];
+    let nonce_bytes = &data[8 + SALT_LEN..8 + SALT_LEN + NONCE_LEN];
+    let ciphertext = &data[header_len..];
+
+    let key = derive_key(passphrase, salt)?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| BackupError::Encryption(format!("Cipher init failed: {}", e)))?;
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| BackupError::WrongPassphrase)
+}
+
+pub fn export_backup(storage: &Storage, passphrase: &str) -> Result<Vec<u8>, BackupError> {
+    let projects = storage.list_projects()?;
+
+    let mut agents = HashMap::new();
+    for project in &projects {
+        let content = storage.get_agents_md(project)?;
+        if !content.is_empty() {
+            agents.insert(project.id.to_string(), content);
+        }
+    }
+
+    let payload = BackupPayload {
+        version: BACKUP_VERSION,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        projects,
+        agents,
+    };
+
+    let json = serde_json::to_vec(&payload)
+        .map_err(|e| BackupError::Encryption(format!("Serialization failed: {}", e)))?;
+
+    encrypt(&json, passphrase)
+}
+
+pub fn import_backup(
+    storage: &Storage,
+    data: &[u8],
+    passphrase: &str,
+) -> Result<u32, BackupError> {
+    let plaintext = decrypt(data, passphrase)?;
+
+    let payload: BackupPayload = serde_json::from_slice(&plaintext).map_err(|e| {
+        BackupError::InvalidFormat(format!("Invalid backup payload: {}", e))
+    })?;
+
+    let count = payload.projects.len() as u32;
+
+    for project in &payload.projects {
+        storage.save_project(project)?;
+    }
+
+    for (project_id_str, content) in &payload.agents {
+        if let Ok(project_id) = project_id_str.parse() {
+            storage.save_agents_md(project_id, content)?;
+        }
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::SessionConfig;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    fn make_storage(tmp: &TempDir) -> Storage {
+        let storage = Storage::new(tmp.path().to_path_buf());
+        storage.ensure_dirs().expect("ensure_dirs");
+        storage
+    }
+
+    fn make_project(name: &str) -> Project {
+        Project {
+            id: Uuid::new_v4(),
+            name: name.to_string(),
+            repo_path: "/tmp/repo".to_string(),
+            created_at: "2026-03-06T00:00:00Z".to_string(),
+            archived: false,
+            sessions: vec![SessionConfig {
+                id: Uuid::new_v4(),
+                label: "main".to_string(),
+                worktree_path: None,
+                worktree_branch: None,
+                archived: false,
+                kind: "claude".to_string(),
+                github_issue: None,
+                initial_prompt: Some("my-secret-api-key".to_string()),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let data = b"hello world";
+        let encrypted = encrypt(data, "password123").unwrap();
+        let decrypted = decrypt(&encrypted, "password123").unwrap();
+        assert_eq!(decrypted, data);
+    }
+
+    #[test]
+    fn test_wrong_passphrase_fails() {
+        let data = b"hello world";
+        let encrypted = encrypt(data, "password123").unwrap();
+        let result = decrypt(&encrypted, "wrong-password");
+        assert!(matches!(result, Err(BackupError::WrongPassphrase)));
+    }
+
+    #[test]
+    fn test_corrupted_data_fails() {
+        let data = b"hello world";
+        let mut encrypted = encrypt(data, "password123").unwrap();
+        // Corrupt a byte in the ciphertext
+        let last = encrypted.len() - 1;
+        encrypted[last] ^= 0xFF;
+        let result = decrypt(&encrypted, "password123");
+        assert!(matches!(result, Err(BackupError::WrongPassphrase)));
+    }
+
+    #[test]
+    fn test_truncated_data_fails() {
+        let result = decrypt(b"short", "password");
+        assert!(matches!(result, Err(BackupError::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn test_invalid_magic_fails() {
+        let mut data = vec![0u8; 100];
+        data[0..4].copy_from_slice(b"XXXX");
+        let result = decrypt(&data, "password");
+        assert!(matches!(result, Err(BackupError::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn test_export_import_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+
+        let p1 = make_project("project-1");
+        let p2 = make_project("project-2");
+        storage.save_project(&p1).unwrap();
+        storage.save_project(&p2).unwrap();
+        storage.save_agents_md(p1.id, "agent instructions").unwrap();
+
+        let backup = export_backup(&storage, "test-pass").unwrap();
+
+        // Import into a fresh storage
+        let tmp2 = TempDir::new().unwrap();
+        let storage2 = make_storage(&tmp2);
+
+        let count = import_backup(&storage2, &backup, "test-pass").unwrap();
+        assert_eq!(count, 2);
+
+        let projects = storage2.list_projects().unwrap();
+        assert_eq!(projects.len(), 2);
+
+        let agents = storage2.get_agents_md(&p1).unwrap();
+        assert_eq!(agents, "agent instructions");
+    }
+
+    #[test]
+    fn test_export_import_wrong_passphrase() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+
+        let project = make_project("project-1");
+        storage.save_project(&project).unwrap();
+
+        let backup = export_backup(&storage, "correct-pass").unwrap();
+
+        let tmp2 = TempDir::new().unwrap();
+        let storage2 = make_storage(&tmp2);
+        let result = import_backup(&storage2, &backup, "wrong-pass");
+        assert!(matches!(result, Err(BackupError::WrongPassphrase)));
+
+        // Verify nothing was imported
+        let projects = storage2.list_projects().unwrap();
+        assert!(projects.is_empty());
+    }
+
+    #[test]
+    fn test_backup_preserves_sensitive_data() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+
+        let project = make_project("sensitive-project");
+        storage.save_project(&project).unwrap();
+
+        let backup = export_backup(&storage, "pass").unwrap();
+
+        // Verify the plaintext secret is NOT in the encrypted backup
+        let backup_str = String::from_utf8_lossy(&backup);
+        assert!(!backup_str.contains("my-secret-api-key"));
+
+        // But it IS recoverable after import
+        let tmp2 = TempDir::new().unwrap();
+        let storage2 = make_storage(&tmp2);
+        import_backup(&storage2, &backup, "pass").unwrap();
+
+        let projects = storage2.list_projects().unwrap();
+        assert_eq!(
+            projects[0].sessions[0].initial_prompt.as_deref(),
+            Some("my-secret-api-key")
+        );
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1181,6 +1181,48 @@ fn find_main_branch_oid(repo: &git2::Repository) -> Option<git2::Oid> {
     None
 }
 
+#[tauri::command]
+pub async fn export_backup(
+    state: State<'_, AppState>,
+    passphrase: String,
+    path: String,
+) -> Result<(), String> {
+    let base_dir = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        storage.base_dir()
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let storage = crate::storage::Storage::new(base_dir);
+        let data =
+            crate::backup::export_backup(&storage, &passphrase).map_err(|e| e.to_string())?;
+        std::fs::write(&path, data).map_err(|e| e.to_string())?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn import_backup(
+    state: State<'_, AppState>,
+    passphrase: String,
+    path: String,
+) -> Result<u32, String> {
+    let base_dir = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        storage.base_dir()
+    };
+
+    tokio::task::spawn_blocking(move || {
+        let storage = crate::storage::Storage::new(base_dir);
+        let data = std::fs::read(&path).map_err(|e| e.to_string())?;
+        crate::backup::import_backup(&storage, &data, &passphrase).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 use tauri::Manager;
 
+pub mod backup;
 pub mod commands;
 pub mod config;
 pub mod models;
@@ -16,6 +17,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(state::AppState::new())
         .setup(|app| {
             status_socket::start_listener(app.handle().clone());
@@ -58,6 +60,8 @@ pub fn run() {
             commands::merge_session_branch,
             commands::copy_image_file_to_clipboard,
             commands::get_session_commits,
+            commands::export_backup,
+            commands::import_backup,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/lib/BackupModal.svelte
+++ b/src/lib/BackupModal.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { invoke } from "@tauri-apps/api/core";
+  import { save, open } from "@tauri-apps/plugin-dialog";
+  import { showToast } from "./toast";
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  let { onClose }: Props = $props();
+  let modalEl: HTMLDivElement | undefined = $state();
+  let passphrase = $state("");
+  let confirmPassphrase = $state("");
+  let mode: "export" | "import" = $state("export");
+  let busy = $state(false);
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  }
+
+  onMount(() => {
+    modalEl?.focus();
+    window.addEventListener("keydown", handleKeydown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeydown, { capture: true });
+    };
+  });
+
+  async function handleExport() {
+    if (!passphrase) {
+      showToast("Passphrase is required", "error");
+      return;
+    }
+    if (passphrase !== confirmPassphrase) {
+      showToast("Passphrases do not match", "error");
+      return;
+    }
+
+    const path = await save({
+      title: "Export Backup",
+      defaultPath: "the-controller-backup.tcbk",
+      filters: [{ name: "Backup", extensions: ["tcbk"] }],
+    });
+
+    if (!path) return;
+
+    busy = true;
+    try {
+      await invoke("export_backup", { passphrase, path });
+      showToast("Backup exported successfully", "info");
+      onClose();
+    } catch (e) {
+      showToast(String(e), "error");
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleImport() {
+    if (!passphrase) {
+      showToast("Passphrase is required", "error");
+      return;
+    }
+
+    const path = await open({
+      title: "Import Backup",
+      filters: [{ name: "Backup", extensions: ["tcbk"] }],
+      multiple: false,
+      directory: false,
+    });
+
+    if (!path) return;
+
+    busy = true;
+    try {
+      const count: number = await invoke("import_backup", { passphrase, path });
+      showToast(`Imported ${count} project${count !== 1 ? "s" : ""} from backup`, "info");
+      onClose();
+    } catch (e) {
+      showToast(String(e), "error");
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="overlay" onclick={onClose} role="dialog">
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="modal"
+    bind:this={modalEl}
+    onclick={(e) => e.stopPropagation()}
+    role="presentation"
+    tabindex="-1"
+  >
+    <div class="modal-header">Backup</div>
+
+    <div class="tabs">
+      <button
+        class="tab"
+        class:active={mode === "export"}
+        onclick={() => { mode = "export"; passphrase = ""; confirmPassphrase = ""; }}
+      >Export</button>
+      <button
+        class="tab"
+        class:active={mode === "import"}
+        onclick={() => { mode = "import"; passphrase = ""; confirmPassphrase = ""; }}
+      >Import</button>
+    </div>
+
+    <p class="description">
+      {#if mode === "export"}
+        Export all projects to an encrypted backup file.
+      {:else}
+        Import projects from an encrypted backup file.
+      {/if}
+    </p>
+
+    <label class="field-label">
+      Passphrase
+      <input
+        type="password"
+        bind:value={passphrase}
+        placeholder="Enter passphrase"
+        class="input"
+        onkeydown={(e) => { if (e.key === "Enter") { mode === "export" ? handleExport() : handleImport(); } }}
+      />
+    </label>
+
+    {#if mode === "export"}
+      <label class="field-label">
+        Confirm passphrase
+        <input
+          type="password"
+          bind:value={confirmPassphrase}
+          placeholder="Confirm passphrase"
+          class="input"
+          onkeydown={(e) => { if (e.key === "Enter") handleExport(); }}
+        />
+      </label>
+    {/if}
+
+    <div class="actions">
+      <button
+        class="btn-confirm"
+        onclick={() => { mode === "export" ? handleExport() : handleImport(); }}
+        disabled={busy}
+      >
+        {busy ? "Working..." : mode === "export" ? "Export" : "Import"}
+      </button>
+      <button class="btn-cancel" onclick={onClose}>Cancel</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 20vh;
+    z-index: 100;
+  }
+  .modal {
+    background: #1e1e2e;
+    border: 1px solid #313244;
+    border-radius: 8px;
+    width: 380px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    outline: none;
+  }
+  .modal-header {
+    font-size: 16px;
+    font-weight: 600;
+    color: #cdd6f4;
+  }
+  .tabs {
+    display: flex;
+    gap: 0;
+    border: 1px solid #313244;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .tab {
+    flex: 1;
+    background: none;
+    border: none;
+    color: #6c7086;
+    padding: 8px 0;
+    font-size: 13px;
+    cursor: pointer;
+    box-shadow: none;
+  }
+  .tab:hover {
+    color: #cdd6f4;
+    background: #313244;
+  }
+  .tab.active {
+    color: #cdd6f4;
+    background: #45475a;
+  }
+  .description {
+    color: #a6adc8;
+    font-size: 13px;
+    margin: 0;
+    line-height: 1.5;
+  }
+  .field-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: #a6adc8;
+  }
+  .input {
+    background: #313244;
+    border: 1px solid #45475a;
+    border-radius: 6px;
+    color: #cdd6f4;
+    padding: 8px 10px;
+    font-size: 13px;
+    outline: none;
+  }
+  .input:focus {
+    border-color: #89b4fa;
+  }
+  .actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
+  }
+  .btn-confirm {
+    background: #89b4fa;
+    color: #1e1e2e;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .btn-confirm:hover {
+    background: #b4d0fb;
+  }
+  .btn-confirm:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .btn-cancel {
+    background: none;
+    color: #6c7086;
+    border: 1px solid #313244;
+    padding: 10px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    margin-left: auto;
+  }
+  .btn-cancel:hover {
+    color: #cdd6f4;
+    border-color: #45475a;
+  }
+</style>

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -9,8 +9,10 @@
   import DeleteProjectModal from "./DeleteProjectModal.svelte";
   import ConfirmModal from "./ConfirmModal.svelte";
   import DeleteSessionModal from "./DeleteSessionModal.svelte";
+  import BackupModal from "./BackupModal.svelte";
 
   let sidebarEl: HTMLElement | undefined = $state();
+  let showBackupModal = $state(false);
   let hintsVisible = $state(false);
   $effect(() => {
     const unsub = showKeyHints.subscribe((v) => { hintsVisible = v; });
@@ -581,6 +583,11 @@
     >Archives</button>
     <button
       class="btn-help"
+      onclick={() => { showBackupModal = true; }}
+      title="Backup / Restore"
+    >B</button>
+    <button
+      class="btn-help"
       class:active={hintsVisible}
       onclick={() => showKeyHints.update(v => !v)}
       title="Keyboard shortcuts (?)"
@@ -678,6 +685,12 @@
         mergeSessionTarget = null;
       }}
       onClose={() => (mergeSessionTarget = null)}
+    />
+  {/if}
+
+  {#if showBackupModal}
+    <BackupModal
+      onClose={() => { showBackupModal = false; loadProjects(); }}
     />
   {/if}
 


### PR DESCRIPTION
## Summary

- Add encrypted export/import flow for project data (all projects + agents.md files)
- Uses AES-256-GCM encryption with Argon2 key derivation from user passphrase
- Versioned binary backup format (.tcbk) with magic bytes and integrity validation
- Backend: new `backup.rs` module + `export_backup`/`import_backup` Tauri commands
- Frontend: BackupModal component with Export/Import tabs, accessible via "B" button in sidebar footer

## Test plan

- [x] 8 unit tests covering: encryption roundtrip, wrong passphrase rejection, corrupted data rejection, truncated data, invalid magic bytes, full export/import roundtrip, wrong passphrase on import, sensitive data not in plaintext
- [x] All 63 Rust tests pass
- [x] All 111 frontend tests pass
- [ ] Manual test: export backup with passphrase, import into fresh instance, verify projects restored

closes #72

Generated with [Claude Code](https://claude.com/claude-code)