### PR TITLE
feat: increase summary pane max-height 3x

### DIFF
--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -119,7 +119,7 @@
     border-bottom: 1px solid #313244;
     font-size: 12px;
     flex-shrink: 0;
-    max-height: 120px;
+    max-height: 360px;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
## Summary
- Increase summary pane `max-height` from 120px to 360px (3x larger)

## Test plan
- [ ] Verify summary pane displays more content before scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)