### PR TITLE
fix: change background agent panel hotkey from Shift+M to Shift+B

### DIFF
--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -26,6 +26,7 @@
     { key: "t", description: "Toggle GitHub issues panel" },
     { key: "i", description: "Create GitHub issue for focused project" },
     { key: "S", description: "Screenshot app → new session with image" },
+    { key: "B", description: "Toggle background agent panel" },
     { key: "Esc", description: "Move focus up (terminal → session → project)" },
     { key: "?", description: "Toggle this help" },
   ];

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -333,7 +333,7 @@
           dispatchAction({ type: "focus-terminal" });
         }
         return true;
-      case "M":
+      case "B":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;
       case "S":


### PR DESCRIPTION
## Summary
- Remaps the background agent panel toggle from Shift+M to Shift+B (B for "background")
- Adds the hotkey to the help overlay (was previously missing)

## Test plan
- [x] Frontend tests pass (118/118)
- [ ] Verify Shift+B toggles the background agent panel in the app
- [ ] Verify Shift+M no longer triggers anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)