### PR TITLE
fix: add missing maintainer field in integration test

### DIFF
--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -613,6 +613,7 @@ fn test_load_archived_project_by_repo_path_unarchives_it() {
         created_at: "2026-03-01T00:00:00Z".to_string(),
         archived: false,
         sessions: vec![],
+        maintainer: MaintainerConfig::default(),
     };
     storage.save_project(&project).expect("save project");
 


### PR DESCRIPTION
## Summary
- Add missing `maintainer: MaintainerConfig::default()` to `Project` initializer in `test_load_archived_project_by_repo_path_unarchives_it`
- This field was added in #132 but missed in this test

## Test plan
- [x] `cargo test` passes (13/13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)