### PR TITLE
fix: status indicator stays green while Claude is busy

### DIFF
--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -109,6 +109,18 @@ pub fn hook_settings_json(_session_id: Uuid) -> String {
                     "command": working_cmd
                 }]
             }],
+            "PreToolUse": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": working_cmd
+                }]
+            }],
+            "PostToolUse": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": working_cmd
+                }]
+            }],
             "Stop": [{
                 "hooks": [{
                     "type": "command",
@@ -161,11 +173,13 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         let hooks = parsed.get("hooks").unwrap();
         assert!(hooks.get("UserPromptSubmit").is_some());
+        assert!(hooks.get("PreToolUse").is_some());
+        assert!(hooks.get("PostToolUse").is_some());
         assert!(hooks.get("Stop").is_some());
         assert!(hooks.get("Notification").is_some());
 
         // Verify new hooks format: each event entry must have a nested "hooks" array
-        for event_name in &["UserPromptSubmit", "Stop", "Notification"] {
+        for event_name in &["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "Notification"] {
             let entries = hooks.get(*event_name).unwrap().as_array().unwrap();
             for entry in entries {
                 assert!(


### PR DESCRIPTION
## Summary
- Adds `PreToolUse` and `PostToolUse` hooks that signal "working" to the status socket
- Fixes the status dot showing green (idle) during multi-tool-call sequences, where `Stop` fires between turns but no "working" signal followed
- The idle debounce timer gets properly canceled by tool-use activity, keeping status yellow until Claude truly stops

## Test plan
- [x] All 8 `status_socket` unit tests pass
- [ ] Manual: verify status dot stays yellow during multi-tool-call sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)