### PR TITLE
feat: auto-cleanup worktree after finishing-a-development-branch

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -31,6 +31,10 @@ Run the project's test suite. If tests fail, fix them before proceeding.
    fi
    ```
 6. Close the associated issue with a summary of what was done
+7. If running inside The Controller (i.e. `$THE_CONTROLLER_SESSION_ID` is set), signal it to clean up this session's worktree:
+   ```bash
+   echo "cleanup:$THE_CONTROLLER_SESSION_ID" | nc -U -w 2 /tmp/the-controller.sock 2>/dev/null; true
+   ```
 
 ## Integration
 

--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -10,12 +10,12 @@ pub fn socket_path() -> &'static str {
     SOCKET_PATH
 }
 
-/// Parse a "working:uuid" or "idle:uuid" message.
+/// Parse a "working:uuid", "idle:uuid", or "cleanup:uuid" message.
 /// Returns None for anything that doesn't match.
 pub fn parse_status_message(msg: &str) -> Option<(&str, Uuid)> {
     let (status, id_str) = msg.split_once(':')?;
     match status {
-        "working" | "idle" => {
+        "working" | "idle" | "cleanup" => {
             let id = Uuid::parse_str(id_str).ok()?;
             Some((status, id))
         }
@@ -75,7 +75,11 @@ fn handle_connection(stream: UnixStream, app_handle: &AppHandle) {
             Ok(msg) => {
                 let msg = msg.trim();
                 if let Some((status, session_id)) = parse_status_message(msg) {
-                    let event_name = format!("session-status-hook:{}", session_id);
+                    let event_name = if status == "cleanup" {
+                        format!("session-cleanup:{}", session_id)
+                    } else {
+                        format!("session-status-hook:{}", session_id)
+                    };
                     if let Err(e) = app_handle.emit(&event_name, status) {
                         eprintln!("Failed to emit {}: {}", event_name, e);
                     }
@@ -206,6 +210,15 @@ mod tests {
             json.contains("nc -U -w 2"),
             "hook commands must use `nc -w 2` for timeout"
         );
+    }
+
+    #[test]
+    fn test_parse_status_message_cleanup() {
+        let id = uuid::Uuid::new_v4();
+        let msg = format!("cleanup:{}", id);
+        let (status, parsed_id) = parse_status_message(&msg).unwrap();
+        assert_eq!(status, "cleanup");
+        assert_eq!(parsed_id, id);
     }
 
     #[test]

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -202,6 +202,11 @@
           markSession(session.id, "exited");
         }).then(unlisten => { if (!cancelled) unlisteners.push(unlisten); else unlisten(); });
 
+        // Cleanup: session finished its branch and requests worktree deletion.
+        listen<string>(`session-cleanup:${session.id}`, () => {
+          closeSession(project.id, session.id, true);
+        }).then(unlisten => { if (!cancelled) unlisteners.push(unlisten); else unlisten(); });
+
         // Hook-based status: precise idle/working from Claude Code hooks.
         // Debounce idle transitions to avoid flickering between tool calls
         // (Stop hook fires after each assistant turn, even mid-task).


### PR DESCRIPTION
## Summary
- Adds a `cleanup` socket message type so sessions can signal The Controller to delete their worktree after merging
- The `finishing-a-development-branch` skill sends `cleanup:$THE_CONTROLLER_SESSION_ID` as its final step
- Frontend listens for `session-cleanup:<id>` events and triggers worktree deletion automatically

## Test plan
- [x] Rust tests pass (10 status_socket tests including new `test_parse_status_message_cleanup`)
- [x] Frontend tests pass (116 tests)
- [ ] Manual: run `finishing-a-development-branch` in a Controller session and verify worktree is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)