### PR TITLE
fix: use initial_prompt for screenshot sessions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -413,6 +413,7 @@ pub fn create_session(
     kind: Option<String>,
     github_issue: Option<crate::models::GithubIssue>,
     background: Option<bool>,
+    initial_prompt: Option<String>,
 ) -> Result<String, String> {
     let kind = kind.unwrap_or_else(|| "claude".to_string());
     let background = background.unwrap_or(false);
@@ -454,9 +455,11 @@ pub fn create_session(
             Err(e) => return Err(e),
         };
 
-    // Build initial prompt from GitHub issue context (if any)
-    let initial_prompt = github_issue.as_ref().map(|issue| {
-        crate::session_args::build_issue_prompt(issue.number, &issue.title, &issue.url, background)
+    // Build initial prompt: explicit prompt takes priority, then GitHub issue context
+    let initial_prompt = initial_prompt.or_else(|| {
+        github_issue.as_ref().map(|issue| {
+            crate::session_args::build_issue_prompt(issue.number, &issue.title, &issue.url, background)
+        })
     });
 
     // Save session config

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,6 @@
   import { onMount } from "svelte";
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
-  import { listen } from "@tauri-apps/api/event";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import Sidebar from "./lib/Sidebar.svelte";
   import TerminalManager from "./lib/TerminalManager.svelte";
@@ -185,45 +184,23 @@
     }
 
     try {
-      // 1. Capture screenshot of the app window → clipboard
+      // 1. Capture screenshot of the app window
       showToast("Capturing screenshot...", "info");
       const screenshotPath: string = await invoke("capture_app_screenshot");
 
       // Open in Preview so user can verify the capture (fire-and-forget)
       import("@tauri-apps/plugin-opener").then(({ openPath }) => openPath(screenshotPath));
 
-      // 2. Create a new session
+      // 2. Create a new session with initial prompt referencing the screenshot file.
+      // Claude Code can read image files directly via its Read tool — no need for
+      // clipboard tricks or idle-hook timing.
       const sessionId: string = await invoke("create_session", {
         projectId,
         kind: "claude",
+        initialPrompt: `I just took a screenshot of the app. The screenshot is saved at: ${screenshotPath}\nPlease read the screenshot image and help me with what you see.`,
       });
-
-      // 3. Register idle listener IMMEDIATELY after session creation.
-      // create_session is synchronous (blocks main thread) while Claude Code
-      // starts in tmux — if worktree creation is slow, Claude may already be
-      // idle by the time JS resumes. Registering the listener before any other
-      // async work ensures we catch events queued during the blocked period.
-      let done = false;
-      let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      const unlisten = await listen<string>(`session-status-hook:${sessionId}`, (event) => {
-        if (event.payload !== "idle" || done) return;
-        done = true;
-        if (timeoutId) clearTimeout(timeoutId);
-        unlisten();
-        // Send bracket paste to trigger Claude Code's clipboard image reader
-        showToast(`Idle hook fired for ${sessionId}, sending bracket paste`, "info");
-        invoke("write_to_pty", { sessionId, data: "\x1b[200~\x1b[201~" });
-      });
-
-      timeoutId = setTimeout(() => {
-        if (done) return;
-        done = true;
-        unlisten();
-      }, 30000);
 
       await activateNewSession(sessionId, projectId);
-
-      // 4. Focus the terminal
       focusTerminalSoon();
     } catch (e) {
       showToast(String(e), "error");

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, waitFor } from "@testing-library/svelte";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import {
   activeSessionId,
   appConfig,
@@ -19,7 +18,6 @@ import {
 const mocks = vi.hoisted(() => ({
   openPath: vi.fn(),
   setTitle: vi.fn(),
-  unlisten: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
@@ -78,15 +76,7 @@ describe("App screenshot flow", () => {
     expandedProjects.set(new Set());
   });
 
-  it("listens for direct idle hook for newly created screenshot session and pastes on idle", async () => {
-    let idleHookCallback: ((event: { payload: string }) => void) | null = null;
-    vi.mocked(listen).mockImplementation(async (eventName: string, callback: unknown) => {
-      if (eventName === "session-status-hook:sess-new") {
-        idleHookCallback = callback as (event: { payload: string }) => void;
-      }
-      return mocks.unlisten;
-    });
-
+  it("creates session with initial prompt referencing screenshot file", async () => {
     vi.mocked(invoke).mockImplementation(async (cmd: string) => {
       if (cmd === "restore_sessions") return;
       if (cmd === "check_onboarding") return { projects_root: "/tmp/projects" };
@@ -119,22 +109,11 @@ describe("App screenshot flow", () => {
 
     await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith("capture_app_screenshot");
-      expect(invoke).toHaveBeenCalledWith("create_session", { projectId: "proj-1", kind: "claude" });
+      expect(invoke).toHaveBeenCalledWith("create_session", expect.objectContaining({
+        projectId: "proj-1",
+        kind: "claude",
+        initialPrompt: expect.stringContaining("/tmp/the-controller-screenshot.png"),
+      }));
     });
-
-    await waitFor(() => {
-      expect(listen).toHaveBeenCalledWith("session-status-hook:sess-new", expect.any(Function));
-    });
-
-    expect(idleHookCallback).not.toBeNull();
-    idleHookCallback!({ payload: "idle" });
-
-    await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith("write_to_pty", {
-        sessionId: "sess-new",
-        data: "\x1b[200~\x1b[201~",
-      });
-    });
-    expect(mocks.unlisten).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Replace idle-hook + bracket-paste mechanism with `initial_prompt` parameter for screenshot sessions
- Add `initial_prompt: Option<String>` to `create_session` Tauri command (falls back to github issue prompt when not provided)
- Claude Code reads the screenshot image file directly via its Read tool — no clipboard race conditions

## Context

The screenshot-to-session flow had an unfixable race condition: `create_session` blocks the main thread, and the idle event fires before the JS listener can register. Three previous fix attempts (`a4d6f8c`, `d284d59`, `eb9a9e8`) all tried to fix the timing — this PR changes the approach entirely.

Follow-up cleanup tracked in #158.

## Test plan

- [ ] All 145 Rust tests pass
- [ ] All 122 frontend tests pass
- [ ] Press Cmd+S to capture screenshot — new session should start with prompt referencing the screenshot file
- [ ] Existing session creation flows (with/without GitHub issues) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)