### PR TITLE
feat: change screenshot hotkey to cmd+s and add paste diagnostic

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -189,9 +189,8 @@
       showToast("Capturing screenshot...", "info");
       const screenshotPath: string = await invoke("capture_app_screenshot");
 
-      // Open in Preview so user can verify the capture
-      const { openPath } = await import("@tauri-apps/plugin-opener");
-      await openPath(screenshotPath);
+      // Open in Preview so user can verify the capture (fire-and-forget)
+      import("@tauri-apps/plugin-opener").then(({ openPath }) => openPath(screenshotPath));
 
       // 2. Create a new session
       const sessionId: string = await invoke("create_session", {
@@ -212,6 +211,7 @@
         if (timeoutId) clearTimeout(timeoutId);
         unlisten();
         // Send bracket paste to trigger Claude Code's clipboard image reader
+        showToast(`Idle hook fired for ${sessionId}, sending bracket paste`, "info");
         invoke("write_to_pty", { sessionId, data: "\x1b[200~\x1b[201~" });
       });
 

--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -25,7 +25,7 @@
     { key: "s", description: "Toggle sidebar" },
     { key: "t", description: "Triage issues (swipe high/low priority)" },
     { key: "i", description: "Create GitHub issue for focused project" },
-    { key: "S", description: "Screenshot app → new session with image" },
+    { key: "⌘S", description: "Screenshot app → new session with image" },
     { key: "b", description: "Toggle background agent panel" },
     { key: "o", description: "Toggle maintainer on/off (when panel open)" },
     { key: "r", description: "Run maintainer check now (when panel open)" },

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -340,10 +340,7 @@
       case "b":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;
-
-      case "S":
-        dispatchAction({ type: "screenshot-to-session" });
-        return true;
+      // Cmd+S (screenshot) is handled earlier in onKeydown
       case "?":
         dispatchAction({ type: "toggle-help" });
         return true;
@@ -355,6 +352,14 @@
   function onKeydown(e: KeyboardEvent) {
     // Ignore modifier-only keypresses
     if (["Shift", "Control", "Alt", "Meta"].includes(e.key)) return;
+
+    // Cmd+S: screenshot (works from any context, including terminal)
+    if (e.metaKey && e.key === "s") {
+      e.stopPropagation();
+      e.preventDefault();
+      dispatchAction({ type: "screenshot-to-session" });
+      return;
+    }
 
     // Jump mode intercepts all keys
     if (jumpActive) {


### PR DESCRIPTION
## Summary
- Change screenshot hotkey from Shift+S to Cmd+S (works from any context including terminal)
- Make `openPath` fire-and-forget to avoid blocking session creation flow
- Add diagnostic toast when idle hook fires to debug image paste issue
- Fix duplicate `maintainer` field in integration test

## Test plan
- [x] All 122 frontend tests pass
- [x] All 145 Rust tests pass
- [ ] Verify Cmd+S triggers screenshot capture
- [ ] Check if diagnostic toast appears (to debug paste issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)