### PR TITLE
fix: capture pasted text into prompt buffer for summary pane

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -51,6 +51,11 @@
       try {
         const text = await navigator.clipboard.readText();
         if (text) {
+          // Capture pasted text into the prompt buffer so the summary pane
+          // shows the full prompt (paste bypasses term.onData).
+          if (!promptCaptured) {
+            promptBuffer += text;
+          }
           await writeToPty("\x1b[200~" + text + "\x1b[201~");
         }
       } catch {


### PR DESCRIPTION
## Summary
- Pasted text (Cmd+V) was sent directly to PTY via `writeToPty`, bypassing `term.onData` where the prompt buffer is built
- This caused the summary pane to only show characters typed *after* the paste, not the full prompt
- Now appends pasted clipboard text to `promptBuffer` so the complete prompt is captured

## Test plan
- [ ] Paste a full prompt into a new session via Cmd+V and press Enter
- [ ] Verify the summary pane PROMPT field shows the complete pasted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)