### PR TITLE
feat: persist session commits so DONE survives merge/rebase

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -427,6 +427,7 @@ pub fn create_session(
             kind: kind.clone(),
             github_issue,
             initial_prompt: initial_prompt.clone(),
+            done_commits: vec![],
         };
         project.sessions.push(session_config);
         storage.save_project(&project).map_err(|e| e.to_string())?;
@@ -1188,11 +1189,7 @@ pub async fn copy_image_file_to_clipboard(app: AppHandle, path: String) -> Resul
         .map_err(|e| format!("Failed to write image to clipboard: {e}"))
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct CommitInfo {
-    pub hash: String,
-    pub message: String,
-}
+use crate::models::CommitInfo;
 
 #[tauri::command]
 pub fn get_session_commits(
@@ -1214,18 +1211,41 @@ pub fn get_session_commits(
 
     let worktree_path = match &session.worktree_path {
         Some(p) => p.clone(),
-        None => return Ok(vec![]),
+        None => return Ok(session.done_commits.clone()),
     };
 
-    let repo = git2::Repository::discover(&worktree_path)
+    // Discover new commits on the branch that aren't on main
+    let new_commits = discover_branch_commits(&worktree_path).unwrap_or_default();
+
+    // Merge with previously stored commits (new first, then stored, dedup by hash)
+    let mut seen = std::collections::HashSet::new();
+    let mut all_commits = Vec::new();
+    for c in new_commits.iter().chain(session.done_commits.iter()) {
+        if seen.insert(c.hash.clone()) {
+            all_commits.push(c.clone());
+        }
+    }
+
+    // Persist if we found new commits
+    if all_commits.len() > session.done_commits.len() {
+        let mut project = project.clone();
+        if let Some(s) = project.sessions.iter_mut().find(|s| s.id == session_uuid) {
+            s.done_commits = all_commits.clone();
+        }
+        let _ = storage.save_project(&project);
+    }
+
+    Ok(all_commits)
+}
+
+/// Walk commits on the worktree branch that aren't on the main branch.
+fn discover_branch_commits(worktree_path: &str) -> Result<Vec<CommitInfo>, String> {
+    let repo = git2::Repository::discover(worktree_path)
         .map_err(|e| format!("Failed to open repo: {e}"))?;
 
-    // Walk commits on the session branch that aren't on the main branch.
-    // The session branch name matches the session label.
     let head = repo.head().map_err(|e| format!("No HEAD: {e}"))?;
     let head_commit = head.peel_to_commit().map_err(|e| e.to_string())?;
 
-    // Find the merge base with the default branch (master or main)
     let main_oid = find_main_branch_oid(&repo);
 
     let mut revwalk = repo.revwalk().map_err(|e| e.to_string())?;
@@ -1235,7 +1255,6 @@ pub fn get_session_commits(
     let mut commits = Vec::new();
     for oid in revwalk {
         let oid = oid.map_err(|e| e.to_string())?;
-        // Stop at merge base (commits shared with main)
         if let Some(main) = main_oid {
             if oid == main {
                 break;
@@ -1248,7 +1267,6 @@ pub fn get_session_commits(
         }
         let commit = repo.find_commit(oid).map_err(|e| e.to_string())?;
         let message = commit.summary().unwrap_or("").to_string();
-        // Skip the initial worktree commit
         if message.starts_with("Initial commit") {
             continue;
         }
@@ -1334,6 +1352,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -1344,6 +1363,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
         ];
         assert_eq!(next_session_label(&sessions), "session-3");
@@ -1362,6 +1382,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -1372,6 +1393,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -1382,6 +1404,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
         ];
         // Max is session-3, so next is session-4
@@ -1400,6 +1423,7 @@ mod tests {
             kind: "claude".to_string(),
             github_issue: None,
             initial_prompt: None,
+            done_commits: vec![],
         }];
         assert_eq!(next_session_label(&sessions), "session-4");
     }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -25,6 +25,15 @@ pub struct SessionConfig {
     pub github_issue: Option<GithubIssue>,
     #[serde(default)]
     pub initial_prompt: Option<String>,
+    /// Accumulated commit summaries — persisted so they survive merge/rebase.
+    #[serde(default)]
+    pub done_commits: Vec<CommitInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommitInfo {
+    pub hash: String,
+    pub message: String,
 }
 
 fn default_kind() -> String {
@@ -90,6 +99,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             }],
         };
 
@@ -142,6 +152,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             }],
         };
 
@@ -178,6 +189,7 @@ mod tests {
                 labels: vec![],
             }),
             initial_prompt: None,
+            done_commits: vec![],
         };
         let json = serde_json::to_string(&session).expect("serialize");
         let deserialized: SessionConfig = serde_json::from_str(&json).expect("deserialize");
@@ -213,6 +225,7 @@ mod tests {
             kind: "claude".to_string(),
             github_issue: None,
             initial_prompt: Some("fix the bug".to_string()),
+            done_commits: vec![],
         };
         let json = serde_json::to_string(&session).expect("serialize");
         let deserialized: SessionConfig = serde_json::from_str(&json).expect("deserialize");

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -184,6 +184,7 @@ mod tests {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             }],
         }
     }

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -40,6 +40,7 @@ fn test_project_lifecycle() {
         kind: "claude".to_string(),
         github_issue: None,
         initial_prompt: None,
+        done_commits: vec![],
     });
     storage.save_project(&project).expect("save with session");
 
@@ -121,6 +122,7 @@ fn test_sessions_persist_across_restarts() {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -131,6 +133,7 @@ fn test_sessions_persist_across_restarts() {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
             SessionConfig {
                 id: Uuid::new_v4(),
@@ -141,6 +144,7 @@ fn test_sessions_persist_across_restarts() {
                 kind: "claude".to_string(),
                 github_issue: None,
                 initial_prompt: None,
+                done_commits: vec![],
             },
         ],
     };
@@ -246,6 +250,7 @@ fn test_worktrees_persist_across_restarts() {
             kind: "claude".to_string(),
             github_issue: None,
             initial_prompt: None,
+            done_commits: vec![],
         }],
     };
     storage.save_project(&project).expect("save project");
@@ -284,6 +289,7 @@ fn test_migrate_worktree_paths_renames_uuid_dir() {
             kind: "claude".to_string(),
             github_issue: None,
             initial_prompt: None,
+            done_commits: vec![],
         }],
     };
     storage.save_project(&project).expect("save project");
@@ -328,6 +334,7 @@ fn test_migrate_worktree_paths_noop_when_no_uuid_dir() {
             kind: "claude".to_string(),
             github_issue: None,
             initial_prompt: None,
+            done_commits: vec![],
         }],
     };
     storage.save_project(&project).expect("save project");
@@ -377,6 +384,7 @@ fn test_migrate_worktree_paths_noop_on_name_collision() {
             kind: "claude".to_string(),
             github_issue: None,
             initial_prompt: None,
+            done_commits: vec![],
         }],
     };
     storage.save_project(&project).expect("save project");


### PR DESCRIPTION
## Summary
- Add `done_commits` field to `SessionConfig` to persist discovered commits
- `get_session_commits` merges new git-discovered commits with stored ones, deduplicating by hash
- After merge/rebase when git walk returns nothing, stored commits still show in DONE section

## Test plan
- [x] All Rust unit and integration tests pass
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)