### PR TITLE
feat: improve terminal UX and dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ Built with Tauri v2 + Svelte 5 + Rust.
 
 ### tmux Configuration
 
-If you use Claude Code inside tmux to develop this project, add the following to `~/.tmux.conf` to fix scrambled output when scrolling:
+If you use Claude Code inside tmux to develop this project, add the following to `~/.tmux.conf` for a cleaner UI:
 
 ```
-set -g mouse on
 set -g status off
 ```
 
 Reload with `tmux source-file ~/.tmux.conf`.
 
-Without `mouse on`, trackpad scrolling sends raw escape sequences to Claude Code's TUI, producing garbled output in the scrollback buffer. `status off` hides the tmux status bar for a cleaner UI.
+`status off` hides the tmux status bar for a cleaner UI.
 
 ## Demo Ideas
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Start the controller dev server on a custom port.
+# Usage: ./dev.sh [port]   (default: 1420)
+PORT=${1:-1420}
+DEV_PORT=$PORT npm run tauri dev -- --config "{\"build\":{\"devUrl\":\"http://localhost:$PORT\"}}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-controller",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-controller",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "the-controller"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-set-title",
     "opener:default",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-read-image",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
+  import { getCurrentWindow } from "@tauri-apps/api/window";
   import Sidebar from "./lib/Sidebar.svelte";
   import TerminalManager from "./lib/TerminalManager.svelte";
   import Onboarding from "./lib/Onboarding.svelte";
@@ -138,6 +139,10 @@
   }
 
   onMount(async () => {
+    getCurrentWindow().setTitle(
+      `The Controller (${__BUILD_COMMIT__}, ${__BUILD_BRANCH__}, localhost:${__DEV_PORT__})`,
+    );
+
     try {
       // Re-spawn PTY sessions for persisted active sessions
       await invoke("restore_sessions");

--- a/src/build-info.d.ts
+++ b/src/build-info.d.ts
@@ -1,0 +1,3 @@
+declare const __BUILD_COMMIT__: string;
+declare const __BUILD_BRANCH__: string;
+declare const __DEV_PORT__: number;

--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -103,6 +103,7 @@
       cursorBlink: true,
       fontSize: 13,
       fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+      scrollback: 10000,
       theme: {
         background: "#11111b",
         foreground: "#cdd6f4",
@@ -114,6 +115,7 @@
     fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(containerEl);
+
     // Only fit if the container is actually visible — xterm.js can't measure
     // character cells in a display:none ancestor, which produces bogus cols.
     if (containerEl.offsetParent !== null) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,29 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { execSync } from "child_process";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// @ts-expect-error process is a nodejs global
+const port = parseInt(process.env.DEV_PORT || "1420", 10);
+
+function git(cmd: string): string {
+  try {
+    return execSync(`git ${cmd}`, { encoding: "utf-8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [svelte()],
+
+  define: {
+    __BUILD_COMMIT__: JSON.stringify(git("rev-parse --short HEAD")),
+    __BUILD_BRANCH__: JSON.stringify(git("rev-parse --abbrev-ref HEAD")),
+    __DEV_PORT__: JSON.stringify(port),
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
@@ -14,14 +31,14 @@ export default defineConfig(async () => ({
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
+    port,
     strictPort: true,
     host: host || false,
     hmr: host
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          port: port + 1,
         }
       : undefined,
     watch: {


### PR DESCRIPTION
## Summary
- Remove tmux `mouse on` so text selection and copy/paste work natively in terminal sessions
- Increase xterm.js scrollback buffer to 10,000 lines
- Add configurable dev port via `DEV_PORT` env var and `./dev.sh [port]` script
- Show (commit, branch, devUrl) in the macOS window title bar

## Test plan
- [x] Scrolling works in terminal sessions without garbling
- [x] Text selection with mouse works
- [x] Cmd+C / Cmd+V copy/paste works
- [x] `./dev.sh 1421` starts on custom port
- [x] Window title shows commit, branch, and port
- [x] All 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)