### PR TITLE
fix: task panel shows wrong issues when terminal focused

### DIFF
--- a/src/lib/TaskPanel.svelte
+++ b/src/lib/TaskPanel.svelte
@@ -42,7 +42,9 @@
       ? currentFocus.projectId
       : currentFocus?.type === "session"
         ? currentFocus.projectId
-        : null;
+        : currentFocus?.type === "terminal"
+          ? currentFocus.projectId
+          : null;
 
     const project = projectId
       ? projectList.find((p) => p.id === projectId)

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -38,7 +38,12 @@
   });
 
   function handleFocusIn() {
-    focusTarget.set({ type: "terminal" });
+    const project = activeSession
+      ? projectList.find((p) => p.sessions.some((s) => s.id === activeSession))
+      : null;
+    if (project) {
+      focusTarget.set({ type: "terminal", projectId: project.id });
+    }
   }
 
   let allSessionIds: string[] = $derived(

--- a/src/lib/TerminalManager.test.ts
+++ b/src/lib/TerminalManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import { projects, activeSessionId } from './stores';
+import { projects, activeSessionId, focusTarget, type FocusTarget } from './stores';
 
 // Mock Terminal.svelte to avoid xterm.js dependency
 vi.mock('./Terminal.svelte', () => {
@@ -18,6 +18,7 @@ describe('TerminalManager', () => {
     vi.clearAllMocks();
     projects.set([]);
     activeSessionId.set(null);
+    focusTarget.set(null);
   });
 
   it('shows empty state when no active session', () => {
@@ -46,5 +47,30 @@ describe('TerminalManager', () => {
 
     render(TerminalManager);
     expect(screen.queryByText('No active session')).not.toBeInTheDocument();
+  });
+
+  it('sets focusTarget with projectId when terminal receives focus', async () => {
+    projects.set([{
+      id: 'proj-1',
+      name: 'test',
+      repo_path: '/tmp/test',
+      created_at: '2026-01-01',
+      archived: false,
+      sessions: [
+        { id: 'sess-1', label: 'session-1', worktree_path: null, worktree_branch: null, archived: false, kind: 'claude', github_issue: null },
+      ],
+    }]);
+    activeSessionId.set('sess-1');
+
+    const { container } = render(TerminalManager);
+    const terminalManager = container.querySelector('.terminal-manager')!;
+    terminalManager.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    // Wait for Svelte reactivity
+    await vi.dynamicImportSettled();
+
+    let focus: FocusTarget = null;
+    focusTarget.subscribe((v) => { focus = v; })();
+    expect(focus).toEqual({ type: 'terminal', projectId: 'proj-1' });
   });
 });

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -67,7 +67,7 @@ export const expandedProjects = writable<Set<string>>(new Set());
 
 // Focus tracking — granular: which element is focused
 export type FocusTarget =
-  | { type: "terminal" }
+  | { type: "terminal"; projectId: string }
   | { type: "session"; sessionId: string; projectId: string }
   | { type: "project"; projectId: string }
   | null;


### PR DESCRIPTION
## Summary
- When focused on a session's terminal, the GitHub issues panel (`t`) was showing issues for `the-controller` instead of the focused project
- Root cause: `focusTarget` for terminals had no `projectId`, so `TaskPanel` fell back to `projectList[0]`
- Added `projectId` to the terminal focus target type and threaded it through from `TerminalManager`

## Test plan
- [x] Added test: terminal focus sets `focusTarget` with correct `projectId`
- [x] All 112 tests pass

closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)