### PR TITLE
feat: add high/low priority label when creating issues

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -870,8 +870,10 @@ pub async fn add_github_label(
     repo_path: String,
     issue_number: u64,
     label: String,
+    description: Option<String>,
+    color: Option<String>,
 ) -> Result<(), String> {
-    github::add_github_label(state, repo_path, issue_number, label).await
+    github::add_github_label(state, repo_path, issue_number, label, description, color).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -224,8 +224,13 @@ pub(crate) async fn add_github_label(
     repo_path: String,
     issue_number: u64,
     label: String,
+    description: Option<String>,
+    color: Option<String>,
 ) -> Result<(), String> {
     let nwo = extract_github_repo_async(repo_path.clone()).await?;
+
+    let desc = description.as_deref().unwrap_or("Issue is being worked on in a session");
+    let col = color.as_deref().unwrap_or("F9E2AF");
 
     // Ensure the label exists on the repo (ignore errors if it already exists)
     let _ = tokio::process::Command::new("gh")
@@ -236,9 +241,9 @@ pub(crate) async fn add_github_label(
             "--repo",
             &nwo,
             "--description",
-            "Issue is being worked on in a session",
+            desc,
             "--color",
-            "F9E2AF",
+            col,
         ])
         .output()
         .await;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -47,7 +47,7 @@
     return unsub;
   });
 
-  async function handleIssueSubmit(title: string) {
+  async function handleIssueSubmit(title: string, priority: "high" | "low") {
     const repoPath = createIssueTarget!.repoPath;
     createIssueTarget = null; // close modal immediately
 
@@ -61,6 +61,15 @@
         title,
         body,
       });
+
+      const label = `priority: ${priority}`;
+      invoke("add_github_label", {
+        repoPath,
+        issueNumber: issue.number,
+        label,
+        description: priority === "high" ? "Important, should be tackled soon" : "Nice to have, can wait",
+        color: priority === "high" ? "F38BA8" : "A6E3A1",
+      }).catch((e: unknown) => showToast(`Failed to add priority label: ${e}`, "error"));
 
       showToast(`Issue #${issue.number} created`, "info");
     } catch (e) {

--- a/src/lib/CreateIssueModal.svelte
+++ b/src/lib/CreateIssueModal.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { onMount } from "svelte";
 
+  type Priority = "high" | "low";
+
   interface Props {
-    onSubmit: (title: string) => void;
+    onSubmit: (title: string, priority: Priority) => void;
     onClose: () => void;
   }
 
   let { onSubmit, onClose }: Props = $props();
 
   let title = $state("");
+  let priority: Priority = $state("low");
   let titleInput: HTMLInputElement | undefined = $state();
 
   onMount(() => {
@@ -17,7 +20,7 @@
 
   function submit() {
     if (!title.trim()) return;
-    onSubmit(title.trim());
+    onSubmit(title.trim(), priority);
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -42,6 +45,23 @@
       placeholder="Issue title"
       class="input"
     />
+    <div class="priority-row">
+      <span class="priority-label">Priority:</span>
+      <div class="priority-buttons">
+        <button
+          class="priority-btn high"
+          class:selected={priority === "high"}
+          onclick={() => priority = "high"}
+          type="button"
+        >High</button>
+        <button
+          class="priority-btn low"
+          class:selected={priority === "low"}
+          onclick={() => priority = "low"}
+          type="button"
+        >Low</button>
+      </div>
+    </div>
     <button
       class="btn-primary"
       onclick={submit}
@@ -105,5 +125,36 @@
   .btn-primary:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+  .priority-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .priority-label {
+    color: #a6adc8;
+    font-size: 13px;
+    flex-shrink: 0;
+  }
+  .priority-buttons {
+    display: flex;
+    gap: 6px;
+  }
+  .priority-btn {
+    background: #313244;
+    color: #a6adc8;
+    border: 1px solid #45475a;
+    padding: 4px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .priority-btn.high.selected {
+    border-color: #f38ba8;
+    color: #f38ba8;
+  }
+  .priority-btn.low.selected {
+    border-color: #a6e3a1;
+    color: #a6e3a1;
   }
 </style>


### PR DESCRIPTION
## Summary
- Adds a high/low priority toggle to the issue creation modal (defaults to low)
- Applies `priority: high` or `priority: low` as a GitHub label after issue creation
- Updates `add_github_label` backend to accept optional description and color params

closes #83

## Test plan
- [x] Rust unit tests pass (132/132)
- [x] `cargo check` clean
- [ ] Manual: create issue → verify priority label appears on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)