### PR TITLE
fix: swap priority button order and use full labels

### DIFF
--- a/src/lib/CreateIssueModal.svelte
+++ b/src/lib/CreateIssueModal.svelte
@@ -68,8 +68,8 @@
     {:else}
       <div class="title-preview">{title}</div>
       <div class="priority-prompt">
-        <span class="priority-key high">k</span> High
-        <span class="priority-key low">j</span> Low
+        <span class="priority-key low">j</span> Low Priority
+        <span class="priority-key high">k</span> High Priority
       </div>
       <div class="hint">Press Esc to go back</div>
     {/if}


### PR DESCRIPTION
## Summary
- Swaps low/high priority options in issue creation modal so low is on the left and high is on the right
- Changes labels from "High"/"Low" to "High Priority"/"Low Priority"

## Test plan
- [ ] Open issue creation modal, enter a title, press Enter
- [ ] Verify "Low Priority" appears on the left, "High Priority" on the right
- [ ] Verify j/k keybindings still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)