### PR TITLE
fix: use carriage return for PTY merge command

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -288,7 +288,7 @@
         return true;
       case "m":
         if (activeId) {
-          invoke("write_to_pty", { sessionId: activeId, data: "create pr, merge, sync local master\n" });
+          invoke("write_to_pty", { sessionId: activeId, data: "create pr, merge, sync local master\r" });
         }
         return true;
       case "s":

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -140,7 +140,7 @@ describe('HotkeyManager', () => {
       pressKey('m');
       expect(invoke).toHaveBeenCalledWith('write_to_pty', {
         sessionId: 'sess-1',
-        data: 'create pr, merge, sync local master\n',
+        data: 'create pr, merge, sync local master\r',
       });
     });
 


### PR DESCRIPTION
## Summary
- Changed `\n` to `\r` in the `m` hotkey's `write_to_pty` call so the command actually executes in the PTY (terminals expect carriage return for Enter, not newline)

## Test plan
- [x] Updated existing test to expect `\r`

🤖 Generated with [Claude Code](https://claude.com/claude-code)