### PR TITLE
fix: make connect_session async to prevent scroll race on reattach

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -98,9 +98,13 @@ pub fn restore_sessions(state: State<AppState>) -> Result<(), String> {
 /// Connect a terminal to its PTY session at the given size.
 /// Called by each Terminal component after it measures its dimensions.
 /// No-op if the session is already connected.
+///
+/// This command is async because it shells out to tmux (create, resize, attach),
+/// which would block the main thread and prevent event delivery — including the
+/// alternate-screen escape sequence that xterm.js needs for correct scrolling.
 #[tauri::command]
-pub fn connect_session(
-    state: State<AppState>,
+pub async fn connect_session(
+    state: State<'_, AppState>,
     app_handle: AppHandle,
     session_id: String,
     rows: u16,
@@ -134,8 +138,17 @@ pub fn connect_session(
             .ok_or_else(|| format!("session not found: {}", session_id))?
     };
 
-    let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
-    pty_manager.spawn_session(id, &session_dir, &kind, app_handle, true, None, rows, cols)
+    // Run on a background thread to avoid blocking the main thread.
+    // This is critical: the reader thread spawned inside spawn_session emits
+    // pty-output events immediately, and the main thread must be free to
+    // deliver them to the webview (especially the smcup/alternate-screen escape).
+    let pty_manager = state.pty_manager.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut mgr = pty_manager.lock().map_err(|e| e.to_string())?;
+        mgr.spawn_session(id, &session_dir, &kind, app_handle, true, None, rows, cols)
+    })
+    .await
+    .map_err(|e| format!("Task failed: {}", e))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -68,7 +68,7 @@ impl IssueCache {
 
 pub struct AppState {
     pub storage: Mutex<Storage>,
-    pub pty_manager: Mutex<PtyManager>,
+    pub pty_manager: Arc<Mutex<PtyManager>>,
     pub issue_cache: Arc<Mutex<IssueCache>>,
 }
 
@@ -78,7 +78,7 @@ impl AppState {
         storage.ensure_dirs().unwrap();
         Self {
             storage: Mutex::new(storage),
-            pty_manager: Mutex::new(PtyManager::new()),
+            pty_manager: Arc::new(Mutex::new(PtyManager::new())),
             issue_cache: Arc::new(Mutex::new(IssueCache::new())),
         }
     }

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -614,7 +614,6 @@ fn test_load_archived_project_by_repo_path_unarchives_it() {
         archived: false,
         maintainer: MaintainerConfig::default(),
         sessions: vec![],
-        maintainer: MaintainerConfig::default(),
     };
     storage.save_project(&project).expect("save project");
 


### PR DESCRIPTION
## Summary
- Made `connect_session` async with `spawn_blocking` so it doesn't block the main thread while shelling out to tmux
- This ensures the alternate-screen escape sequence (`smcup`) from tmux is delivered to the webview immediately, fixing trackpad scroll on reattached sessions
- Wrapped `pty_manager` in `Arc<Mutex<>>` to support cloning into the blocking closure
- Fixed pre-existing duplicate `maintainer` field in integration test

## Test plan
- [x] `cargo test` — all 13 tests pass
- [x] `npx vitest run` — all 122 tests pass
- [ ] Manual: restart dev server, reattach to existing tmux session, verify trackpad scroll sends arrow keys to Claude Code TUI instead of scrolling xterm.js scrollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)