### PR TITLE
refactor: simplify frontend architecture and remove obsolete UI glue

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import Sidebar from "./lib/Sidebar.svelte";
@@ -12,31 +13,19 @@
   import CreateIssueModal from "./lib/CreateIssueModal.svelte";
   import IssuePickerModal from "./lib/IssuePickerModal.svelte";
   import { showToast } from "./lib/toast";
-  import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, taskPanelVisible, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, type Config, type FocusTarget, type GithubIssue, type Project } from "./lib/stores";
+  import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, taskPanelVisible, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, dispatchHotkeyAction, focusTerminalSoon, type Config, type GithubIssue, type Project, type SessionStatus } from "./lib/stores";
 
   let ready = $state(false);
-  let needsOnboarding = $state(true);
-  let sidebarIsVisible = $state(true);
-  let hintsVisible = $state(false);
-  let taskPanelIsVisible = $state(false);
   let createIssueTarget: { projectId: string; repoPath: string } | null = $state(null);
   let issuePickerTarget: { projectId: string; repoPath: string; kind?: string; background?: boolean } | null = $state(null);
 
-
-  $effect(() => {
-    const unsub = sidebarVisible.subscribe((v) => { sidebarIsVisible = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = showKeyHints.subscribe((v) => { hintsVisible = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = taskPanelVisible.subscribe((v) => { taskPanelIsVisible = v; });
-    return unsub;
-  });
+  const sidebarVisibleState = fromStore(sidebarVisible);
+  const showKeyHintsState = fromStore(showKeyHints);
+  const taskPanelVisibleState = fromStore(taskPanelVisible);
+  const onboardingCompleteState = fromStore(onboardingComplete);
+  const projectsState = fromStore(projects);
+  const activeSessionIdState = fromStore(activeSessionId);
+  const focusTargetState = fromStore(focusTarget);
 
   $effect(() => {
     const unsub = hotkeyAction.subscribe((action) => {
@@ -83,8 +72,22 @@
   function handleIssuePickerSkip() {
     const target = issuePickerTarget!;
     issuePickerTarget = null;
-    hotkeyAction.set({ type: "create-session", projectId: target.projectId, kind: target.kind });
-    setTimeout(() => hotkeyAction.set(null), 0);
+    dispatchHotkeyAction({ type: "create-session", projectId: target.projectId, kind: target.kind });
+  }
+
+  async function activateNewSession(sessionId: string, projectId: string) {
+    sessionStatuses.update((m: Map<string, SessionStatus>) => {
+      const next = new Map(m);
+      next.set(sessionId, "working");
+      return next;
+    });
+    activeSessionId.set(sessionId);
+    projects.set(await invoke<Project[]>("list_projects"));
+    expandedProjects.update((s: Set<string>) => {
+      const next = new Set(s);
+      next.add(projectId);
+      return next;
+    });
   }
 
   async function createSessionWithIssue(projectId: string, repoPath: string, issue: GithubIssue, kind?: string, background?: boolean) {
@@ -108,19 +111,8 @@
         label: "in-progress",
       }).catch((e: unknown) => showToast(`Failed to add label: ${e}`, "error"));
 
-      sessionStatuses.update((m: Map<string, string>) => {
-        const next = new Map(m);
-        next.set(sessionId, "working");
-        return next;
-      });
-      activeSessionId.set(sessionId);
-      const result = await invoke<Project[]>("list_projects");
-      projects.set(result);
-      expandedProjects.update((s: Set<string>) => { const next = new Set(s); next.add(projectId); return next; });
-      setTimeout(() => {
-        hotkeyAction.set({ type: "focus-terminal" });
-        setTimeout(() => hotkeyAction.set(null), 0);
-      }, 50);
+      await activateNewSession(sessionId, projectId);
+      focusTerminalSoon();
     } catch (e) {
       showToast(String(e), "error");
     }
@@ -128,16 +120,9 @@
 
   async function screenshotToNewSession() {
     // Determine project from current focus or active session
-    let projectList: Project[] = [];
-    projects.subscribe((v) => { projectList = v; })();
-    let active: string | null = null;
-    activeSessionId.subscribe((v) => { active = v; })();
-    let focus: FocusTarget = null;
-    focusTarget.subscribe((v) => { focus = v; })();
-
-    const projectId = focus?.projectId
-      ?? projectList.find((p) => p.sessions.some((s) => s.id === active))?.id
-      ?? projectList[0]?.id;
+    const projectId = focusTargetState.current?.projectId
+      ?? projectsState.current.find((p) => p.sessions.some((s) => s.id === activeSessionIdState.current))?.id
+      ?? projectsState.current[0]?.id;
 
     if (!projectId) {
       showToast("No project to create session in", "error");
@@ -159,25 +144,10 @@
         kind: "claude",
       });
 
-      sessionStatuses.update((m: Map<string, string>) => {
-        const next = new Map(m);
-        next.set(sessionId, "working");
-        return next;
-      });
-      activeSessionId.set(sessionId);
-      const result = await invoke<Project[]>("list_projects");
-      projects.set(result);
-      expandedProjects.update((s: Set<string>) => {
-        const next = new Set(s);
-        next.add(projectId);
-        return next;
-      });
+      await activateNewSession(sessionId, projectId);
 
       // 3. Focus the terminal
-      setTimeout(() => {
-        hotkeyAction.set({ type: "focus-terminal" });
-        setTimeout(() => hotkeyAction.set(null), 0);
-      }, 50);
+      focusTerminalSoon();
 
       // 4. When session becomes idle (Claude Code ready), auto-paste the screenshot
       const unsubStatus = sessionStatuses.subscribe((statuses) => {
@@ -210,40 +180,31 @@
       if (config) {
         appConfig.set(config);
         onboardingComplete.set(true);
-        needsOnboarding = false;
       }
     } catch (e) {
       // Config check failed, show onboarding
     }
     ready = true;
   });
-
-  // Listen for onboarding completion
-  $effect(() => {
-    const unsub = onboardingComplete.subscribe((complete) => {
-      if (complete) needsOnboarding = false;
-    });
-    return unsub;
-  });
 </script>
 
 {#if ready}
-  {#if needsOnboarding}
+  {#if !onboardingCompleteState.current}
     <Onboarding />
   {:else}
     <div class="app-layout">
-      {#if sidebarIsVisible}
+      {#if sidebarVisibleState.current}
         <Sidebar />
       {/if}
       <main class="terminal-area">
         <TerminalManager />
       </main>
-      {#if taskPanelIsVisible}
-        <TaskPanel visible={taskPanelIsVisible} />
+      {#if taskPanelVisibleState.current}
+        <TaskPanel />
       {/if}
     </div>
     <HotkeyManager />
-    {#if hintsVisible}
+    {#if showKeyHintsState.current}
       <HotkeyHelp onClose={() => showKeyHints.set(false)} />
     {/if}
     {#if createIssueTarget}

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import {
     projects,
     activeSessionId,
-    hotkeyAction,
     jumpMode,
     generateJumpLabels,
     JUMP_KEYS,
@@ -14,6 +14,7 @@
     archivedProjects,
     focusTarget,
     expandedProjects,
+    dispatchHotkeyAction,
     type Project,
     type HotkeyAction,
     type FocusTarget,
@@ -28,44 +29,18 @@
   let jumpBuffer = $state("");
   let jumpLabels: string[] = $state([]);
 
-  // Reactive store subscriptions
-  let projectList: Project[] = $state([]);
-  let activeId: string | null = $state(null);
-  let currentFocus: FocusTarget = $state(null);
-
-  $effect(() => {
-    const unsub = projects.subscribe((value) => { projectList = value; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = activeSessionId.subscribe((value) => { activeId = value; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = focusTarget.subscribe((v) => { currentFocus = v; });
-    return unsub;
-  });
-
-  let isArchiveView = $state(false);
-  let archivedProjectList: Project[] = $state([]);
-  let expandedSet: Set<string> = $state(new Set());
-
-  $effect(() => {
-    const unsub = archiveView.subscribe((v) => { isArchiveView = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = archivedProjects.subscribe((v) => { archivedProjectList = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = expandedProjects.subscribe((v) => { expandedSet = v; });
-    return unsub;
-  });
+  const projectsState = fromStore(projects);
+  let projectList: Project[] = $derived(projectsState.current);
+  const activeSessionIdState = fromStore(activeSessionId);
+  let activeId: string | null = $derived(activeSessionIdState.current);
+  const focusTargetState = fromStore(focusTarget);
+  let currentFocus: FocusTarget = $derived(focusTargetState.current);
+  const archiveViewState = fromStore(archiveView);
+  let isArchiveView = $derived(archiveViewState.current);
+  const archivedProjectsState = fromStore(archivedProjects);
+  let archivedProjectList: Project[] = $derived(archivedProjectsState.current);
+  const expandedProjectsState = fromStore(expandedProjects);
+  let expandedSet: Set<string> = $derived(expandedProjectsState.current);
 
   // Detect if a terminal (xterm) has focus
   function isTerminalFocused(): boolean {
@@ -106,8 +81,7 @@
   }
 
   function dispatchAction(action: NonNullable<HotkeyAction>) {
-    hotkeyAction.set(action);
-    setTimeout(() => hotkeyAction.set(null), 0);
+    dispatchHotkeyAction(action);
   }
 
   function getJumpProjects(): Project[] {
@@ -206,19 +180,71 @@
   function navigateProject(direction: 1 | -1) {
     const list = isArchiveView ? archivedProjectList : projectList;
     if (list.length === 0) return;
+    const focusedProjectId = currentFocus?.type === "project" || currentFocus?.type === "session"
+      ? currentFocus.projectId
+      : null;
     let idx = -1;
-    if (currentFocus?.type === "project") {
-      idx = list.findIndex(p => p.id === currentFocus.projectId);
-    } else if (currentFocus?.type === "session") {
-      idx = list.findIndex(p => p.id === currentFocus.projectId);
-    }
+    if (focusedProjectId) idx = list.findIndex(p => p.id === focusedProjectId);
     const len = list.length;
     const next = list[((idx + direction) % len + len) % len];
     focusTarget.set({ type: "project", projectId: next.id });
   }
 
-  function handleHotkey(e: KeyboardEvent): boolean {
-    const key = e.key;
+  function getFocusedProject(): Project | null {
+    if (currentFocus?.type !== "project" && currentFocus?.type !== "session") return null;
+    return projectList.find((p) => p.id === currentFocus.projectId) ?? null;
+  }
+
+  function dispatchDeleteAction() {
+    if (currentFocus?.type === "session") {
+      dispatchAction({ type: "delete-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
+      return;
+    }
+    if (currentFocus?.type === "project") {
+      dispatchAction({ type: "delete-project", projectId: currentFocus.projectId });
+      return;
+    }
+    dispatchAction({ type: "delete-project" });
+  }
+
+  function dispatchArchiveAction() {
+    if (isArchiveView) {
+      if (currentFocus?.type === "session") {
+        dispatchAction({ type: "unarchive-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
+      } else if (currentFocus?.type === "project") {
+        dispatchAction({ type: "unarchive-project", projectId: currentFocus.projectId });
+      }
+      return;
+    }
+
+    if (currentFocus?.type === "session") {
+      dispatchAction({ type: "archive-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
+    } else if (currentFocus?.type === "project") {
+      dispatchAction({ type: "archive-project", projectId: currentFocus.projectId });
+    } else {
+      dispatchAction({ type: "archive-project" });
+    }
+  }
+
+  function dispatchIssuePicker(opts?: { kind?: string; background?: boolean }) {
+    const project = getFocusedProject();
+    if (!project) return;
+    dispatchAction({
+      type: "pick-issue-for-session",
+      projectId: project.id,
+      repoPath: project.repo_path,
+      kind: opts?.kind,
+      background: opts?.background,
+    });
+  }
+
+  function dispatchCreateIssue() {
+    const project = getFocusedProject();
+    if (!project) return;
+    dispatchAction({ type: "create-issue", projectId: project.id, repoPath: project.repo_path });
+  }
+
+  function handleHotkey(key: string): boolean {
 
     switch (key) {
       case "g":
@@ -243,64 +269,25 @@
         dispatchAction({ type: "open-new-project" });
         return true;
       case "d":
-        if (currentFocus?.type === "session") {
-          dispatchAction({ type: "delete-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
-        } else if (currentFocus?.type === "project") {
-          dispatchAction({ type: "delete-project", projectId: currentFocus.projectId });
-        } else {
-          dispatchAction({ type: "delete-project" });
-        }
+        dispatchDeleteAction();
         return true;
       case "a":
-        if (isArchiveView) {
-          // In archive view, a unarchives the focused item
-          if (currentFocus?.type === "session") {
-            dispatchAction({ type: "unarchive-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
-          } else if (currentFocus?.type === "project") {
-            dispatchAction({ type: "unarchive-project", projectId: currentFocus.projectId });
-          }
-        } else if (currentFocus?.type === "session") {
-          dispatchAction({ type: "archive-session", sessionId: currentFocus.sessionId, projectId: currentFocus.projectId });
-        } else if (currentFocus?.type === "project") {
-          dispatchAction({ type: "archive-project", projectId: currentFocus.projectId });
-        } else {
-          dispatchAction({ type: "archive-project" });
-        }
+        dispatchArchiveAction();
         return true;
       case "A":
         dispatchAction({ type: "toggle-archive-view" });
         return true;
       case "c":
-        if (currentFocus?.type === "project" || currentFocus?.type === "session") {
-          const project = projectList.find(p => p.id === currentFocus.projectId);
-          if (project) {
-            dispatchAction({ type: "pick-issue-for-session", projectId: project.id, repoPath: project.repo_path });
-          }
-        }
+        dispatchIssuePicker();
         return true;
       case "x":
-        if (currentFocus?.type === "project" || currentFocus?.type === "session") {
-          const project = projectList.find(p => p.id === currentFocus.projectId);
-          if (project) {
-            dispatchAction({ type: "pick-issue-for-session", projectId: project.id, repoPath: project.repo_path, kind: "codex" });
-          }
-        }
+        dispatchIssuePicker({ kind: "codex" });
         return true;
       case "C":
-        if (currentFocus?.type === "project" || currentFocus?.type === "session") {
-          const project = projectList.find(p => p.id === currentFocus.projectId);
-          if (project) {
-            dispatchAction({ type: "pick-issue-for-session", projectId: project.id, repoPath: project.repo_path, background: true });
-          }
-        }
+        dispatchIssuePicker({ background: true });
         return true;
       case "X":
-        if (currentFocus?.type === "project" || currentFocus?.type === "session") {
-          const project = projectList.find(p => p.id === currentFocus.projectId);
-          if (project) {
-            dispatchAction({ type: "pick-issue-for-session", projectId: project.id, repoPath: project.repo_path, kind: "codex", background: true });
-          }
-        }
+        dispatchIssuePicker({ kind: "codex", background: true });
         return true;
       case "m":
         if (activeId) {
@@ -317,12 +304,7 @@
         sidebarVisible.update(v => !v);
         return true;
       case "i":
-        if (currentFocus?.type === "project" || currentFocus?.type === "session") {
-          const project = projectList.find(p => p.id === currentFocus.projectId);
-          if (project) {
-            dispatchAction({ type: "create-issue", projectId: project.id, repoPath: project.repo_path });
-          }
-        }
+        dispatchCreateIssue();
         return true;
       case "t":
         taskPanelVisible.update(v => !v);
@@ -415,7 +397,7 @@
     }
 
     // Try to handle as hotkey
-    if (handleHotkey(e)) {
+    if (handleHotkey(e.key)) {
       e.stopPropagation();
       e.preventDefault();
     }

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
-  import { projects, activeSessionId, sessionStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, type Project, type JumpPhase, type FocusTarget, type SessionStatus } from "./stores";
+  import { projects, activeSessionId, sessionStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, type Project, type JumpPhase, type FocusTarget, type SessionStatus } from "./stores";
   import { showToast } from "./toast";
   import { focusAfterSessionDelete, focusAfterProjectDelete } from "./focus-helpers";
   import FuzzyFinder from "./FuzzyFinder.svelte";
@@ -9,38 +10,24 @@
   import DeleteProjectModal from "./DeleteProjectModal.svelte";
   import ConfirmModal from "./ConfirmModal.svelte";
   import DeleteSessionModal from "./DeleteSessionModal.svelte";
+  import ProjectTree from "./sidebar/ProjectTree.svelte";
 
   let sidebarEl: HTMLElement | undefined = $state();
-  let hintsVisible = $state(false);
-  $effect(() => {
-    const unsub = showKeyHints.subscribe((v) => { hintsVisible = v; });
-    return unsub;
-  });
+  const showKeyHintsState = fromStore(showKeyHints);
   let showFuzzyFinder = $state(false);
   let showNewProjectModal = $state(false);
-  let expandedProjectSet: Set<string> = $state(new Set());
-  $effect(() => {
-    const unsub = expandedProjects.subscribe((v) => { expandedProjectSet = v; });
-    return unsub;
-  });
+  const expandedProjectsState = fromStore(expandedProjects);
+  let expandedProjectSet: Set<string> = $derived(expandedProjectsState.current);
   let deleteTarget: Project | null = $state(null);
   let deleteSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let archiveSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let archiveProjectTarget: Project | null = $state(null);
   let mergeSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let mergeInProgress = $state(false);
-  let isArchiveView = $state(false);
-  let archivedProjectList: Project[] = $state([]);
-
-  $effect(() => {
-    const unsub = archiveView.subscribe((v) => { isArchiveView = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = archivedProjects.subscribe((v) => { archivedProjectList = v; });
-    return unsub;
-  });
+  const archiveViewState = fromStore(archiveView);
+  let isArchiveView = $derived(archiveViewState.current);
+  const archivedProjectsState = fromStore(archivedProjects);
+  let archivedProjectList: Project[] = $derived(archivedProjectsState.current);
 
   // Load archived projects when entering archive view
   $effect(() => {
@@ -48,38 +35,20 @@
       loadArchivedProjects();
     }
   });
-  let projectList: Project[] = $state([]);
-  let activeSession: string | null = $state(null);
-  let statuses: Map<string, SessionStatus> = $state(new Map());
+  const projectsState = fromStore(projects);
+  let projectList: Project[] = $derived(projectsState.current);
+  const activeSessionIdState = fromStore(activeSessionId);
+  let activeSession: string | null = $derived(activeSessionIdState.current);
+  const sessionStatusesState = fromStore(sessionStatuses);
+  let statuses: Map<string, SessionStatus> = $derived(sessionStatusesState.current);
   const idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const IDLE_DEBOUNCE_MS = 1500;
 
-  $effect(() => {
-    const unsub = projects.subscribe((value) => { projectList = value; });
-    return unsub;
-  });
+  const jumpModeState = fromStore(jumpMode);
+  let jumpState: JumpPhase = $derived(jumpModeState.current);
 
-  $effect(() => {
-    const unsub = activeSessionId.subscribe((value) => { activeSession = value; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = sessionStatuses.subscribe((value) => { statuses = value; });
-    return unsub;
-  });
-
-  let jumpState: JumpPhase = $state(null);
-  $effect(() => {
-    const unsub = jumpMode.subscribe((v) => { jumpState = v; });
-    return unsub;
-  });
-
-  let currentFocus: FocusTarget = $state(null);
-  $effect(() => {
-    const unsub = focusTarget.subscribe((v) => { currentFocus = v; });
-    return unsub;
-  });
+  const focusTargetState = fromStore(focusTarget);
+  let currentFocus: FocusTarget = $derived(focusTargetState.current);
 
   // When focusTarget changes, expand and focus the relevant DOM element
   $effect(() => {
@@ -314,10 +283,7 @@
       next.add(projectId);
       expandedProjects.set(next);
       // Auto-focus the terminal (slight delay for component mount)
-      setTimeout(() => {
-        hotkeyAction.set({ type: "focus-terminal" });
-        setTimeout(() => hotkeyAction.set(null), 0);
-      }, 50);
+      focusTerminalSoon();
     } catch (err) {
       showToast(String(err), "error");
     }
@@ -327,38 +293,53 @@
     activeSessionId.set(sessionId);
   }
 
+  async function maybeRemoveInProgressLabel(projectId: string, sessionId: string, fromArchivedList = false) {
+    const list = fromArchivedList ? archivedProjectList : projectList;
+    const project = list.find((p) => p.id === projectId);
+    const session = project?.sessions.find((s) => s.id === sessionId);
+    if (session?.github_issue && project) {
+      invoke("remove_github_label", {
+        repoPath: project.repo_path,
+        issueNumber: session.github_issue.number,
+        label: "in-progress",
+      }).catch(() => {});
+    }
+  }
+
+  function clearSessionTracking(sessionId: string) {
+    const timer = idleTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      idleTimers.delete(sessionId);
+    }
+    sessionStatuses.update((m) => {
+      const next = new Map(m);
+      next.delete(sessionId);
+      return next;
+    });
+  }
+
+  async function refreshProjectLists() {
+    await loadProjects();
+    if (isArchiveView) await loadArchivedProjects();
+  }
+
   async function closeSession(projectId: string, sessionId: string, deleteWorktree: boolean) {
     try {
       const list = isArchiveView ? archivedProjectList : projectList;
       const nextFocus = focusAfterSessionDelete(list, projectId, sessionId, isArchiveView);
 
-      // Remove in-progress label if session has a linked issue
-      const project = list.find(p => p.id === projectId);
-      const session = project?.sessions.find(s => s.id === sessionId);
-      if (session?.github_issue && project) {
-        invoke("remove_github_label", {
-          repoPath: project.repo_path,
-          issueNumber: session.github_issue.number,
-          label: "in-progress",
-        }).catch(() => {});
-      }
+      await maybeRemoveInProgressLabel(projectId, sessionId, isArchiveView);
 
       await invoke("close_session", { projectId, sessionId, deleteWorktree });
-      const closeTimer = idleTimers.get(sessionId);
-      if (closeTimer) { clearTimeout(closeTimer); idleTimers.delete(sessionId); }
-      sessionStatuses.update(m => {
-        const next = new Map(m);
-        next.delete(sessionId);
-        return next;
-      });
+      clearSessionTracking(sessionId);
       activeSessionId.update(current => {
         if (current !== sessionId) return current;
         if (nextFocus?.type === "session") return nextFocus.sessionId;
         return null;
       });
       focusTarget.set(nextFocus);
-      await loadProjects();
-      if (isArchiveView) await loadArchivedProjects();
+      await refreshProjectLists();
     } catch (e) {
       showToast(String(e), "error");
     }
@@ -372,32 +353,17 @@
       const idx = activeSessions.findIndex(s => s.id === sessionId);
       const prevSession = idx > 0 ? activeSessions[idx - 1] : null;
 
-      // Remove in-progress label if session has a linked issue
-      const session = activeSessions.find(s => s.id === sessionId);
-      if (session?.github_issue && project) {
-        invoke("remove_github_label", {
-          repoPath: project.repo_path,
-          issueNumber: session.github_issue.number,
-          label: "in-progress",
-        }).catch(() => {});
-      }
+      await maybeRemoveInProgressLabel(projectId, sessionId);
 
       await invoke("archive_session", { projectId, sessionId });
-      const archiveTimer = idleTimers.get(sessionId);
-      if (archiveTimer) { clearTimeout(archiveTimer); idleTimers.delete(sessionId); }
-      sessionStatuses.update(m => {
-        const next = new Map(m);
-        next.delete(sessionId);
-        return next;
-      });
+      clearSessionTracking(sessionId);
       activeSessionId.update(current => current === sessionId ? (prevSession?.id ?? null) : current);
       if (prevSession) {
         focusTarget.set({ type: "session", sessionId: prevSession.id, projectId });
       } else {
         focusTarget.set({ type: "project", projectId });
       }
-      await loadProjects();
-      if (isArchiveView) await loadArchivedProjects();
+      await refreshProjectLists();
     } catch (e) {
       showToast(String(e), "error");
     }
@@ -408,8 +374,7 @@
       await invoke("unarchive_session", { projectId, sessionId });
       markSession(sessionId, "working");
       activeSessionId.set(sessionId);
-      await loadProjects();
-      if (isArchiveView) await loadArchivedProjects();
+      await refreshProjectLists();
     } catch (e) {
       showToast(String(e), "error");
     }
@@ -434,10 +399,7 @@
 
     // Focus the terminal so user can watch Claude resolve conflicts if any
     activeSessionId.set(sessionId);
-    setTimeout(() => {
-      hotkeyAction.set({ type: "focus-terminal" });
-      setTimeout(() => hotkeyAction.set(null), 0);
-    }, 50);
+    focusTerminalSoon();
 
     // Listen for intermediate merge status events
     let unlistenStatus: (() => void) | null = null;
@@ -470,102 +432,27 @@
   </div>
 
   <div class="project-list">
-    {#if isArchiveView}
-      {#each archivedProjectList as project, i (project.id)}
-        {@const archivedSessions = project.sessions.filter(s => s.archived)}
-        <div class="project-item">
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div
-            class="project-header"
-            class:focus-target={currentFocus?.type === 'project' && currentFocus.projectId === project.id}
-            tabindex="0"
-            data-project-id={project.id}
-            onfocusin={(e: FocusEvent) => { if (e.target === e.currentTarget) focusTarget.set({ type: 'project', projectId: project.id }); }}
-          >
-            <button class="btn-expand" onclick={() => toggleProject(project.id)}>
-              {expandedProjectSet.has(project.id) ? "\u25BC" : "\u25B6"}
-            </button>
-            <span class="project-name">{project.name}</span>
-            {#if jumpState?.phase === 'project' && projectJumpLabels[i]}
-              <kbd class="jump-label">{projectJumpLabels[i]}</kbd>
-            {/if}
-            <span class="session-count">{archivedSessions.length}</span>
-          </div>
-
-          {#if expandedProjectSet.has(project.id)}
-            <div class="session-list">
-              {#each archivedSessions as session, sessionIdx (session.id)}
-                <div
-                  class="session-item archived"
-                  class:focus-target={currentFocus?.type === 'session' && currentFocus.sessionId === session.id}
-                  data-session-id={session.id}
-                  tabindex="0"
-                  onfocusin={() => { focusTarget.set({ type: 'session', sessionId: session.id, projectId: project.id }); }}
-                >
-                  <span class="status-dot archived-dot">&cir;</span>
-                  <span class="session-label">{session.label}</span>
-                </div>
-              {/each}
-            </div>
-          {/if}
-        </div>
-      {:else}
-        <div class="empty-state">No archived sessions</div>
-      {/each}
-    {:else}
-      {#each projectList as project, i (project.id)}
-        <div class="project-item">
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <div
-            class="project-header"
-            class:focus-target={currentFocus?.type === 'project' && currentFocus.projectId === project.id}
-            tabindex="0"
-            data-project-id={project.id}
-            onfocusin={(e: FocusEvent) => { if (e.target === e.currentTarget) focusTarget.set({ type: 'project', projectId: project.id }); }}
-          >
-            <button class="btn-expand" onclick={() => toggleProject(project.id)}>
-              {expandedProjectSet.has(project.id) ? "\u25BC" : "\u25B6"}
-            </button>
-            <span class="project-name">{project.name}</span>
-            {#if jumpState?.phase === 'project' && projectJumpLabels[i]}
-              <kbd class="jump-label">{projectJumpLabels[i]}</kbd>
-            {/if}
-            <span class="session-count">{project.sessions.filter(s => !s.archived).length}</span>
-          </div>
-
-          {#if expandedProjectSet.has(project.id)}
-            {@const activeSessions = project.sessions.filter(s => !s.archived)}
-            <div class="session-list">
-              {#each activeSessions as session, sessionIdx (session.id)}
-                <div
-                  class="session-item"
-                  class:active={activeSession === session.id}
-                  class:focus-target={currentFocus?.type === 'session' && currentFocus.sessionId === session.id}
-                  data-session-id={session.id}
-                  role="button"
-                  tabindex="0"
-                  onclick={() => { selectSession(session.id); focusTarget.set({ type: 'session', sessionId: session.id, projectId: project.id }); }}
-                  onfocusin={() => { focusTarget.set({ type: 'session', sessionId: session.id, projectId: project.id }); }}
-                  onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') selectSession(session.id); }}
-                >
-                  <span
-                    class="status-dot"
-                    class:idle={getSessionStatus(session.id) === "idle"}
-                    class:working={getSessionStatus(session.id) === "working"}
-                  >
-                    {getSessionStatus(session.id) === "exited" ? "\u25CB" : "\u25CF"}
-                  </span>
-                  <span class="session-label">{session.label}</span>
-                  {#if session.github_issue}
-                    <span class="issue-badge">#{session.github_issue.number}</span>
-                  {/if}
-                </div>
-              {/each}
-            </div>
-          {/if}
-        </div>
-      {/each}
-    {/if}
+    <ProjectTree
+      projects={isArchiveView ? archivedProjectList : projectList}
+      mode={isArchiveView ? "archived" : "active"}
+      {expandedProjectSet}
+      {activeSession}
+      {currentFocus}
+      jumpState={jumpState}
+      {projectJumpLabels}
+      {getSessionStatus}
+      onToggleProject={toggleProject}
+      onProjectFocus={(projectId) => {
+        focusTarget.set({ type: "project", projectId });
+      }}
+      onSessionFocus={(sessionId, projectId) => {
+        focusTarget.set({ type: "session", sessionId, projectId });
+      }}
+      onSessionSelect={(sessionId, projectId) => {
+        selectSession(sessionId);
+        focusTarget.set({ type: "session", sessionId, projectId });
+      }}
+    />
   </div>
 
   <div class="sidebar-footer">
@@ -581,7 +468,7 @@
     >Archives</button>
     <button
       class="btn-help"
-      class:active={hintsVisible}
+      class:active={showKeyHintsState.current}
       onclick={() => showKeyHints.update(v => !v)}
       title="Keyboard shortcuts (?)"
     >?</button>
@@ -735,164 +622,6 @@
     overflow-y: auto;
   }
 
-  .project-item {
-    border-bottom: 1px solid #313244;
-  }
-
-  .project-header {
-    display: flex;
-    align-items: center;
-    padding: 8px 16px;
-    gap: 8px;
-  }
-
-  .project-header:hover {
-    background: #313244;
-  }
-
-  .project-header.focus-target {
-    outline: 2px solid #89b4fa;
-    outline-offset: -2px;
-    border-radius: 4px;
-  }
-
-  .btn-expand {
-    background: none;
-    border: none;
-    color: #6c7086;
-    cursor: pointer;
-    padding: 0;
-    font-size: 10px;
-    width: 16px;
-    text-align: center;
-    box-shadow: none;
-  }
-
-  .project-name {
-    flex: 1;
-    font-size: 13px;
-    font-weight: 500;
-    word-break: break-word;
-  }
-
-  .session-count {
-    font-size: 11px;
-    color: #6c7086;
-    background: #313244;
-    padding: 1px 6px;
-    border-radius: 8px;
-  }
-
-  .session-list {
-    padding: 0;
-  }
-
-  .session-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 16px 6px 40px;
-    cursor: pointer;
-    font-size: 12px;
-    width: 100%;
-    background: none;
-    border: none;
-    color: #cdd6f4;
-    text-align: left;
-    box-shadow: none;
-  }
-
-  .session-item:hover {
-    background: #313244;
-  }
-
-  .session-item.active {
-    background: #45475a;
-  }
-
-  .session-item.focus-target {
-    outline: 2px solid #89b4fa;
-    outline-offset: -2px;
-    border-radius: 4px;
-  }
-
-  .session-item.create-option {
-    color: #a6e3a1;
-    font-style: italic;
-  }
-
-  .session-item.archived {
-    opacity: 0.6;
-  }
-
-  .archived-dot {
-    color: #6c7086;
-  }
-
-  .status-dot {
-    font-size: 10px;
-    color: #6c7086;
-  }
-
-  .status-dot.idle {
-    color: #a6e3a1;
-  }
-
-  .status-dot.working {
-    color: #f9e2af;
-  }
-
-  .session-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    flex: 1;
-  }
-
-  .issue-badge {
-    font-size: 10px;
-    color: #89b4fa;
-    background: rgba(137, 180, 250, 0.15);
-    padding: 0 4px;
-    border-radius: 3px;
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .jump-label {
-    background: #fab387;
-    color: #1e1e2e;
-    padding: 0 5px;
-    border-radius: 3px;
-    font-family: monospace;
-    font-size: 11px;
-    font-weight: 700;
-    line-height: 16px;
-    flex-shrink: 0;
-    margin-left: auto;
-  }
-
-  .hint {
-    background: #313244;
-    color: #89b4fa;
-    padding: 0 5px;
-    border-radius: 3px;
-    font-family: monospace;
-    font-size: 10px;
-    font-weight: 600;
-    line-height: 16px;
-    white-space: nowrap;
-    flex-shrink: 0;
-    margin-left: 4px;
-  }
-
-  .empty-state {
-    padding: 24px 16px;
-    color: #6c7086;
-    font-size: 13px;
-    text-align: center;
-  }
-
   /* Footer */
   .sidebar-footer {
     display: flex;
@@ -945,34 +674,5 @@
 
   .btn-help.active {
     color: #89b4fa;
-  }
-
-  .new-menu {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    background: #1e1e2e;
-    border: 1px solid #313244;
-    border-radius: 4px;
-    z-index: 10;
-    min-width: 140px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  }
-
-  .new-menu-item {
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    background: none;
-    border: none;
-    color: #cdd6f4;
-    font-size: 12px;
-    text-align: left;
-    cursor: pointer;
-    box-shadow: none;
-  }
-
-  .new-menu-item:hover {
-    background: #313244;
   }
 </style>

--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-  import { onDestroy } from "svelte";
   import { projects, sessionStatuses, type Project, type SessionStatus } from "./stores";
 
   interface Props {
@@ -15,19 +15,11 @@
     message: string;
   }
 
-  let projectList: Project[] = $state([]);
-  let statuses: Map<string, SessionStatus> = $state(new Map());
+  const projectsState = fromStore(projects);
+  let projectList: Project[] = $derived(projectsState.current);
+  const sessionStatusesState = fromStore(sessionStatuses);
+  let statuses: Map<string, SessionStatus> = $derived(sessionStatusesState.current);
   let commits: CommitInfo[] = $state([]);
-
-  $effect(() => {
-    const unsub = projects.subscribe((v) => { projectList = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = sessionStatuses.subscribe((v) => { statuses = v; });
-    return unsub;
-  });
 
   let session = $derived(
     projectList.flatMap((p) =>

--- a/src/lib/TaskPanel.svelte
+++ b/src/lib/TaskPanel.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
+  import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { focusTarget, projects, type GithubIssue, type Project, type FocusTarget } from "./stores";
-
-  interface Props {
-    visible: boolean;
-  }
-
-  let { visible }: Props = $props();
 
   let issues: GithubIssue[] = $state([]);
 
@@ -14,27 +9,13 @@
   let error: string | null = $state(null);
   let currentRepoPath: string | null = $state(null);
 
-  let projectList: Project[] = $state([]);
-  let currentFocus: FocusTarget = $state(null);
+  const projectsState = fromStore(projects);
+  let projectList: Project[] = $derived(projectsState.current);
+  const focusTargetState = fromStore(focusTarget);
+  let currentFocus: FocusTarget = $derived(focusTargetState.current);
 
   $effect(() => {
-    const unsub = projects.subscribe((v) => { projectList = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = focusTarget.subscribe((v) => { currentFocus = v; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const projectId = currentFocus?.type === "project"
-      ? currentFocus.projectId
-      : currentFocus?.type === "session"
-        ? currentFocus.projectId
-        : currentFocus?.type === "terminal"
-          ? currentFocus.projectId
-          : null;
+    const projectId = currentFocus?.projectId ?? null;
 
     const project = projectId
       ? projectList.find((p) => p.id === projectId)
@@ -45,12 +26,6 @@
     if (repoPath && repoPath !== currentRepoPath) {
       currentRepoPath = repoPath;
       fetchIssues(repoPath);
-    }
-  });
-
-  $effect(() => {
-    if (visible && currentRepoPath) {
-      fetchIssues(currentRepoPath);
     }
   });
 

--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
+  import { get } from "svelte/store";
   import { Terminal } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { makeCustomKeyHandler } from "./terminal-keys";
   import { clipboardHasImage } from "./clipboard";
-  import { activeSessionId, projects, type Project } from "./stores";
+  import { activeSessionId, projects } from "./stores";
   import "@xterm/xterm/css/xterm.css";
 
   interface Props {
@@ -37,9 +38,7 @@
   // Skip if session already has a prompt (e.g., from a GitHub issue).
   let promptBuffer = "";
   let promptCaptured = (() => {
-    let list: Project[] = [];
-    projects.subscribe((v) => { list = v; })();
-    const session = list.flatMap((p) => p.sessions).find((s) => s.id === sessionId);
+    const session = get(projects).flatMap((p) => p.sessions).find((s) => s.id === sessionId);
     return session?.initial_prompt != null || session?.github_issue != null;
   })();
 
@@ -69,9 +68,7 @@
   }
 
   function saveInitialPrompt(prompt: string) {
-    let projectList: Project[] = [];
-    projects.subscribe((v) => { projectList = v; })();
-    const match = projectList.flatMap((p) =>
+    const match = get(projects).flatMap((p) =>
       p.sessions.map((s) => ({ session: s, projectId: p.id }))
     ).find((x) => x.session.id === sessionId);
     if (!match || match.session.initial_prompt != null) return;
@@ -216,9 +213,7 @@
     // Gate on active session — this is a window-level event so all
     // mounted Terminal instances receive it; only the active one should act.
     listen<{ paths: string[] }>("tauri://drag-drop", async (event) => {
-      let active: string | null = null;
-      activeSessionId.subscribe((v) => { active = v; })();
-      if (active !== sessionId) return;
+      if (get(activeSessionId) !== sessionId) return;
 
       const imagePath = event.payload.paths.find(isImageFile);
       if (imagePath) {

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -1,22 +1,14 @@
 <script lang="ts">
+  import { fromStore } from "svelte/store";
   import Terminal from "./Terminal.svelte";
   import SummaryPane from "./SummaryPane.svelte";
   import { projects, activeSessionId, hotkeyAction, focusTarget, type Project } from "./stores";
 
-  let projectList: Project[] = $state([]);
-  let activeSession: string | null = $state(null);
+  const projectsState = fromStore(projects);
+  let projectList: Project[] = $derived(projectsState.current);
+  const activeSessionIdState = fromStore(activeSessionId);
+  let activeSession: string | null = $derived(activeSessionIdState.current);
   let terminalComponents: Record<string, Terminal> = $state({});
-  let isFocused = $state(false);
-
-  $effect(() => {
-    const unsub = projects.subscribe((value) => { projectList = value; });
-    return unsub;
-  });
-
-  $effect(() => {
-    const unsub = activeSessionId.subscribe((value) => { activeSession = value; });
-    return unsub;
-  });
 
   $effect(() => {
     const unsub = hotkeyAction.subscribe((action) => {
@@ -27,15 +19,11 @@
     return unsub;
   });
 
-  let focusedSessionId: string | null = $state(null);
-
-  $effect(() => {
-    const unsub = focusTarget.subscribe((v) => {
-      isFocused = v?.type === "terminal";
-      focusedSessionId = v?.type === "session" ? v.sessionId : null;
-    });
-    return unsub;
-  });
+  const focusTargetState = fromStore(focusTarget);
+  let isFocused = $derived(focusTargetState.current?.type === "terminal");
+  let focusedSessionId: string | null = $derived(
+    focusTargetState.current?.type === "session" ? focusTargetState.current.sessionId : null,
+  );
 
   function handleFocusIn() {
     const project = activeSession

--- a/src/lib/Toast.svelte
+++ b/src/lib/Toast.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
+  import { fromStore } from "svelte/store";
   import { toasts } from "./toast";
 
-  let toastList: { id: number; text: string; type: "error" | "info" }[] = $state([]);
-
-  toasts.subscribe((value) => {
-    toastList = value;
-  });
+  const toastsState = fromStore(toasts);
+  let toastList = $derived(toastsState.current);
 </script>
 
 {#if toastList.length > 0}

--- a/src/lib/sidebar/ProjectTree.svelte
+++ b/src/lib/sidebar/ProjectTree.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+  import type { FocusTarget, JumpPhase, Project, SessionStatus } from "../stores";
+
+  interface Props {
+    projects: Project[];
+    mode: "active" | "archived";
+    expandedProjectSet: Set<string>;
+    activeSession: string | null;
+    currentFocus: FocusTarget;
+    jumpState: JumpPhase;
+    projectJumpLabels: string[];
+    getSessionStatus: (sessionId: string) => SessionStatus;
+    onToggleProject: (projectId: string) => void;
+    onProjectFocus: (projectId: string) => void;
+    onSessionFocus: (sessionId: string, projectId: string) => void;
+    onSessionSelect: (sessionId: string, projectId: string) => void;
+  }
+
+  let {
+    projects,
+    mode,
+    expandedProjectSet,
+    activeSession,
+    currentFocus,
+    jumpState,
+    projectJumpLabels,
+    getSessionStatus,
+    onToggleProject,
+    onProjectFocus,
+    onSessionFocus,
+    onSessionSelect,
+  }: Props = $props();
+
+  function isArchivedMode() {
+    return mode === "archived";
+  }
+</script>
+
+{#if isArchivedMode() && projects.length === 0}
+  <div class="empty-state">No archived sessions</div>
+{:else}
+  {#each projects as project, i (project.id)}
+    {@const visibleSessions = isArchivedMode()
+      ? project.sessions.filter((s) => s.archived)
+      : project.sessions.filter((s) => !s.archived)}
+    <div class="project-item">
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="project-header"
+        class:focus-target={currentFocus?.type === "project" && currentFocus.projectId === project.id}
+        tabindex="0"
+        data-project-id={project.id}
+        onfocusin={(e: FocusEvent) => {
+          if (e.target === e.currentTarget) onProjectFocus(project.id);
+        }}
+      >
+        <button class="btn-expand" onclick={() => onToggleProject(project.id)}>
+          {expandedProjectSet.has(project.id) ? "\u25BC" : "\u25B6"}
+        </button>
+        <span class="project-name">{project.name}</span>
+        {#if jumpState?.phase === "project" && projectJumpLabels[i]}
+          <kbd class="jump-label">{projectJumpLabels[i]}</kbd>
+        {/if}
+        <span class="session-count">{visibleSessions.length}</span>
+      </div>
+
+      {#if expandedProjectSet.has(project.id)}
+        <div class="session-list">
+          {#each visibleSessions as session (session.id)}
+            {#if isArchivedMode()}
+              <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+              <div
+                class="session-item archived"
+                class:focus-target={currentFocus?.type === "session" && currentFocus.sessionId === session.id}
+                data-session-id={session.id}
+                tabindex="0"
+                onfocusin={() => {
+                  onSessionFocus(session.id, project.id);
+                }}
+              >
+                <span class="status-dot archived-dot">&cir;</span>
+                <span class="session-label">{session.label}</span>
+              </div>
+            {:else}
+              <div
+                class="session-item"
+                class:active={activeSession === session.id}
+                class:focus-target={currentFocus?.type === "session" && currentFocus.sessionId === session.id}
+                data-session-id={session.id}
+                role="button"
+                tabindex="0"
+                onclick={() => {
+                  onSessionSelect(session.id, project.id);
+                  onSessionFocus(session.id, project.id);
+                }}
+                onfocusin={() => {
+                  onSessionFocus(session.id, project.id);
+                }}
+                onkeydown={(e: KeyboardEvent) => {
+                  if (e.key === "Enter" || e.key === " ") onSessionSelect(session.id, project.id);
+                }}
+              >
+                <span
+                  class="status-dot"
+                  class:idle={getSessionStatus(session.id) === "idle"}
+                  class:working={getSessionStatus(session.id) === "working"}
+                >
+                  {getSessionStatus(session.id) === "exited" ? "\u25CB" : "\u25CF"}
+                </span>
+                <span class="session-label">{session.label}</span>
+                {#if session.github_issue}
+                  <span class="issue-badge">#{session.github_issue.number}</span>
+                {/if}
+              </div>
+            {/if}
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/each}
+{/if}
+
+<style>
+  .project-item {
+    border-bottom: 1px solid #313244;
+  }
+
+  .project-header {
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    gap: 8px;
+  }
+
+  .project-header:hover {
+    background: #313244;
+  }
+
+  .project-header.focus-target {
+    outline: 2px solid #89b4fa;
+    outline-offset: -2px;
+    border-radius: 4px;
+  }
+
+  .btn-expand {
+    background: none;
+    border: none;
+    color: #6c7086;
+    cursor: pointer;
+    padding: 0;
+    font-size: 10px;
+    width: 16px;
+    text-align: center;
+    box-shadow: none;
+  }
+
+  .project-name {
+    flex: 1;
+    font-size: 13px;
+    font-weight: 500;
+    word-break: break-word;
+  }
+
+  .session-count {
+    font-size: 11px;
+    color: #6c7086;
+    background: #313244;
+    padding: 1px 6px;
+    border-radius: 8px;
+  }
+
+  .session-list {
+    padding: 0;
+  }
+
+  .session-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px 6px 40px;
+    cursor: pointer;
+    font-size: 12px;
+    width: 100%;
+    background: none;
+    border: none;
+    color: #cdd6f4;
+    text-align: left;
+    box-shadow: none;
+  }
+
+  .session-item:hover {
+    background: #313244;
+  }
+
+  .session-item.active {
+    background: #45475a;
+  }
+
+  .session-item.focus-target {
+    outline: 2px solid #89b4fa;
+    outline-offset: -2px;
+    border-radius: 4px;
+  }
+
+  .session-item.archived {
+    opacity: 0.6;
+  }
+
+  .archived-dot {
+    color: #6c7086;
+  }
+
+  .status-dot {
+    font-size: 10px;
+    color: #6c7086;
+  }
+
+  .status-dot.idle {
+    color: #a6e3a1;
+  }
+
+  .status-dot.working {
+    color: #f9e2af;
+  }
+
+  .session-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+
+  .issue-badge {
+    font-size: 10px;
+    color: #89b4fa;
+    background: rgba(137, 180, 250, 0.15);
+    padding: 0 4px;
+    border-radius: 3px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .jump-label {
+    background: #fab387;
+    color: #1e1e2e;
+    padding: 0 5px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 16px;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  .empty-state {
+    padding: 24px 16px;
+    color: #6c7086;
+    font-size: 13px;
+    text-align: center;
+  }
+</style>

--- a/src/lib/sidebar/ProjectTree.test.ts
+++ b/src/lib/sidebar/ProjectTree.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+import type { Project, FocusTarget, JumpPhase, SessionStatus } from "../stores";
+
+import ProjectTree from "./ProjectTree.svelte";
+
+const baseProjects: Project[] = [
+  {
+    id: "proj-1",
+    name: "Project One",
+    repo_path: "/tmp/proj-1",
+    created_at: "2026-01-01",
+    archived: false,
+    sessions: [
+      {
+        id: "sess-1",
+        label: "session-1",
+        worktree_path: null,
+        worktree_branch: null,
+        archived: false,
+        kind: "claude",
+        github_issue: { number: 42, title: "Issue", url: "https://example.com", labels: [] },
+        initial_prompt: null,
+      },
+      {
+        id: "sess-2",
+        label: "session-2",
+        worktree_path: null,
+        worktree_branch: null,
+        archived: true,
+        kind: "claude",
+        github_issue: null,
+        initial_prompt: null,
+      },
+    ],
+  },
+];
+
+describe("ProjectTree", () => {
+  let onToggleProjectSpy: ReturnType<typeof vi.fn>;
+  let onProjectFocusSpy: ReturnType<typeof vi.fn>;
+  let onSessionFocusSpy: ReturnType<typeof vi.fn>;
+  let onSessionSelectSpy: ReturnType<typeof vi.fn>;
+  let onToggleProject: (projectId: string) => void;
+  let onProjectFocus: (projectId: string) => void;
+  let onSessionFocus: (sessionId: string, projectId: string) => void;
+  let onSessionSelect: (sessionId: string, projectId: string) => void;
+
+  beforeEach(() => {
+    onToggleProjectSpy = vi.fn();
+    onProjectFocusSpy = vi.fn();
+    onSessionFocusSpy = vi.fn();
+    onSessionSelectSpy = vi.fn();
+    onToggleProject = (projectId: string) => onToggleProjectSpy(projectId);
+    onProjectFocus = (projectId: string) => onProjectFocusSpy(projectId);
+    onSessionFocus = (sessionId: string, projectId: string) => onSessionFocusSpy(sessionId, projectId);
+    onSessionSelect = (sessionId: string, projectId: string) => onSessionSelectSpy(sessionId, projectId);
+  });
+
+  function renderTree(mode: "active" | "archived", focus: FocusTarget = null, statuses = new Map<string, SessionStatus>()) {
+    return render(ProjectTree, {
+      projects: baseProjects,
+      mode,
+      expandedProjectSet: new Set(["proj-1"]),
+      activeSession: "sess-1",
+      currentFocus: focus,
+      jumpState: { phase: "project" } as JumpPhase,
+      projectJumpLabels: ["z"],
+      getSessionStatus: (id: string) => statuses.get(id) ?? "idle",
+      onToggleProject,
+      onProjectFocus,
+      onSessionFocus,
+      onSessionSelect,
+    });
+  }
+
+  it("renders active-mode session rows with issue badge and status classes", () => {
+    const { container, getByText, queryByText } = renderTree("active", null, new Map([["sess-1", "working"]]));
+
+    expect(getByText("Project One")).toBeTruthy();
+    expect(getByText("session-1")).toBeTruthy();
+    expect(getByText("#42")).toBeTruthy();
+    expect(queryByText("session-2")).toBeNull();
+
+    const row = container.querySelector('[data-session-id="sess-1"]');
+    expect(row?.classList.contains("active")).toBe(true);
+
+    const dot = row?.querySelector(".status-dot");
+    expect(dot?.classList.contains("working")).toBe(true);
+  });
+
+  it("calls session callbacks on active row click", async () => {
+    const { container } = renderTree("active");
+    const row = container.querySelector('[data-session-id="sess-1"]') as HTMLElement;
+
+    row.click();
+
+    expect(onSessionSelectSpy).toHaveBeenCalledWith("sess-1", "proj-1");
+    expect(onSessionFocusSpy).toHaveBeenCalledWith("sess-1", "proj-1");
+  });
+
+  it("renders archived sessions as non-interactive rows", () => {
+    const { container, getByText, queryByText } = renderTree("archived");
+
+    expect(getByText("session-2")).toBeTruthy();
+    expect(queryByText("session-1")).toBeNull();
+
+    const row = container.querySelector('[data-session-id="sess-2"]') as HTMLElement;
+    expect(row.getAttribute("role")).toBeNull();
+    expect(row.classList.contains("archived")).toBe(true);
+  });
+});

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -71,6 +71,15 @@ export const sidebarVisible = writable<boolean>(true);
 export const taskPanelVisible = writable<boolean>(false);
 export const expandedProjects = writable<Set<string>>(new Set());
 
+export function dispatchHotkeyAction(action: NonNullable<HotkeyAction>) {
+  hotkeyAction.set(action);
+  setTimeout(() => hotkeyAction.set(null), 0);
+}
+
+export function focusTerminalSoon(delayMs = 50) {
+  setTimeout(() => dispatchHotkeyAction({ type: "focus-terminal" }), delayMs);
+}
+
 // Focus tracking — granular: which element is focused
 export type FocusTarget =
   | { type: "terminal"; projectId: string }


### PR DESCRIPTION
## Summary
- simplify frontend architecture by extracting sidebar tree UI into a focused ProjectTree component
- remove obsolete glue code and reduce ad-hoc store subscriptions with direct/derived store usage
- eliminate unused visibility wiring and duplicate one-shot subscription patterns

## Validation
- npx vitest run
- cd src-tauri && cargo test