### PR TITLE
fix: surface cleanup errors and fix duplicate maintainer field

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -35,7 +35,11 @@ Run the project's test suite. If tests fail, fix them before proceeding.
 7. Close the associated issue with a summary of what was done
 8. If running inside The Controller (i.e. `$THE_CONTROLLER_SESSION_ID` is set), signal it to clean up this session's worktree:
    ```bash
-   echo "cleanup:$THE_CONTROLLER_SESSION_ID" | nc -U -w 2 /tmp/the-controller.sock 2>/dev/null; true
+   if [ -z "$THE_CONTROLLER_SESSION_ID" ]; then
+     echo "ERROR: THE_CONTROLLER_SESSION_ID is not set, cannot signal cleanup"
+   else
+     echo "cleanup:$THE_CONTROLLER_SESSION_ID" | nc -U -w 2 /tmp/the-controller.sock
+   fi
    ```
 
 ## Integration


### PR DESCRIPTION
## Summary
- Remove `2>/dev/null; true` from cleanup command in finishing skill so socket/env errors are visible instead of silently swallowed
- Add explicit validation for `THE_CONTROLLER_SESSION_ID` env var before sending cleanup signal
- Fix duplicate `maintainer` field in integration test

Closes #149

## Test plan
- [x] Rust tests pass (`cargo test`)
- [x] Frontend tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)