### PR TITLE
fix: let xterm handle paste natively for codex sessions

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -12,9 +12,10 @@
 
   interface Props {
     sessionId: string;
+    kind?: string;
   }
 
-  let { sessionId }: Props = $props();
+  let { sessionId, kind = "claude" }: Props = $props();
 
   let containerEl: HTMLDivElement | undefined = $state();
   let term: Terminal | undefined;
@@ -136,19 +137,25 @@
     const writeToPty = (data: string) =>
       invoke("write_to_pty", { sessionId, data });
 
-    // Handle keys that xterm.js doesn't natively support
+    // Handle keys that xterm.js doesn't natively support.
+    // Only intercept paste for Claude sessions (image paste is Claude Code-specific).
+    // For other session types (e.g. Codex), let xterm handle paste natively.
+    const keyHandlerOptions = kind === "claude"
+      ? {
+          onImagePaste: () => {
+            if (!inputReady) return;
+            handleImagePaste(writeToPty);
+          },
+        }
+      : undefined;
+
     term.attachCustomKeyEventHandler(
       makeCustomKeyHandler(
         (data) => {
           if (!inputReady) return;
           invoke("send_raw_to_pty", { sessionId, data });
         },
-        {
-          onImagePaste: () => {
-            if (!inputReady) return;
-            handleImagePaste(writeToPty);
-          },
-        },
+        keyHandlerOptions,
       ),
     );
 

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -34,20 +34,21 @@
     }
   }
 
-  let allSessionIds: string[] = $derived(
-    projectList.flatMap((p) => p.sessions.map((s) => s.id)),
+  let allSessions: { id: string; kind: string }[] = $derived(
+    projectList.flatMap((p) => p.sessions.map((s) => ({ id: s.id, kind: s.kind }))),
   );
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="terminal-manager" class:focused={isFocused} onfocusin={handleFocusIn}>
-  {#each allSessionIds as sessionId (sessionId)}
+  {#each allSessions as session (session.id)}
+    {@const sessionId = session.id}
     <div class="terminal-wrapper" class:visible={activeSession === sessionId}>
       {#if focusedSessionId === sessionId}
         <SummaryPane {sessionId} />
       {/if}
       <div class="terminal-inner">
-        <Terminal {sessionId} bind:this={terminalComponents[sessionId]} />
+        <Terminal {sessionId} kind={session.kind} bind:this={terminalComponents[sessionId]} />
       </div>
     </div>
   {/each}


### PR DESCRIPTION
## Summary
- Cmd+V paste was broken for Codex sessions because the custom key handler always intercepted it for Claude Code's image paste feature
- Now only Claude sessions get the image paste interceptor; Codex sessions use xterm's native paste handling
- Added `kind` prop to `Terminal.svelte`, passed from `TerminalManager.svelte`

## Test plan
- [x] All 117 frontend tests pass
- [x] All 12 Rust tests pass
- [ ] Manual: paste text into a Codex session with Cmd+V — should work
- [ ] Manual: paste text/image into a Claude session — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)