### PR TITLE
fix: codex merge hotkey submits on single keypress

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -293,7 +293,7 @@
         if (activeId) {
           const proj = projectList.find((p) => p.sessions.some((s) => s.id === activeId));
           const sess = proj?.sessions.find((s) => s.id === activeId);
-          const eol = sess?.kind === "codex" ? "\n" : "\r";
+          const eol = "\r";
           const prompt = sess?.kind === "codex"
             ? `$finishing-a-development-branch`
             : `/finishing-a-development-branch`;

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -144,6 +144,25 @@ describe('HotkeyManager', () => {
       });
     });
 
+    it('m submits codex merge command without needing extra Enter', () => {
+      projects.set([
+        {
+          ...testProject,
+          sessions: [
+            { ...testProject.sessions[0], kind: 'codex' },
+          ],
+        },
+      ]);
+      activeSessionId.set('sess-1');
+
+      pressKey('m');
+
+      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+        sessionId: 'sess-1',
+        data: '$finishing-a-development-branch\r',
+      });
+    });
+
     it('modifier keys alone do not dispatch', () => {
       const initial = get(activeSessionId);
       pressKey('Shift');


### PR DESCRIPTION
## Summary
- ensure `m` hotkey sends a submitted command for codex sessions
- use carriage return terminator for both claude and codex merge prompts
- add regression test for codex merge hotkey behavior

## Verification
- npx vitest run
- cargo test
