### PR TITLE
refactor: remove dead code and consolidate duplicate types

### DIFF
--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -61,7 +61,7 @@ impl PtyManager {
             // produce extra newlines).
             let _ = TmuxManager::resize_session(session_id, cols, rows);
             // Attach to the tmux session via a local PTY
-            self.attach_tmux_session(session_id, app_handle, rows, cols)
+            self.attach_tmux_session(session_id, app_handle)
         } else {
             // No tmux — spawn the command directly in a PTY
             self.spawn_direct_session(session_id, working_dir, command, app_handle, initial_prompt, rows, cols)
@@ -165,8 +165,6 @@ impl PtyManager {
         &mut self,
         session_id: Uuid,
         app_handle: AppHandle,
-        rows: u16,
-        cols: u16,
     ) -> Result<(), String> {
         let tmux_name = TmuxManager::session_name(session_id);
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,14 +12,7 @@
   import CreateIssueModal from "./lib/CreateIssueModal.svelte";
   import IssuePickerModal from "./lib/IssuePickerModal.svelte";
   import { showToast } from "./lib/toast";
-  import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, taskPanelVisible, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, type Config, type FocusTarget, type Project } from "./lib/stores";
-
-  interface GithubIssue {
-    number: number;
-    title: string;
-    url: string;
-    labels: { name: string }[];
-  }
+  import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, taskPanelVisible, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, type Config, type FocusTarget, type GithubIssue, type Project } from "./lib/stores";
 
   let ready = $state(false);
   let needsOnboarding = $state(true);
@@ -81,14 +74,7 @@
     }
   }
 
-  interface GithubIssueForSession {
-    number: number;
-    title: string;
-    url: string;
-    labels: { name: string }[];
-  }
-
-  function handleIssuePicked(issue: GithubIssueForSession) {
+  function handleIssuePicked(issue: GithubIssue) {
     const target = issuePickerTarget!;
     issuePickerTarget = null;
     createSessionWithIssue(target.projectId, target.repoPath, issue, target.kind, target.background);
@@ -101,7 +87,7 @@
     setTimeout(() => hotkeyAction.set(null), 0);
   }
 
-  async function createSessionWithIssue(projectId: string, repoPath: string, issue: GithubIssueForSession, kind?: string, background?: boolean) {
+  async function createSessionWithIssue(projectId: string, repoPath: string, issue: GithubIssue, kind?: string, background?: boolean) {
     try {
       const sessionId: string = await invoke("create_session", {
         projectId,

--- a/src/lib/FuzzyFinder.svelte
+++ b/src/lib/FuzzyFinder.svelte
@@ -2,18 +2,14 @@
   import { invoke } from "@tauri-apps/api/core";
   import { onMount } from "svelte";
   import { showToast } from "./toast";
+  import type { DirEntry } from "./stores";
 
   interface Props {
-    onSelect: (entry: { name: string; path: string }) => void;
+    onSelect: (entry: DirEntry) => void;
     onClose: () => void;
   }
 
   let { onSelect, onClose }: Props = $props();
-
-  interface DirEntry {
-    name: string;
-    path: string;
-  }
 
   let query = $state("");
   let entries = $state<DirEntry[]>([]);

--- a/src/lib/IssuePickerModal.svelte
+++ b/src/lib/IssuePickerModal.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
-
-  interface GithubIssue {
-    number: number;
-    title: string;
-    url: string;
-    labels: { name: string }[];
-  }
+  import type { GithubIssue } from "./stores";
 
   interface Props {
     repoPath: string;

--- a/src/lib/Onboarding.svelte
+++ b/src/lib/Onboarding.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { onMount, onDestroy } from "svelte";
-  import { appConfig, onboardingComplete } from "./stores";
+  import { appConfig, onboardingComplete, type DirEntry } from "./stores";
   import { showToast } from "./toast";
   import Terminal from "./Terminal.svelte";
-
-  interface DirEntry {
-    name: string;
-    path: string;
-  }
 
   let step = $state<"pick-dir" | "cli-check">("pick-dir");
   let projectsRoot = $state("");

--- a/src/lib/TaskPanel.svelte
+++ b/src/lib/TaskPanel.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { focusTarget, projects, type Project, type FocusTarget } from "./stores";
+  import { focusTarget, projects, type GithubIssue, type Project, type FocusTarget } from "./stores";
 
   interface Props {
     visible: boolean;
   }
 
   let { visible }: Props = $props();
-
-  interface GithubIssue {
-    number: number;
-    title: string;
-    url: string;
-    labels: { name: string }[];
-  }
 
   let issues: GithubIssue[] = $state([]);
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -7,6 +7,11 @@ export interface GithubIssue {
   labels: { name: string }[];
 }
 
+export interface DirEntry {
+  name: string;
+  path: string;
+}
+
 export interface SessionConfig {
   id: string;
   label: string;


### PR DESCRIPTION
## Summary
- Remove unused `rows`/`cols` parameters from `attach_tmux_session()` in Rust backend (were always shadowed by `TmuxManager::session_size()`)
- Consolidate 4 duplicate `GithubIssue` interface definitions into a single export from `stores.ts`
- Consolidate 2 duplicate `DirEntry` interface definitions into a single export from `stores.ts`
- Remove redundant `GithubIssueForSession` type alias (structurally identical to `GithubIssue`)

Net: -33 lines, 0 behavior changes.

## Test plan
- [x] `cargo check` passes with 0 warnings (previously had 2 unused variable warnings)
- [x] Frontend tests pass (111/112, 1 pre-existing failure unrelated to changes)
- [x] All type imports resolve correctly across components

🤖 Generated with [Claude Code](https://claude.com/claude-code)