### PR TITLE
fix: add opener scope for screenshot temp path

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,7 +7,10 @@
     "core:default",
     "core:window:allow-set-title",
     "opener:default",
-    "opener:allow-open-path",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [{ "path": "$TEMP/the-controller-screenshot.png" }]
+    },
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-read-image",
     "clipboard-manager:allow-write-image"


### PR DESCRIPTION
## Summary
- Fix "Not allowed to open path" error when pressing `shift+s` to capture a screenshot
- Add `$TEMP/the-controller-screenshot.png` to the `opener:allow-open-path` permission scope in Tauri capabilities

## Test plan
- [ ] Press `shift+s` — screenshot should capture and open in Preview without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)