### PR TITLE
fix: restore focus after backend-initiated session cleanup

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -209,8 +209,14 @@
 
         // Cleanup: backend already deleted the session and worktree, just refresh.
         listen<string>(`session-cleanup:${session.id}`, () => {
+          const nextFocus = focusAfterSessionDelete(projectList, project.id, session.id, isArchiveView);
           clearSessionTracking(session.id);
-          activeSessionId.update(current => current === session.id ? null : current);
+          activeSessionId.update(current => {
+            if (current !== session.id) return current;
+            if (nextFocus?.type === "session") return nextFocus.sessionId;
+            return null;
+          });
+          focusTarget.set(nextFocus);
           refreshProjectLists();
         }).then(unlisten => { if (!cancelled) unlisteners.push(unlisten); else unlisten(); });
 


### PR DESCRIPTION
## Summary
- After a merge completes and the backend cleans up a session, the `session-cleanup` handler now computes a next focus target (mirroring user-initiated deletion)
- Sets `activeSessionId` to a sibling session instead of unconditionally nulling it
- Updates `focusTarget` so DOM focus moves to the next sidebar item, restoring keyboard input capture

## Test plan
- [x] Existing frontend tests pass (9/10, 1 pre-existing failure in App.test.ts)
- [x] Rust tests pass
- [ ] Manual: trigger a merge via `m` hotkey, verify focus moves to sibling session after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)