### PR TITLE
fix: match local PTY size to tmux session on reattach

### DIFF
--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -155,11 +155,15 @@ impl PtyManager {
     ) -> Result<(), String> {
         let tmux_name = TmuxManager::session_name(session_id);
 
+        // Use the tmux session's current dimensions so the attach doesn't
+        // force a resize (which causes TUI glitches like garbled input).
+        let (cols, rows) = TmuxManager::session_size(session_id).unwrap_or((80, 24));
+
         let pty_system = native_pty_system();
         let pair = pty_system
             .openpty(PtySize {
-                rows: 24,
-                cols: 80,
+                rows,
+                cols,
                 pixel_width: 0,
                 pixel_height: 0,
             })

--- a/src-tauri/src/tmux.rs
+++ b/src-tauri/src/tmux.rs
@@ -124,6 +124,28 @@ impl TmuxManager {
         Ok(())
     }
 
+    /// Query the current window dimensions of a tmux session.
+    /// Returns `(cols, rows)` or `None` if the query fails.
+    pub fn session_size(session_id: Uuid) -> Option<(u16, u16)> {
+        let name = Self::session_name(session_id);
+        let output = Command::new(TMUX_BIN)
+            .args(["display-message", "-t", &name, "-p", "#{window_width} #{window_height}"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        let parts: Vec<&str> = text.trim().split_whitespace().collect();
+        if parts.len() == 2 {
+            let cols = parts[0].parse::<u16>().ok()?;
+            let rows = parts[1].parse::<u16>().ok()?;
+            Some((cols, rows))
+        } else {
+            None
+        }
+    }
+
     pub fn resize_session(session_id: Uuid, cols: u16, rows: u16) -> Result<(), String> {
         let name = Self::session_name(session_id);
         let output = Command::new(TMUX_BIN)
@@ -171,6 +193,12 @@ mod tests {
     fn test_has_session_returns_false_for_nonexistent() {
         let id = Uuid::new_v4();
         assert!(!TmuxManager::has_session(id));
+    }
+
+    #[test]
+    fn test_session_size_returns_none_for_nonexistent() {
+        let id = Uuid::new_v4();
+        assert!(TmuxManager::session_size(id).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Query tmux session's current window dimensions before attaching, instead of hardcoding 80×24
- Prevents TUI garbling (overlapping input) in codex sessions after app restart
- Falls back to 80×24 if the tmux size query fails

## Test plan
- [x] All 127 existing tests pass
- [x] New test for `TmuxManager::session_size()` with nonexistent session
- [ ] Manual: restart app with active codex session, verify input box renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)