### PR TITLE
feat: don't auto-open task panel when filing new issue

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,7 +27,7 @@
   let taskPanelIsVisible = $state(false);
   let createIssueTarget: { projectId: string; repoPath: string } | null = $state(null);
   let issuePickerTarget: { projectId: string; repoPath: string; kind?: string; background?: boolean } | null = $state(null);
-  let taskPanelRef: { insertIssue: (issue: any) => void } | undefined = $state();
+
 
   $effect(() => {
     const unsub = sidebarVisible.subscribe((v) => { sidebarIsVisible = v; });
@@ -73,10 +73,6 @@
       });
 
       showToast(`Issue #${issue.number} created`, "info");
-      taskPanelVisible.set(true);
-      setTimeout(() => {
-        taskPanelRef?.insertIssue(issue);
-      }, 50);
     } catch (e) {
       showToast(String(e), "error");
     }
@@ -179,7 +175,7 @@
         <TerminalManager />
       </main>
       {#if taskPanelIsVisible}
-        <TaskPanel visible={taskPanelIsVisible} bind:this={taskPanelRef} />
+        <TaskPanel visible={taskPanelIsVisible} />
       {/if}
     </div>
     <HotkeyManager />

--- a/src/lib/TaskPanel.svelte
+++ b/src/lib/TaskPanel.svelte
@@ -17,9 +17,6 @@
 
   let issues: GithubIssue[] = $state([]);
 
-  export function insertIssue(issue: GithubIssue) {
-    issues = [issue, ...issues];
-  }
   let loading = $state(false);
   let error: string | null = $state(null);
   let currentRepoPath: string | null = $state(null);


### PR DESCRIPTION
## Summary
- Remove auto-opening of the task panel (`t` panel) after creating a new GitHub issue
- Clean up unused `insertIssue` export from TaskPanel and `taskPanelRef` binding

## Test plan
- [ ] Create a new issue via the `i` hotkey and verify the task panel does not auto-open
- [ ] Verify the issue is still created successfully with toast notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)