### PR TITLE
fix: make finishing-a-development-branch skill worktree-compatible

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -11,11 +11,24 @@ Run the project's test suite. If tests fail, fix them before proceeding.
 
 ## Step 2: Execute Merge Workflow
 
-1. Rebase onto `master`
-2. Create a PR to `master`
-3. Squash merge the PR (include commit messages inline in the squash message)
-4. Delete the remote branch
-5. Sync local master: `git checkout master && git pull`
+1. Ensure all changes are committed before proceeding
+2. Rebase onto `master`
+3. Create a PR to `master`
+4. Squash merge the PR and delete the remote branch:
+   ```bash
+   # Use --squash and --delete-branch, but do NOT let gh try to checkout master locally
+   gh pr merge --squash --delete-branch
+   ```
+   **Worktree note:** If this errors with "'master' is already used by worktree", the merge still succeeded on GitHub. The error is just the local checkout step — ignore it and proceed to step 5.
+5. Sync local master:
+   ```bash
+   git fetch origin master:master
+   # If master is checked out in another worktree, update that working tree too
+   master_worktree=$(git worktree list | grep '\[master\]' | awk '{print $1}')
+   if [ -n "$master_worktree" ]; then
+     git -C "$master_worktree" reset --hard master
+   fi
+   ```
 6. Close the associated issue with a summary of what was done
 
 ## Integration

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -140,7 +140,7 @@ describe('HotkeyManager', () => {
       pressKey('m');
       expect(invoke).toHaveBeenCalledWith('write_to_pty', {
         sessionId: 'sess-1',
-        data: 'create pr, merge, sync local master\r',
+        data: '/finishing-a-development-branch\r',
       });
     });
 


### PR DESCRIPTION
## Summary
- Fix `finishing-a-development-branch` skill failing in git worktrees due to `git checkout master` errors
- Replace checkout-based master sync with `git fetch origin master:master` + worktree-aware working tree update
- Add explicit step to commit before rebasing, and document that `gh pr merge` worktree errors are safe to ignore
- Fix pre-existing test expecting old `m` shortcut text

## Test plan
- [x] All 112 tests passing
- [x] Verified skill instructions handle worktree scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)