### PR TITLE
feat: rebind triage hotkeys to j/k for low/high

### DIFF
--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -104,11 +104,11 @@
 
     if (swipeDirection) return; // animating
 
-    if (e.key === "ArrowRight" || e.key === "h") {
+    if (e.key === "ArrowRight" || e.key === "k") {
       e.preventDefault();
       e.stopPropagation();
       assignPriority("high");
-    } else if (e.key === "ArrowLeft" || e.key === "l") {
+    } else if (e.key === "ArrowLeft" || e.key === "j") {
       e.preventDefault();
       e.stopPropagation();
       assignPriority("low");
@@ -191,7 +191,7 @@
 
       <div class="hotkey-bar">
         <div class="hotkey-group">
-          <kbd>←</kbd> / <kbd>l</kbd>
+          <kbd>←</kbd> / <kbd>j</kbd>
           <span class="hotkey-desc">Low priority</span>
         </div>
         <div class="hotkey-group">
@@ -199,7 +199,7 @@
           <span class="hotkey-desc">Skip</span>
         </div>
         <div class="hotkey-group">
-          <kbd>→</kbd> / <kbd>h</kbd>
+          <kbd>→</kbd> / <kbd>k</kbd>
           <span class="hotkey-desc">High priority</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Changed triage panel hotkeys from `h`/`l` to `k`/`j` for high/low priority (vim-style: j=down=low, k=up=high)
- Updated hotkey bar display to match

## Test plan
- [x] All 122 frontend tests pass
- [x] All 13 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)