### PR TITLE
feat: enforce squash-only merge for new projects

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -806,6 +806,24 @@ pub fn scaffold_project(state: State<AppState>, name: String) -> Result<Project,
         return Err(format!("Failed to create GitHub repo: {}", stderr.trim()));
     }
 
+    // Configure repo to only allow squash merges
+    let merge_cfg = std::process::Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/{{owner}}/{}", name),
+            "-X", "PATCH",
+            "-f", "allow_squash_merge=true",
+            "-f", "allow_merge_commit=false",
+            "-f", "allow_rebase_merge=false",
+        ])
+        .current_dir(&repo_path)
+        .output()
+        .map_err(|e| format!("Failed to configure merge settings: {}", e))?;
+    if !merge_cfg.status.success() {
+        let stderr = String::from_utf8_lossy(&merge_cfg.stderr);
+        return Err(format!("Failed to configure merge settings: {}", stderr.trim()));
+    }
+
     // Create project entry
     let project = Project {
         id: Uuid::new_v4(),

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -304,7 +304,7 @@
         return true;
       case "m":
         if (activeId) {
-          invoke("write_to_pty", { sessionId: activeId, data: "create pr, merge, sync local master\r" });
+          invoke("write_to_pty", { sessionId: activeId, data: "rebase onto master, create pr, squash merge, sync local master\r" });
         }
         return true;
       case "s":


### PR DESCRIPTION
## Summary
- Configure newly scaffolded repos to only allow squash merges (disable merge commits and rebase merges)
- Update the `m` hotkey prompt to explicitly mention the rebase+squash workflow

## Test plan
- [ ] Scaffold a new project and verify only squash merge is enabled on the GitHub repo
- [ ] Press `m` in a session and verify the prompt mentions rebase+squash

🤖 Generated with [Claude Code](https://claude.com/claude-code)