### PR TITLE
fix: register screenshot idle listener before async activation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -145,13 +145,11 @@
         kind: "claude",
       });
 
-      await activateNewSession(sessionId, projectId);
-
-      // 3. Focus the terminal
-      focusTerminalSoon();
-
-      // 4. Listen directly for idle hook so we don't miss the first idle event
-      // while Sidebar is still wiring listeners for a newly created session.
+      // 3. Register idle listener IMMEDIATELY after session creation.
+      // create_session is synchronous (blocks main thread) while Claude Code
+      // starts in tmux — if worktree creation is slow, Claude may already be
+      // idle by the time JS resumes. Registering the listener before any other
+      // async work ensures we catch events queued during the blocked period.
       let done = false;
       let timeoutId: ReturnType<typeof setTimeout> | null = null;
       const unlisten = await listen<string>(`session-status-hook:${sessionId}`, (event) => {
@@ -168,6 +166,11 @@
         done = true;
         unlisten();
       }, 30000);
+
+      await activateNewSession(sessionId, projectId);
+
+      // 4. Focus the terminal
+      focusTerminalSoon();
     } catch (e) {
       showToast(String(e), "error");
     }


### PR DESCRIPTION
## Summary
- Moves the `listen()` call for the idle event immediately after `create_session`, before `activateNewSession`
- `create_session` is synchronous and blocks the main thread during git worktree creation + tmux spawn — Claude Code may reach idle before JS resumes
- Previously the listener was registered after `activateNewSession` (which does async `list_projects`), widening the race window

## Test plan
- [x] Existing `App.test.ts` screenshot flow test passes
- [x] All 117 frontend tests pass
- [x] All 12 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)