### PR TITLE
chore: remove hardcoded task workflow from agents.md

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -2,16 +2,6 @@
 
 Tauri v2 + Svelte 5 desktop app for orchestrating multiple Claude Code terminal sessions.
 
-## Task Workflow (CRITICAL)
-
-For every new task, follow this workflow:
-
-1. **File a GitHub issue** — Create an issue in this repository describing the task before starting work.
-2. **Update with design plan** — Once the design is complete, update the GitHub issue with the design plan.
-3. **Update with implementation plan** — Once the implementation plan is ready, update the GitHub issue with it.
-4. **Close the issue** — Close the GitHub issue once the task is fully completed and verified.
-5. **Update the merge commit/PR** — After merging, update the merge note (PR description or commit message) to summarize what work was done.
-
 ## Task Structure (CRITICAL — NEVER SKIP)
 
 **This is the most important rule. Every task, no matter how small, MUST follow this structure before writing any code. No exceptions.**


### PR DESCRIPTION
## Summary
- Removed the hardcoded "Task Workflow (CRITICAL)" section from `agents.md` that prescribed a rigid issue/PR workflow (file issue, update with plans, close issue, update PR)

## Test plan
- [x] Verify the Task Structure section and all other sections remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)