### PR TITLE
feat: add cropped screenshot and optional preview hotkeys

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -908,8 +908,8 @@ pub async fn copy_image_file_to_clipboard(app: AppHandle, path: String) -> Resul
 }
 
 #[tauri::command]
-pub async fn capture_app_screenshot(app: AppHandle) -> Result<String, String> {
-    media::capture_app_screenshot(app).await
+pub async fn capture_app_screenshot(app: AppHandle, cropped: bool) -> Result<String, String> {
+    media::capture_app_screenshot(app, cropped).await
 }
 
 const MAX_MERGE_RETRIES: u32 = 5;

--- a/src-tauri/src/commands/media.rs
+++ b/src-tauri/src/commands/media.rs
@@ -27,10 +27,11 @@ pub(crate) async fn copy_image_file_to_clipboard(
         .map_err(|e| format!("Failed to write image to clipboard: {e}"))
 }
 
-/// Capture a screenshot of the app window and copy it to the system clipboard.
-/// Uses macOS `screencapture` with the window ID obtained from the NSWindow.
+/// Capture a screenshot and copy it to the system clipboard.
+/// When `cropped` is false, captures the app window using the window ID.
+/// When `cropped` is true, launches interactive crop selection via `screencapture -i`.
 /// Returns the path to the screenshot file so the caller can preview it.
-pub(crate) async fn capture_app_screenshot(app: AppHandle) -> Result<String, String> {
+pub(crate) async fn capture_app_screenshot(app: AppHandle, cropped: bool) -> Result<String, String> {
     #[cfg(not(target_os = "macos"))]
     return Err("Screenshot capture is only supported on macOS".into());
 
@@ -39,34 +40,46 @@ pub(crate) async fn capture_app_screenshot(app: AppHandle) -> Result<String, Str
         use raw_window_handle::{HasWindowHandle, RawWindowHandle};
         use tauri_plugin_clipboard_manager::ClipboardExt;
 
-        let window = app
-            .get_webview_window("main")
-            .ok_or("No main window found")?;
-
-        let window_id = {
-            let handle = window.window_handle().map_err(|e| e.to_string())?;
-            match handle.as_raw() {
-                RawWindowHandle::AppKit(appkit) => {
-                    let ns_view = appkit.ns_view.as_ptr() as *mut std::ffi::c_void;
-                    unsafe { macos_window_number(ns_view) }
-                }
-                _ => return Err("Not a macOS window".into()),
-            }
-        };
-
         let tmp_path = std::env::temp_dir().join("the-controller-screenshot.png");
         let tmp_str = tmp_path.to_str().ok_or("Invalid temp path")?.to_string();
 
-        let status = tokio::task::spawn_blocking({
-            let tmp_str = tmp_str.clone();
-            move || {
-                std::process::Command::new("screencapture")
-                    .arg("-x")
-                    .arg(format!("-l{}", window_id))
-                    .arg(&tmp_str)
-                    .status()
-            }
-        })
+        let status = if cropped {
+            tokio::task::spawn_blocking({
+                let tmp_str = tmp_str.clone();
+                move || {
+                    std::process::Command::new("screencapture")
+                        .arg("-i")
+                        .arg(&tmp_str)
+                        .status()
+                }
+            })
+        } else {
+            let window = app
+                .get_webview_window("main")
+                .ok_or("No main window found")?;
+
+            let window_id = {
+                let handle = window.window_handle().map_err(|e| e.to_string())?;
+                match handle.as_raw() {
+                    RawWindowHandle::AppKit(appkit) => {
+                        let ns_view = appkit.ns_view.as_ptr() as *mut std::ffi::c_void;
+                        unsafe { macos_window_number(ns_view) }
+                    }
+                    _ => return Err("Not a macOS window".into()),
+                }
+            };
+
+            tokio::task::spawn_blocking({
+                let tmp_str = tmp_str.clone();
+                move || {
+                    std::process::Command::new("screencapture")
+                        .arg("-x")
+                        .arg(format!("-l{}", window_id))
+                        .arg(&tmp_str)
+                        .status()
+                }
+            })
+        }
         .await
         .map_err(|e| format!("Task failed: {e}"))?
         .map_err(|e| format!("Failed to run screencapture: {e}"))?;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -40,7 +40,7 @@
       } else if (action?.type === "pick-issue-for-session") {
         issuePickerTarget = { projectId: action.projectId, repoPath: action.repoPath, kind: action.kind, background: action.background };
       } else if (action?.type === "screenshot-to-session") {
-        screenshotToNewSession();
+        screenshotToNewSession(action.preview ?? false, action.cropped ?? false);
       } else if (action?.type === "toggle-maintainer-panel") {
         maintainerPanelVisible.update(v => !v);
       } else if (action?.type === "toggle-maintainer-enabled") {
@@ -172,7 +172,7 @@
     }
   }
 
-  async function screenshotToNewSession() {
+  async function screenshotToNewSession(preview: boolean, cropped: boolean) {
     // Determine project from current focus or active session
     const projectId = focusTargetState.current?.projectId
       ?? projectsState.current.find((p) => p.sessions.some((s) => s.id === activeSessionIdState.current))?.id
@@ -184,12 +184,14 @@
     }
 
     try {
-      // 1. Capture screenshot of the app window
-      showToast("Capturing screenshot...", "info");
-      const screenshotPath: string = await invoke("capture_app_screenshot");
+      // 1. Capture screenshot
+      showToast(cropped ? "Select area to capture..." : "Capturing screenshot...", "info");
+      const screenshotPath: string = await invoke("capture_app_screenshot", { cropped });
 
-      // Open in Preview so user can verify the capture (fire-and-forget)
-      import("@tauri-apps/plugin-opener").then(({ openPath }) => openPath(screenshotPath));
+      // Open in Preview only when preview is requested
+      if (preview) {
+        import("@tauri-apps/plugin-opener").then(({ openPath }) => openPath(screenshotPath));
+      }
 
       // 2. Create a new session with initial prompt referencing the screenshot file.
       // Tell Claude to share the path and wait for further instructions.

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -76,7 +76,7 @@ describe("App screenshot flow", () => {
     expandedProjects.set(new Set());
   });
 
-  it("creates session with initial prompt referencing screenshot file", async () => {
+  function setupMocks() {
     vi.mocked(invoke).mockImplementation(async (cmd: string) => {
       if (cmd === "restore_sessions") return;
       if (cmd === "check_onboarding") return { projects_root: "/tmp/projects" };
@@ -103,17 +103,56 @@ describe("App screenshot flow", () => {
       }
       return;
     });
+  }
 
+  it("Cmd+S: captures screenshot without preview", async () => {
+    setupMocks();
     render(App);
     hotkeyAction.set({ type: "screenshot-to-session" });
 
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith("capture_app_screenshot");
+      expect(invoke).toHaveBeenCalledWith("capture_app_screenshot", { cropped: false });
       expect(invoke).toHaveBeenCalledWith("create_session", expect.objectContaining({
         projectId: "proj-1",
         kind: "claude",
         initialPrompt: expect.stringContaining("/tmp/the-controller-screenshot.png"),
       }));
+    });
+
+    expect(mocks.openPath).not.toHaveBeenCalled();
+  });
+
+  it("Cmd+Shift+S: captures screenshot with preview", async () => {
+    setupMocks();
+    render(App);
+    hotkeyAction.set({ type: "screenshot-to-session", preview: true });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("capture_app_screenshot", { cropped: false });
+      expect(mocks.openPath).toHaveBeenCalledWith("/tmp/the-controller-screenshot.png");
+    });
+  });
+
+  it("Cmd+D: captures cropped screenshot without preview", async () => {
+    setupMocks();
+    render(App);
+    hotkeyAction.set({ type: "screenshot-to-session", cropped: true });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("capture_app_screenshot", { cropped: true });
+    });
+
+    expect(mocks.openPath).not.toHaveBeenCalled();
+  });
+
+  it("Cmd+Shift+D: captures cropped screenshot with preview", async () => {
+    setupMocks();
+    render(App);
+    hotkeyAction.set({ type: "screenshot-to-session", preview: true, cropped: true });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("capture_app_screenshot", { cropped: true });
+      expect(mocks.openPath).toHaveBeenCalledWith("/tmp/the-controller-screenshot.png");
     });
   });
 });

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -340,7 +340,7 @@
       case "b":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;
-      // Cmd+S (screenshot) is handled earlier in onKeydown
+      // Cmd+S/D (screenshot) is handled earlier in onKeydown
       case "?":
         dispatchAction({ type: "toggle-help" });
         return true;
@@ -353,11 +353,16 @@
     // Ignore modifier-only keypresses
     if (["Shift", "Control", "Alt", "Meta"].includes(e.key)) return;
 
-    // Cmd+S: screenshot (works from any context, including terminal)
-    if (e.metaKey && e.key === "s") {
+    // Cmd+S/Cmd+Shift+S: full window screenshot (shift = preview)
+    // Cmd+D/Cmd+Shift+D: cropped screenshot (shift = preview)
+    if (e.metaKey && (e.key === "s" || e.key === "d")) {
       e.stopPropagation();
       e.preventDefault();
-      dispatchAction({ type: "screenshot-to-session" });
+      dispatchAction({
+        type: "screenshot-to-session",
+        preview: e.shiftKey,
+        cropped: e.key === "d",
+      });
       return;
     }
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -88,7 +88,7 @@ export type HotkeyAction =
   | { type: "pick-issue-for-session"; projectId: string; repoPath: string; kind?: string; background?: boolean }
   | { type: "merge-session"; sessionId: string; projectId: string }
   | { type: "finish-branch"; sessionId: string; kind?: string }
-  | { type: "screenshot-to-session" }
+  | { type: "screenshot-to-session"; preview?: boolean; cropped?: boolean }
   | { type: "toggle-maintainer-panel" }
   | { type: "toggle-maintainer-enabled" }
   | { type: "toggle-triage-panel" }


### PR DESCRIPTION
## Summary
- **Cmd+S**: full window screenshot, no preview (was: full screenshot with preview)
- **Cmd+Shift+S**: full window screenshot, with preview
- **Cmd+D**: interactive cropped screenshot (`screencapture -i`), no preview
- **Cmd+Shift+D**: interactive cropped screenshot, with preview

## Changes
- Added `cropped` parameter to `capture_app_screenshot` Rust command — uses `screencapture -i` for interactive crop selection
- Extended `screenshot-to-session` hotkey action with `preview` and `cropped` flags
- Updated HotkeyManager to dispatch all 4 combinations
- Preview (opening in Preview.app) is now opt-in via Shift modifier

## Test plan
- [x] 4 new test cases covering each hotkey combination
- [x] All 125 frontend tests pass
- [x] All 13 Rust tests pass
- [x] Cargo check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)