### PR TITLE
fix: use initialPrompt for screenshot sessions with wait instruction

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,6 @@
   import { onMount } from "svelte";
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
-  import { listen } from "@tauri-apps/api/event";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import Sidebar from "./lib/Sidebar.svelte";
   import TerminalManager from "./lib/TerminalManager.svelte";
@@ -192,27 +191,16 @@
       // Open in Preview so user can verify the capture (fire-and-forget)
       import("@tauri-apps/plugin-opener").then(({ openPath }) => openPath(screenshotPath));
 
-      // 2. Create a new session without initial prompt — we'll paste into
-      // the input once Claude is ready so the user can add context first.
+      // 2. Create a new session with initial prompt referencing the screenshot file.
+      // Tell Claude to share the path and wait for further instructions.
       const sessionId: string = await invoke("create_session", {
         projectId,
         kind: "claude",
+        initialPrompt: `I just took a screenshot of the app. The screenshot is saved at: ${screenshotPath}\nPlease read the screenshot image and share what you see, but wait for further prompts before taking any action.`,
       });
 
       await activateNewSession(sessionId, projectId);
       focusTerminalSoon();
-
-      // 3. Wait for Claude to become idle (ready for input), then paste
-      // the screenshot reference. The user can type what they expected
-      // before pressing Enter.
-      const prompt = `I just took a screenshot of the app. The screenshot is saved at: ${screenshotPath}\nPlease read the screenshot image and help me with what you see.\n\n`;
-      const unlisten = await listen<string>(`session-status-hook:${sessionId}`, (event) => {
-        if (event.payload === "idle") {
-          unlisten();
-          // Bracket-paste so it lands as a single chunk in Claude's input
-          invoke("write_to_pty", { sessionId, data: `\x1b[200~${prompt}\x1b[201~` });
-        }
-      });
     } catch (e) {
       showToast(String(e), "error");
     }


### PR DESCRIPTION
## Summary
- Revert bracket-paste approach for screenshot sessions which wasn't sending prompts reliably
- Use `initialPrompt` on `create_session` instead, telling Claude to describe the screenshot but wait for further instructions before acting
- Remove unused `listen` import

## Test plan
- [x] Frontend tests pass (122/122)
- [x] Rust tests pass (13/13)
- [ ] Manual: take screenshot with Cmd+S, verify Claude reads the image and waits for instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)