### PR TITLE
feat: add 'o' hotkey to toggle maintainer enabled state

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,10 +42,32 @@
         screenshotToNewSession();
       } else if (action?.type === "toggle-maintainer-panel") {
         maintainerPanelVisible.update(v => !v);
+      } else if (action?.type === "toggle-maintainer-enabled") {
+        toggleMaintainerEnabled();
       }
     });
     return unsub;
   });
+
+  async function toggleMaintainerEnabled() {
+    const focus = focusTargetState.current;
+    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
+    const project = projectsState.current.find((p) => p.id === focus.projectId);
+    if (!project) return;
+    const newEnabled = !project.maintainer.enabled;
+    try {
+      await invoke("configure_maintainer", {
+        projectId: project.id,
+        enabled: newEnabled,
+        intervalMinutes: project.maintainer.interval_minutes,
+      });
+      const result: Project[] = await invoke("list_projects");
+      projects.set(result);
+      showToast(`Maintainer ${newEnabled ? "enabled" : "disabled"}`, "info");
+    } catch (e) {
+      showToast(String(e), "error");
+    }
+  }
 
   async function handleIssueSubmit(title: string, priority: "high" | "low") {
     const repoPath = createIssueTarget!.repoPath;

--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -27,6 +27,7 @@
     { key: "i", description: "Create GitHub issue for focused project" },
     { key: "S", description: "Screenshot app → new session with image" },
     { key: "b", description: "Toggle background agent panel" },
+    { key: "o", description: "Toggle maintainer on/off (when panel open)" },
     { key: "Esc", description: "Move focus up (terminal → session → project)" },
     { key: "?", description: "Toggle this help" },
   ];

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -10,6 +10,7 @@
     JUMP_KEYS,
     sidebarVisible,
     taskPanelVisible,
+    maintainerPanelVisible,
     archiveView,
     archivedProjects,
     focusTarget,
@@ -41,6 +42,8 @@
   let archivedProjectList: Project[] = $derived(archivedProjectsState.current);
   const expandedProjectsState = fromStore(expandedProjects);
   let expandedSet: Set<string> = $derived(expandedProjectsState.current);
+  const maintainerPanelVisibleState = fromStore(maintainerPanelVisible);
+  let isMaintainerPanelVisible = $derived(maintainerPanelVisibleState.current);
 
   // Detect if a terminal (xterm) has focus
   function isTerminalFocused(): boolean {
@@ -322,6 +325,12 @@
           dispatchAction({ type: "focus-terminal" });
         }
         return true;
+      case "o":
+        if (isMaintainerPanelVisible && getFocusedProject()) {
+          dispatchAction({ type: "toggle-maintainer-enabled" });
+          return true;
+        }
+        return false;
       case "b":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
-import { projects, activeSessionId, hotkeyAction, focusTarget, jumpMode, sidebarVisible, expandedProjects } from './stores';
+import { projects, activeSessionId, hotkeyAction, focusTarget, jumpMode, sidebarVisible, expandedProjects, maintainerPanelVisible } from './stores';
 import HotkeyManager from './HotkeyManager.svelte';
 
 const testProject = {
@@ -11,6 +11,7 @@ const testProject = {
   repo_path: '/tmp/test',
   created_at: '2026-01-01',
   archived: false,
+  maintainer: { enabled: false, interval_minutes: 60 },
   sessions: [
     { id: 'sess-1', label: 'session-1', worktree_path: null, worktree_branch: null, archived: false, kind: 'claude', github_issue: null },
     { id: 'sess-2', label: 'session-2', worktree_path: null, worktree_branch: null, archived: false, kind: 'claude', github_issue: null },
@@ -23,6 +24,7 @@ const testProject2 = {
   repo_path: '/tmp/other',
   created_at: '2026-01-01',
   archived: false,
+  maintainer: { enabled: false, interval_minutes: 60 },
   sessions: [
     { id: 'sess-3', label: 'session-1', worktree_path: null, worktree_branch: null, archived: false, kind: 'claude', github_issue: null },
     { id: 'sess-4', label: 'session-2', worktree_path: null, worktree_branch: null, archived: false, kind: 'claude', github_issue: null },
@@ -57,6 +59,7 @@ describe('HotkeyManager', () => {
     focusTarget.set(null);
     jumpMode.set(null);
     sidebarVisible.set(true);
+    maintainerPanelVisible.set(false);
     expandedProjects.set(new Set(['proj-1', 'proj-2']));
     vi.clearAllMocks();
     render(HotkeyManager);
@@ -601,6 +604,50 @@ describe('HotkeyManager', () => {
       let captured: any = null;
       const unsub = hotkeyAction.subscribe((v) => { captured = v; });
       pressKey('x');
+      expect(captured).toBeNull();
+      unsub();
+    });
+  });
+
+  // ── Maintainer toggle (o) ──
+
+  describe('maintainer toggle (o)', () => {
+    it('o dispatches toggle-maintainer-enabled when panel visible and project focused', () => {
+      maintainerPanelVisible.set(true);
+      focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('o');
+      expect(captured).toEqual({ type: 'toggle-maintainer-enabled' });
+      unsub();
+    });
+
+    it('o dispatches toggle-maintainer-enabled when panel visible and session focused', () => {
+      maintainerPanelVisible.set(true);
+      focusTarget.set({ type: 'session', sessionId: 'sess-1', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('o');
+      expect(captured).toEqual({ type: 'toggle-maintainer-enabled' });
+      unsub();
+    });
+
+    it('o does nothing when panel is hidden', () => {
+      maintainerPanelVisible.set(false);
+      focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('o');
+      expect(captured).toBeNull();
+      unsub();
+    });
+
+    it('o does nothing when no project focused', () => {
+      maintainerPanelVisible.set(true);
+      focusTarget.set(null);
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('o');
       expect(captured).toBeNull();
       unsub();
     });

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -89,6 +89,7 @@ export type HotkeyAction =
   | { type: "finish-branch"; sessionId: string; kind?: string }
   | { type: "screenshot-to-session" }
   | { type: "toggle-maintainer-panel" }
+  | { type: "toggle-maintainer-enabled" }
   | null;
 
 export const hotkeyAction = writable<HotkeyAction>(null);


### PR DESCRIPTION
## Summary
- Adds `o` hotkey to toggle the maintainer on/off for the focused project
- Only active when the maintainer panel is visible and a project/session is focused
- Shows a toast confirmation when toggled
- Documented in the hotkey help panel

## Test plan
- [x] 4 new tests: panel open + project focused, panel open + session focused, panel hidden (no-op), no focus (no-op)
- [x] All 122 frontend tests pass
- [x] All 13 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)