### PR TITLE
feat: add confirmation popup for merge hotkey

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -293,18 +293,7 @@
         if (activeId) {
           const proj = projectList.find((p) => p.sessions.some((s) => s.id === activeId));
           const sess = proj?.sessions.find((s) => s.id === activeId);
-          const isCodex = sess?.kind === "codex";
-          const prompt = isCodex
-            ? `$finishing-a-development-branch`
-            : `/finishing-a-development-branch`;
-          if (isCodex) {
-            // Codex TUI needs Enter sent as a separate write to register as a keypress
-            invoke("write_to_pty", { sessionId: activeId, data: prompt }).then(() => {
-              invoke("write_to_pty", { sessionId: activeId, data: "\r" });
-            });
-          } else {
-            invoke("write_to_pty", { sessionId: activeId, data: `${prompt}\r` });
-          }
+          dispatchHotkeyAction({ type: "finish-branch", sessionId: activeId, kind: sess?.kind });
         }
         return true;
       case "s":

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -136,15 +136,16 @@ describe('HotkeyManager', () => {
       unsub();
     });
 
-    it('m writes merge command to PTY when session is active', () => {
+    it('m dispatches finish-branch action instead of writing directly', () => {
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
       pressKey('m');
-      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
-        sessionId: 'sess-1',
-        data: '/finishing-a-development-branch\r',
-      });
+      expect(captured).toEqual({ type: 'finish-branch', sessionId: 'sess-1', kind: 'claude' });
+      expect(invoke).not.toHaveBeenCalled();
+      unsub();
     });
 
-    it('m sends codex merge text and Enter as separate writes', async () => {
+    it('m dispatches finish-branch with codex kind', () => {
       projects.set([
         {
           ...testProject,
@@ -155,20 +156,12 @@ describe('HotkeyManager', () => {
       ]);
       activeSessionId.set('sess-1');
 
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
       pressKey('m');
-      // Wait for the .then() chain to resolve
-      await vi.waitFor(() => {
-        expect(invoke).toHaveBeenCalledTimes(2);
-      });
-
-      expect(invoke).toHaveBeenNthCalledWith(1, 'write_to_pty', {
-        sessionId: 'sess-1',
-        data: '$finishing-a-development-branch',
-      });
-      expect(invoke).toHaveBeenNthCalledWith(2, 'write_to_pty', {
-        sessionId: 'sess-1',
-        data: '\r',
-      });
+      expect(captured).toEqual({ type: 'finish-branch', sessionId: 'sess-1', kind: 'codex' });
+      expect(invoke).not.toHaveBeenCalled();
+      unsub();
     });
 
     it('modifier keys alone do not dispatch', () => {

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -24,6 +24,7 @@
   let archiveProjectTarget: Project | null = $state(null);
   let mergeSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let mergeInProgress = $state(false);
+  let finishBranchTarget: { sessionId: string; kind?: string } | null = $state(null);
   const archiveViewState = fromStore(archiveView);
   let isArchiveView = $derived(archiveViewState.current);
   const archivedProjectsState = fromStore(archivedProjects);
@@ -173,6 +174,10 @@
               label: sess.label,
             };
           }
+          break;
+        }
+        case "finish-branch": {
+          finishBranchTarget = { sessionId: action.sessionId, kind: action.kind };
           break;
         }
       }
@@ -586,6 +591,32 @@
         mergeSessionTarget = null;
       }}
       onClose={() => (mergeSessionTarget = null)}
+    />
+  {/if}
+
+  {#if finishBranchTarget}
+    <ConfirmModal
+      title="Confirm Merge"
+      message="Merge this session's branch?"
+      confirmLabel="Merge"
+      onConfirm={() => {
+        if (finishBranchTarget) {
+          const { sessionId, kind } = finishBranchTarget;
+          const isCodex = kind === "codex";
+          const prompt = isCodex
+            ? `$finishing-a-development-branch`
+            : `/finishing-a-development-branch`;
+          if (isCodex) {
+            invoke("write_to_pty", { sessionId, data: prompt }).then(() => {
+              invoke("write_to_pty", { sessionId, data: "\r" });
+            });
+          } else {
+            invoke("write_to_pty", { sessionId, data: `${prompt}\r` });
+          }
+        }
+        finishBranchTarget = null;
+      }}
+      onClose={() => (finishBranchTarget = null)}
     />
   {/if}
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -86,6 +86,7 @@ export type HotkeyAction =
   | { type: "create-issue"; projectId: string; repoPath: string }
   | { type: "pick-issue-for-session"; projectId: string; repoPath: string; kind?: string; background?: boolean }
   | { type: "merge-session"; sessionId: string; projectId: string }
+  | { type: "finish-branch"; sessionId: string; kind?: string }
   | { type: "screenshot-to-session" }
   | { type: "toggle-maintainer-panel" }
   | null;


### PR DESCRIPTION
## Summary
- The `m` hotkey now shows a "Confirm Merge" popup before sending `/finishing-a-development-branch` to the terminal
- Prevents accidental merges when intending to press a different key
- Uses the existing `ConfirmModal` component and `HotkeyAction` dispatch pattern

## Test plan
- [x] All 118 frontend tests pass
- [ ] Press `m` hotkey → confirmation popup appears
- [ ] Click "Merge" → command sent to PTY
- [ ] Click cancel / press Escape → nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)