### PR TITLE
fix: eliminate extra newlines in sessions after restart

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -75,49 +75,74 @@ pub fn render_agents_md(name: &str) -> String {
     DEFAULT_AGENTS_MD.replace("{name}", name)
 }
 
-/// Re-spawn PTY sessions for all active (non-archived) sessions across all projects.
-/// PTY processes don't survive restart, but session metadata and worktrees persist.
+/// Run storage migrations on startup (worktree path format, etc.).
+/// PTY connections are deferred to `connect_session` so each terminal
+/// can attach at the correct size.
 #[tauri::command]
 pub fn restore_sessions(
     state: State<AppState>,
-    app_handle: AppHandle,
 ) -> Result<(), String> {
-    let projects = {
-        let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let projects = storage.list_projects().map_err(|e| e.to_string())?;
-        // Migrate worktree paths from UUID-based to name-based directories
-        for project in &projects {
-            if let Err(e) = storage.migrate_worktree_paths(project) {
-                eprintln!("Failed to migrate worktrees for project '{}': {}", project.name, e);
-            }
-        }
-        // Reload after migration to get updated paths
-        storage.list_projects().map_err(|e| e.to_string())?
-    };
-
-    let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
-
+    let storage = state.storage.lock().map_err(|e| e.to_string())?;
+    let projects = storage.list_projects().map_err(|e| e.to_string())?;
+    // Migrate worktree paths from UUID-based to name-based directories
     for project in &projects {
-        for session in &project.sessions {
-            if session.archived {
-                continue;
-            }
-            let session_dir = session
-                .worktree_path
-                .clone()
-                .unwrap_or_else(|| project.repo_path.clone());
+        if let Err(e) = storage.migrate_worktree_paths(project) {
+            eprintln!("Failed to migrate worktrees for project '{}': {}", project.name, e);
+        }
+    }
+    Ok(())
+}
 
-            if let Err(e) = pty_manager.spawn_session(session.id, &session_dir, &session.kind, app_handle.clone(), true, None)
-            {
-                eprintln!(
-                    "Failed to restore session {} ({}): {}",
-                    session.label, session.id, e
-                );
-            }
+/// Connect a terminal to its PTY session at the given size.
+/// Called by each Terminal component after it measures its dimensions.
+/// No-op if the session is already connected.
+#[tauri::command]
+pub fn connect_session(
+    state: State<AppState>,
+    app_handle: AppHandle,
+    session_id: String,
+    rows: u16,
+    cols: u16,
+) -> Result<(), String> {
+    let id = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    // Check if already connected
+    {
+        let pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
+        if pty_manager.sessions.contains_key(&id) {
+            return Ok(());
         }
     }
 
-    Ok(())
+    // Find session config from storage
+    let (session_dir, kind) = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        let projects = storage.list_projects().map_err(|e| e.to_string())?;
+        projects
+            .iter()
+            .flat_map(|p| p.sessions.iter().map(move |s| (p, s)))
+            .find(|(_, s)| s.id == id)
+            .map(|(p, s)| {
+                let dir = s
+                    .worktree_path
+                    .clone()
+                    .unwrap_or_else(|| p.repo_path.clone());
+                (dir, s.kind.clone())
+            })
+            .ok_or_else(|| format!("session not found: {}", session_id))?
+    };
+
+    let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
+    pty_manager.spawn_session(
+        id,
+        &session_dir,
+        &kind,
+        app_handle,
+        true,
+        None,
+        rows,
+        cols,
+    )
 }
 
 #[tauri::command]
@@ -336,7 +361,7 @@ pub fn unarchive_project(
     // Spawn PTYs for restored sessions
     let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
     for (session_id, session_dir, kind) in to_restore {
-        pty_manager.spawn_session(session_id, &session_dir, &kind, app_handle.clone(), true, None)?;
+        pty_manager.spawn_session(session_id, &session_dir, &kind, app_handle.clone(), true, None, 24, 80)?;
     }
 
     Ok(())
@@ -435,7 +460,7 @@ pub fn create_session(
 
     // Spawn the PTY session in the worktree (or repo) directory
     let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
-    pty_manager.spawn_session(session_id, &session_dir, &kind, app_handle, false, initial_prompt.as_deref())?;
+    pty_manager.spawn_session(session_id, &session_dir, &kind, app_handle, false, initial_prompt.as_deref(), 24, 80)?;
 
     Ok(session_id.to_string())
 }
@@ -560,7 +585,7 @@ pub fn unarchive_session(
 
     // Spawn the PTY session in the existing worktree directory
     let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
-    pty_manager.spawn_session(session_uuid, &session_dir, &kind, app_handle, true, None)?;
+    pty_manager.spawn_session(session_uuid, &session_dir, &kind, app_handle, true, None, 24, 80)?;
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::restore_sessions,
+            commands::connect_session,
             commands::create_project,
             commands::load_project,
             commands::list_projects,

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -17,7 +17,7 @@ pub struct PtySession {
 }
 
 pub struct PtyManager {
-    sessions: HashMap<Uuid, PtySession>,
+    pub(crate) sessions: HashMap<Uuid, PtySession>,
 }
 
 impl PtyManager {
@@ -39,7 +39,14 @@ impl PtyManager {
         app_handle: AppHandle,
         continue_session: bool,
         initial_prompt: Option<&str>,
+        rows: u16,
+        cols: u16,
     ) -> Result<(), String> {
+        // Skip if already connected
+        if self.sessions.contains_key(&session_id) {
+            return Ok(());
+        }
+
         let command = match kind {
             "codex" => "codex",
             _ => "claude",
@@ -49,11 +56,15 @@ impl PtyManager {
             if !TmuxManager::has_session(session_id) {
                 TmuxManager::create_session(session_id, working_dir, command, continue_session, initial_prompt)?;
             }
+            // Pre-resize tmux to the target size so attaching doesn't cause
+            // an intermediate resize (which would make claude re-render and
+            // produce extra newlines).
+            let _ = TmuxManager::resize_session(session_id, cols, rows);
             // Attach to the tmux session via a local PTY
-            self.attach_tmux_session(session_id, app_handle)
+            self.attach_tmux_session(session_id, app_handle, rows, cols)
         } else {
             // No tmux — spawn the command directly in a PTY
-            self.spawn_direct_session(session_id, working_dir, command, app_handle, initial_prompt)
+            self.spawn_direct_session(session_id, working_dir, command, app_handle, initial_prompt, rows, cols)
         }
     }
 
@@ -65,12 +76,14 @@ impl PtyManager {
         command: &str,
         app_handle: AppHandle,
         initial_prompt: Option<&str>,
+        rows: u16,
+        cols: u16,
     ) -> Result<(), String> {
         let pty_system = native_pty_system();
         let pair = pty_system
             .openpty(PtySize {
-                rows: 24,
-                cols: 80,
+                rows,
+                cols,
                 pixel_width: 0,
                 pixel_height: 0,
             })
@@ -152,14 +165,16 @@ impl PtyManager {
         &mut self,
         session_id: Uuid,
         app_handle: AppHandle,
+        rows: u16,
+        cols: u16,
     ) -> Result<(), String> {
         let tmux_name = TmuxManager::session_name(session_id);
 
         let pty_system = native_pty_system();
         let pair = pty_system
             .openpty(PtySize {
-                rows: 24,
-                cols: 80,
+                rows,
+                cols,
                 pixel_width: 0,
                 pixel_height: 0,
             })

--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -30,6 +30,9 @@
   // sent to the PTY as input. See GitHub issue #49.
   let inputReady = false;
 
+  // Whether connect_session has been called for this terminal.
+  let connected = false;
+
   // Capture the first prompt typed by the user (text before first Enter).
   // Skip if session already has a prompt (e.g., from a GitHub issue).
   let promptBuffer = "";
@@ -121,6 +124,16 @@
     if (containerEl.offsetParent !== null) {
       fitAddon.fit();
       termOpened = true;
+      // Connect PTY at the measured size to avoid intermediate resizes
+      // that cause extra newlines on restart.
+      connected = true;
+      invoke("connect_session", {
+        sessionId,
+        rows: term.rows,
+        cols: term.cols,
+      }).catch((err) => {
+        console.error("Failed to connect session:", err);
+      });
     }
 
     const writeToPty = (data: string) =>
@@ -264,6 +277,18 @@
 
         // Guard against bogus dimensions
         if (term.cols < 10) return;
+
+        // Connect PTY if this terminal was hidden on mount
+        if (!connected) {
+          connected = true;
+          invoke("connect_session", {
+            sessionId,
+            rows: term.rows,
+            cols: term.cols,
+          }).catch((err: unknown) => {
+            console.error("Failed to connect session:", err);
+          });
+        }
 
         // Force full repaint — canvas content may be stale after display:none
         term.refresh(0, term.rows - 1);


### PR DESCRIPTION
## Summary
- Defers PTY attachment from `restore_sessions` to a new per-terminal `connect_session` command, so each terminal attaches at its measured size instead of hardcoded 24x80
- Pre-resizes tmux window before attaching to avoid intermediate resize that caused claude/codex to re-render and produce extra scrollback lines
- Works for both claude and codex sessions

## Test plan
- [ ] Restart app with active sessions — verify no extra newlines appear
- [ ] Create new sessions — verify they still work correctly
- [ ] Switch between tabs — verify hidden terminals connect when first shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)