### PR TITLE
feat: capture first user prompt for summary pane

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -475,6 +475,29 @@ pub fn resize_pty(
 }
 
 #[tauri::command]
+pub fn set_initial_prompt(
+    state: State<AppState>,
+    project_id: String,
+    session_id: String,
+    prompt: String,
+) -> Result<(), String> {
+    let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let session_uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    let storage = state.storage.lock().map_err(|e| e.to_string())?;
+    let mut project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
+
+    if let Some(session) = project.sessions.iter_mut().find(|s| s.id == session_uuid) {
+        if session.initial_prompt.is_none() {
+            session.initial_prompt = Some(prompt);
+            storage.save_project(&project).map_err(|e| e.to_string())?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
 pub fn archive_session(
     state: State<AppState>,
     project_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub fn run() {
             commands::send_raw_to_pty,
             commands::resize_pty,
             commands::close_session,
+            commands::set_initial_prompt,
             commands::archive_session,
             commands::unarchive_session,
             commands::start_claude_login,

--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -82,10 +82,10 @@
     <div class="summary-row">
       <span class="label">PROMPT</span>
       <span class="value prompt-text">
-        {#if session.initial_prompt}
-          {session.initial_prompt}
-        {:else if session.github_issue}
+        {#if session.github_issue}
           #{session.github_issue.number}: {session.github_issue.title}
+        {:else if session.initial_prompt}
+          {session.initial_prompt}
         {:else}
           <span class="muted">No prompt</span>
         {/if}

--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -6,7 +6,7 @@
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { makeCustomKeyHandler } from "./terminal-keys";
   import { clipboardHasImage } from "./clipboard";
-  import { activeSessionId } from "./stores";
+  import { activeSessionId, projects, type Project } from "./stores";
   import "@xterm/xterm/css/xterm.css";
 
   interface Props {
@@ -29,6 +29,16 @@
   // sent to the PTY as input. See GitHub issue #49.
   let inputReady = false;
 
+  // Capture the first prompt typed by the user (text before first Enter).
+  // Skip if session already has a prompt (e.g., from a GitHub issue).
+  let promptBuffer = "";
+  let promptCaptured = (() => {
+    let list: Project[] = [];
+    projects.subscribe((v) => { list = v; })();
+    const session = list.flatMap((p) => p.sessions).find((s) => s.id === sessionId);
+    return session?.initial_prompt != null || session?.github_issue != null;
+  })();
+
   async function handleImagePaste(
     writeToPty: (data: string) => Promise<unknown>,
   ) {
@@ -47,6 +57,28 @@
         // Clipboard read failed — nothing to paste
       }
     }
+  }
+
+  function saveInitialPrompt(prompt: string) {
+    let projectList: Project[] = [];
+    projects.subscribe((v) => { projectList = v; })();
+    const match = projectList.flatMap((p) =>
+      p.sessions.map((s) => ({ session: s, projectId: p.id }))
+    ).find((x) => x.session.id === sessionId);
+    if (!match || match.session.initial_prompt != null) return;
+
+    invoke("set_initial_prompt", {
+      projectId: match.projectId,
+      sessionId,
+      prompt,
+    }).then(() => {
+      // Refresh the store so SummaryPane picks up the change
+      invoke<Project[]>("list_projects").then((result) => {
+        projects.set(result);
+      });
+    }).catch((err) => {
+      console.error("Failed to save initial prompt:", err);
+    });
   }
 
   const IMAGE_EXTENSIONS = new Set([
@@ -100,6 +132,28 @@
     // Connect user input to PTY (gated until initialization settles)
     term.onData((data: string) => {
       if (!inputReady) return;
+
+      // Capture the first prompt: buffer keystrokes until Enter
+      if (!promptCaptured) {
+        for (const ch of data) {
+          if (ch === "\r" || ch === "\n") {
+            const trimmed = promptBuffer.trim();
+            if (trimmed.length > 0) {
+              promptCaptured = true;
+              saveInitialPrompt(trimmed);
+            }
+            promptBuffer = "";
+            break;
+          } else if (ch === "\x7f" || ch === "\b") {
+            // Backspace
+            promptBuffer = promptBuffer.slice(0, -1);
+          } else if (ch >= " ") {
+            // Printable character
+            promptBuffer += ch;
+          }
+        }
+      }
+
       writeToPty(data).catch((err) => {
         console.error("Failed to write to PTY:", err);
       });


### PR DESCRIPTION
## Summary
- Summary pane now shows GitHub issue header (`#number: title`) when available, falling back to the initial prompt
- For sessions without an issue, captures the first line the user types into the terminal and persists it as the session's `initial_prompt`
- Adds `set_initial_prompt` backend command to update session config on disk

## Test plan
- [ ] Create a session with a GitHub issue — summary pane shows issue header
- [ ] Create a raw session, type a prompt, press Enter — summary pane updates to show that prompt
- [ ] Verify sessions with existing prompts don't get overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)