### PR TITLE
feat: maintainer panel hotkey change and live countdown timer

### DIFF
--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -612,6 +612,7 @@ fn test_load_archived_project_by_repo_path_unarchives_it() {
         repo_path: repo_path.clone(),
         created_at: "2026-03-01T00:00:00Z".to_string(),
         archived: false,
+        maintainer: MaintainerConfig::default(),
         sessions: vec![],
     };
     storage.save_project(&project).expect("save project");

--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -26,7 +26,7 @@
     { key: "t", description: "Toggle GitHub issues panel" },
     { key: "i", description: "Create GitHub issue for focused project" },
     { key: "S", description: "Screenshot app → new session with image" },
-    { key: "B", description: "Toggle background agent panel" },
+    { key: "b", description: "Toggle background agent panel" },
     { key: "Esc", description: "Move focus up (terminal → session → project)" },
     { key: "?", description: "Toggle this help" },
   ];

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -322,7 +322,7 @@
           dispatchAction({ type: "focus-terminal" });
         }
         return true;
-      case "B":
+      case "b":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;
       case "S":

--- a/src/lib/MaintainerPanel.svelte
+++ b/src/lib/MaintainerPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { focusTarget, projects, type Project, type FocusTarget, type MaintainerReport } from "./stores";
@@ -13,6 +14,8 @@
   let projectList: Project[] = $derived(projectsState.current);
   const focusTargetState = fromStore(focusTarget);
   let currentFocus: FocusTarget = $derived(focusTargetState.current);
+
+  let nextRunText = $state("");
 
   let project = $derived(
     currentFocus?.projectId
@@ -68,6 +71,33 @@
     }
   }
 
+  function formatCountdown(diffMs: number): string {
+    if (diffMs <= 0) return "Due now";
+    const totalSecs = Math.floor(diffMs / 1000);
+    const hours = Math.floor(totalSecs / 3600);
+    const mins = Math.floor((totalSecs % 3600) / 60);
+    const secs = totalSecs % 60;
+    if (hours > 0) return `${hours}h ${mins}m ${secs}s`;
+    if (mins > 0) return `${mins}m ${secs}s`;
+    return `${secs}s`;
+  }
+
+  function computeNextRunText(): string {
+    if (!project?.maintainer.enabled) return "Disabled";
+    if (!report) return "Pending";
+    const lastRun = new Date(report.timestamp).getTime();
+    const intervalMs = project.maintainer.interval_minutes * 60 * 1000;
+    const nextRun = lastRun + intervalMs;
+    return formatCountdown(nextRun - Date.now());
+  }
+
+  // Tick the countdown every 30s while the panel is mounted
+  $effect(() => {
+    nextRunText = computeNextRunText();
+    const id = setInterval(() => { nextRunText = computeNextRunText(); }, 1_000);
+    return () => clearInterval(id);
+  });
+
   function severityColor(severity: string): string {
     switch (severity) {
       case "error": return "#f38ba8";
@@ -93,6 +123,13 @@
       </button>
     {/if}
   </div>
+
+  {#if project}
+    <div class="schedule-info">
+      <span class="schedule-label">Interval: {project.maintainer.interval_minutes}m</span>
+      <span class="schedule-label">Next: {nextRunText}</span>
+    </div>
+  {/if}
 
   {#if !project}
     <div class="status">No project selected</div>
@@ -153,6 +190,19 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+  }
+
+  .schedule-info {
+    padding: 8px 16px;
+    border-bottom: 1px solid #313244;
+    display: flex;
+    justify-content: space-between;
+    font-size: 11px;
+    color: #6c7086;
+  }
+
+  .schedule-label {
+    color: #6c7086;
   }
 
   .btn-toggle {


### PR DESCRIPTION
## Summary
- Change maintainer panel toggle hotkey from `B` (Shift+B) to `b`
- Add schedule info bar to MaintainerPanel showing interval and live countdown (ticks every second) to next scheduled run
- Fix missing `maintainer` field in integration test

## Test plan
- [x] Rust tests pass (`cargo test`)
- [x] Frontend tests pass (`npx vitest run`)
- [ ] Open maintainer panel with `b`, verify countdown ticks down in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)