### PR TITLE
fix: replace timeout with nc -w 2 for macOS status hooks

### DIFF
--- a/docs/domain-knowledge.md
+++ b/docs/domain-knowledge.md
@@ -78,6 +78,6 @@ Session status (idle/working/exited) is detected using Claude Code hooks, not PT
 - `src/lib/Sidebar.svelte` — listens for `session-status-hook` events
 
 **Edge cases:**
-- Hook commands use `timeout 2` + `; true` to avoid blocking Claude Code
+- Hook commands use `nc -w 2` + `; true` to avoid blocking Claude Code (`timeout` is not available on macOS)
 - Stale socket files are cleaned up on startup
 - Reattached tmux sessions default to "idle" until the next hook fires

--- a/docs/plans/2026-03-04-session-status-hooks-design.md
+++ b/docs/plans/2026-03-04-session-status-hooks-design.md
@@ -41,24 +41,24 @@ When spawning a Claude Code session, The Controller:
   "hooks": {
     "UserPromptSubmit": [{
       "type": "command",
-      "command": "timeout 2 bash -c 'echo \"working:$THE_CONTROLLER_SESSION_ID\" | nc -U /tmp/the-controller.sock' 2>/dev/null; true"
+      "command": "echo \"working:$THE_CONTROLLER_SESSION_ID\" | nc -U -w 2 /tmp/the-controller.sock 2>/dev/null; true"
     }],
     "Stop": [{
       "type": "command",
-      "command": "timeout 2 bash -c 'echo \"idle:$THE_CONTROLLER_SESSION_ID\" | nc -U /tmp/the-controller.sock' 2>/dev/null; true"
+      "command": "echo \"idle:$THE_CONTROLLER_SESSION_ID\" | nc -U -w 2 /tmp/the-controller.sock 2>/dev/null; true"
     }],
     "Notification": [{
       "matcher": "idle_prompt",
       "hooks": [{
         "type": "command",
-        "command": "timeout 2 bash -c 'echo \"idle:$THE_CONTROLLER_SESSION_ID\" | nc -U /tmp/the-controller.sock' 2>/dev/null; true"
+        "command": "echo \"idle:$THE_CONTROLLER_SESSION_ID\" | nc -U -w 2 /tmp/the-controller.sock 2>/dev/null; true"
       }]
     }]
   }
 }
 ```
 
-The `timeout 2` prevents the hook from blocking Claude Code if the socket is unavailable. The `; true` ensures exit code 0 so Claude Code doesn't treat it as a hook failure.
+The `nc -w 2` flag sets a 2-second idle timeout, preventing the hook from blocking Claude Code if the socket is unavailable. The `; true` ensures exit code 0 so Claude Code doesn't treat it as a hook failure. Note: `timeout` is not available on macOS by default, so we use `nc -w` instead.
 
 ## Socket Listener
 

--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -93,11 +93,11 @@ fn handle_connection(stream: UnixStream, app_handle: &AppHandle) {
 /// Configures hooks that report session status changes over the Unix socket.
 pub fn hook_settings_json(_session_id: Uuid) -> String {
     let working_cmd = format!(
-        "timeout 2 bash -c 'echo \"working:$THE_CONTROLLER_SESSION_ID\" | nc -U {}' 2>/dev/null; true",
+        "echo \"working:$THE_CONTROLLER_SESSION_ID\" | nc -U -w 2 {} 2>/dev/null; true",
         SOCKET_PATH
     );
     let idle_cmd = format!(
-        "timeout 2 bash -c 'echo \"idle:$THE_CONTROLLER_SESSION_ID\" | nc -U {}' 2>/dev/null; true",
+        "echo \"idle:$THE_CONTROLLER_SESSION_ID\" | nc -U -w 2 {} 2>/dev/null; true",
         SOCKET_PATH
     );
 
@@ -177,6 +177,21 @@ mod tests {
                 assert!(!inner.is_empty(), "{} has empty hooks array", event_name);
             }
         }
+    }
+
+    #[test]
+    fn test_hook_commands_use_nc_timeout_not_timeout_binary() {
+        // macOS doesn't have `timeout` — hook commands must use `nc -w` instead
+        let id = uuid::Uuid::new_v4();
+        let json = hook_settings_json(id);
+        assert!(
+            !json.contains("timeout "),
+            "hook commands must not use `timeout` (not available on macOS)"
+        );
+        assert!(
+            json.contains("nc -U -w 2"),
+            "hook commands must use `nc -w 2` for timeout"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- macOS doesn't ship with `timeout` (GNU coreutils), so all hook commands in `status_socket.rs` were silently failing
- The `; true` at the end masked the failure, meaning status messages never reached the Unix socket
- Sessions stayed all-green (idle default on restart) or all-yellow (working from creation) because no status updates were ever received
- Fix: use `nc -w 2` (native macOS netcat idle timeout flag) instead of wrapping with `timeout 2 bash -c '...'`

closes #32

## Test plan
- [x] Added regression test `test_hook_commands_use_nc_timeout_not_timeout_binary` that verifies hook commands don't use `timeout` and do use `nc -w 2`
- [x] Manually verified `echo "msg" | nc -U -w 2 /tmp/sock` works on macOS with a test socket
- [x] All existing tests pass
- [ ] Manual verification: create multiple sessions, confirm independent green/yellow status transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)