### PR TITLE
feat: highlight maintainer panel and add 'r' hotkey for run check

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -46,6 +46,8 @@
         maintainerPanelVisible.update(v => !v);
       } else if (action?.type === "toggle-maintainer-enabled") {
         toggleMaintainerEnabled();
+      } else if (action?.type === "trigger-maintainer-check") {
+        triggerMaintainerCheck();
       } else if (action?.type === "toggle-triage-panel") {
         triagePanelOpen = !triagePanelOpen;
       }
@@ -68,6 +70,19 @@
       const result: Project[] = await invoke("list_projects");
       projects.set(result);
       showToast(`Maintainer ${newEnabled ? "enabled" : "disabled"}`, "info");
+    } catch (e) {
+      showToast(String(e), "error");
+    }
+  }
+
+  async function triggerMaintainerCheck() {
+    const focus = focusTargetState.current;
+    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
+    const project = projectsState.current.find((p) => p.id === focus.projectId);
+    if (!project) return;
+    try {
+      await invoke<any>("trigger_maintainer_check", { projectId: project.id });
+      showToast("Maintainer check complete", "info");
     } catch (e) {
       showToast(String(e), "error");
     }

--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -28,6 +28,7 @@
     { key: "S", description: "Screenshot app → new session with image" },
     { key: "b", description: "Toggle background agent panel" },
     { key: "o", description: "Toggle maintainer on/off (when panel open)" },
+    { key: "r", description: "Run maintainer check now (when panel open)" },
     { key: "p", description: "Triage issues (swipe high/low priority)" },
     { key: "Esc", description: "Move focus up (terminal → session → project)" },
     { key: "?", description: "Toggle this help" },

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -331,6 +331,12 @@
           return true;
         }
         return false;
+      case "r":
+        if (isMaintainerPanelVisible) {
+          dispatchAction({ type: "trigger-maintainer-check" });
+          return true;
+        }
+        return false;
       case "b":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;

--- a/src/lib/MaintainerPanel.svelte
+++ b/src/lib/MaintainerPanel.svelte
@@ -139,7 +139,7 @@
     <div class="status">
       <p>No reports yet</p>
       <button class="btn-run" onclick={triggerCheck} disabled={triggerLoading}>
-        {triggerLoading ? "Running..." : "Run check now"}
+        {triggerLoading ? "Running..." : "(r) Run check now"}
       </button>
     </div>
   {:else}
@@ -163,7 +163,7 @@
 
     <div class="panel-actions">
       <button class="btn-run" onclick={triggerCheck} disabled={triggerLoading}>
-        {triggerLoading ? "Running..." : "Run again"}
+        {triggerLoading ? "Running..." : "(r) Run again"}
       </button>
     </div>
   {/if}
@@ -175,7 +175,7 @@
     min-width: 320px;
     height: 100vh;
     background: #1e1e2e;
-    border-left: 1px solid #313244;
+    border-left: 2px solid #89b4fa;
     display: flex;
     flex-direction: column;
     overflow: hidden;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -91,6 +91,7 @@ export type HotkeyAction =
   | { type: "toggle-maintainer-panel" }
   | { type: "toggle-maintainer-enabled" }
   | { type: "toggle-triage-panel" }
+  | { type: "trigger-maintainer-check" }
   | null;
 
 export const hotkeyAction = writable<HotkeyAction>(null);


### PR DESCRIPTION
## Summary
- Highlights the maintainer panel with a blue accent border (`#89b4fa`) when open to indicate focus
- Adds `r` hotkey to trigger "Run check now" when the maintainer panel is visible
- Button labels show `(r)` shortcut hint
- Updates hotkey help with the new shortcut

## Test plan
- [ ] Press `b` to open maintainer panel — verify blue left border appears
- [ ] Press `r` while panel is open — verify maintainer check triggers
- [ ] Press `r` while panel is closed — verify no action
- [ ] Press `?` — verify `r` shortcut listed in help

🤖 Generated with [Claude Code](https://claude.com/claude-code)