### PR TITLE
fix: send Enter as separate PTY write for codex merge hotkey

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -293,11 +293,18 @@
         if (activeId) {
           const proj = projectList.find((p) => p.sessions.some((s) => s.id === activeId));
           const sess = proj?.sessions.find((s) => s.id === activeId);
-          const eol = "\r";
-          const prompt = sess?.kind === "codex"
+          const isCodex = sess?.kind === "codex";
+          const prompt = isCodex
             ? `$finishing-a-development-branch`
             : `/finishing-a-development-branch`;
-          invoke("write_to_pty", { sessionId: activeId, data: `${prompt}${eol}` });
+          if (isCodex) {
+            // Codex TUI needs Enter sent as a separate write to register as a keypress
+            invoke("write_to_pty", { sessionId: activeId, data: prompt }).then(() => {
+              invoke("write_to_pty", { sessionId: activeId, data: "\r" });
+            });
+          } else {
+            invoke("write_to_pty", { sessionId: activeId, data: `${prompt}\r` });
+          }
         }
         return true;
       case "s":

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -144,7 +144,7 @@ describe('HotkeyManager', () => {
       });
     });
 
-    it('m submits codex merge command without needing extra Enter', () => {
+    it('m sends codex merge text and Enter as separate writes', async () => {
       projects.set([
         {
           ...testProject,
@@ -156,10 +156,18 @@ describe('HotkeyManager', () => {
       activeSessionId.set('sess-1');
 
       pressKey('m');
+      // Wait for the .then() chain to resolve
+      await vi.waitFor(() => {
+        expect(invoke).toHaveBeenCalledTimes(2);
+      });
 
-      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+      expect(invoke).toHaveBeenNthCalledWith(1, 'write_to_pty', {
         sessionId: 'sess-1',
-        data: '$finishing-a-development-branch\r',
+        data: '$finishing-a-development-branch',
+      });
+      expect(invoke).toHaveBeenNthCalledWith(2, 'write_to_pty', {
+        sessionId: 'sess-1',
+        data: '\r',
       });
     });
 

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
+  invoke: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({


### PR DESCRIPTION
## Summary
- Codex TUI doesn't interpret `\r` at the end of a single PTY write as Enter
- Split the merge hotkey (`m`) into two separate `write_to_pty` calls for codex: first the prompt text, then `\r` via `.then()`
- Also fixed `invoke` mock in vitest-setup to return a Promise (matching real Tauri API)

## Test plan
- [x] All 116 frontend tests pass
- [x] All 12 Rust tests pass
- [ ] Manual: press `m` on a codex session — should auto-submit without extra Enter

🤖 Generated with [Claude Code](https://claude.com/claude-code)