### PR TITLE
fix: add UUID suffix to session branch names to prevent collisions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -21,16 +21,18 @@ pub(crate) fn validate_project_name(name: &str) -> Result<(), String> {
 }
 
 /// Generate the next session label by finding the highest existing session number
-/// and returning "session-N" where N = max + 1. This avoids collisions when
-/// sessions are deleted or archived out of order.
+/// and returning "session-N-<6-char-uuid>" where N = max + 1. The UUID suffix
+/// guarantees uniqueness even when branches from deleted sessions persist on the
+/// remote.
 pub(crate) fn next_session_label(sessions: &[SessionConfig]) -> String {
     let max_num = sessions
         .iter()
         .filter_map(|s| s.label.strip_prefix("session-"))
-        .filter_map(|n| n.parse::<u32>().ok())
+        .filter_map(|n| n.split('-').next()?.parse::<u32>().ok())
         .max()
         .unwrap_or(0);
-    format!("session-{}", max_num + 1)
+    let short_id = &Uuid::new_v4().to_string()[..6];
+    format!("session-{}-{}", max_num + 1, short_id)
 }
 
 const DEFAULT_AGENTS_MD: &str = r#"# {name}
@@ -1130,7 +1132,9 @@ mod tests {
     #[test]
     fn test_next_session_label_empty() {
         let sessions: Vec<SessionConfig> = vec![];
-        assert_eq!(next_session_label(&sessions), "session-1");
+        let label = next_session_label(&sessions);
+        assert!(label.starts_with("session-1-"), "expected session-1-<id>, got {}", label);
+        assert_eq!(label.len(), "session-1-".len() + 6); // 6-char UUID suffix
     }
 
     #[test]
@@ -1159,7 +1163,8 @@ mod tests {
                 done_commits: vec![],
             },
         ];
-        assert_eq!(next_session_label(&sessions), "session-3");
+        let label = next_session_label(&sessions);
+        assert!(label.starts_with("session-3-"), "expected session-3-<id>, got {}", label);
     }
 
     #[test]
@@ -1201,7 +1206,8 @@ mod tests {
             },
         ];
         // Max is session-3, so next is session-4
-        assert_eq!(next_session_label(&sessions), "session-4");
+        let label = next_session_label(&sessions);
+        assert!(label.starts_with("session-4-"), "expected session-4-<id>, got {}", label);
     }
 
     #[test]
@@ -1218,7 +1224,34 @@ mod tests {
             initial_prompt: None,
             done_commits: vec![],
         }];
-        assert_eq!(next_session_label(&sessions), "session-4");
+        let label = next_session_label(&sessions);
+        assert!(label.starts_with("session-4-"), "expected session-4-<id>, got {}", label);
+    }
+
+    #[test]
+    fn test_next_session_label_parses_new_format() {
+        // Labels with UUID suffix (session-2-abc123) should parse correctly
+        let sessions = vec![SessionConfig {
+            id: Uuid::new_v4(),
+            label: "session-2-a1b2c3".to_string(),
+            worktree_path: None,
+            worktree_branch: None,
+            archived: false,
+            kind: "claude".to_string(),
+            github_issue: None,
+            initial_prompt: None,
+            done_commits: vec![],
+        }];
+        let label = next_session_label(&sessions);
+        assert!(label.starts_with("session-3-"), "expected session-3-<id>, got {}", label);
+    }
+
+    #[test]
+    fn test_next_session_label_unique() {
+        let sessions: Vec<SessionConfig> = vec![];
+        let label1 = next_session_label(&sessions);
+        let label2 = next_session_label(&sessions);
+        assert_ne!(label1, label2, "labels should be unique across calls");
     }
 
     // --- render_agents_md tests ---


### PR DESCRIPTION
## Summary
- Session labels like `session-3` could collide with remote branches from previously deleted/merged sessions, causing PRs to inherit stale diverged history
- Labels now include a 6-char UUID suffix (e.g. `session-3-a1b2c3`) guaranteeing unique branch names
- Parser updated to handle both old (`session-3`) and new (`session-3-a1b2c3`) label formats

## Test plan
- [x] 6 `next_session_label` unit tests pass (empty, two existing, archived, gap, new format, uniqueness)
- [x] Labels from consecutive calls are always unique

🤖 Generated with [Claude Code](https://claude.com/claude-code)