### PR TITLE
refactor: move maintainer status from sidebar dot to panel text

### DIFF
--- a/src/lib/MaintainerPanel.svelte
+++ b/src/lib/MaintainerPanel.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
-  import { focusTarget, projects, type Project, type FocusTarget, type MaintainerReport } from "./stores";
+  import { focusTarget, projects, maintainerStatuses, type Project, type FocusTarget, type MaintainerReport, type MaintainerStatus } from "./stores";
   import { showToast } from "./toast";
 
   let report: MaintainerReport | null = $state(null);
@@ -98,6 +98,12 @@
     return () => clearInterval(id);
   });
 
+  const maintainerStatusesState = fromStore(maintainerStatuses);
+  let maintainerStatusMap: Map<string, MaintainerStatus> = $derived(maintainerStatusesState.current);
+  let maintainerStatus: MaintainerStatus | null = $derived(
+    project ? (maintainerStatusMap.get(project.id) ?? null) : null
+  );
+
   function severityColor(severity: string): string {
     switch (severity) {
       case "error": return "#f38ba8";
@@ -117,6 +123,11 @@
 <aside class="maintainer-panel">
   <div class="panel-header">
     <span class="panel-title">Maintainer</span>
+    {#if maintainerStatus && maintainerStatus !== "idle"}
+      <span class="maintainer-status" class:passing={maintainerStatus === "passing"} class:warnings={maintainerStatus === "warnings"} class:failing={maintainerStatus === "failing"} class:running={maintainerStatus === "running"} class:error={maintainerStatus === "error"}>
+        {#if maintainerStatus === "running"}Running…{:else if maintainerStatus === "passing"}Passing{:else if maintainerStatus === "warnings"}Warnings{:else if maintainerStatus === "failing"}Failing{:else if maintainerStatus === "error"}Error{/if}
+      </span>
+    {/if}
     {#if project}
       <button class="btn-toggle" class:enabled={project.maintainer.enabled} onclick={toggleMaintainer}>
         {project.maintainer.enabled ? "ON" : "OFF"}
@@ -281,6 +292,20 @@
   .finding-category { color: #89b4fa; font-size: 11px; }
   .finding-desc { color: #cdd6f4; }
   .finding-action { color: #6c7086; font-size: 11px; font-style: italic; }
+
+  .maintainer-status {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 1px 6px;
+    border-radius: 4px;
+    color: #6c7086;
+  }
+
+  .maintainer-status.passing { color: #a6e3a1; }
+  .maintainer-status.warnings { color: #f9e2af; }
+  .maintainer-status.failing { color: #f38ba8; }
+  .maintainer-status.error { color: #f38ba8; }
+  .maintainer-status.running { color: #89b4fa; }
 
   .panel-actions {
     padding: 12px 16px;

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
-  import { projects, activeSessionId, sessionStatuses, maintainerStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, type Project, type JumpPhase, type FocusTarget, type SessionStatus, type MaintainerStatus } from "./stores";
+  import { projects, activeSessionId, sessionStatuses, maintainerStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, type Project, type JumpPhase, type FocusTarget, type SessionStatus } from "./stores";
   import { showToast } from "./toast";
   import { focusAfterSessionDelete, focusAfterProjectDelete } from "./focus-helpers";
   import FuzzyFinder from "./FuzzyFinder.svelte";
@@ -450,12 +450,6 @@
     return statuses.get(sessionId) ?? "idle";
   }
 
-  const maintainerStatusesState = fromStore(maintainerStatuses);
-  let maintainerStatusMap: Map<string, MaintainerStatus> = $derived(maintainerStatusesState.current);
-
-  function getMaintainerStatus(projectId: string): MaintainerStatus | null {
-    return maintainerStatusMap.get(projectId) ?? null;
-  }
 
 </script>
 
@@ -474,7 +468,6 @@
       jumpState={jumpState}
       {projectJumpLabels}
       {getSessionStatus}
-      {getMaintainerStatus}
       onToggleProject={toggleProject}
       onProjectFocus={(projectId) => {
         focusTarget.set({ type: "project", projectId });

--- a/src/lib/sidebar/ProjectTree.svelte
+++ b/src/lib/sidebar/ProjectTree.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { FocusTarget, JumpPhase, MaintainerStatus, Project, SessionStatus } from "../stores";
+  import type { FocusTarget, JumpPhase, Project, SessionStatus } from "../stores";
 
   interface Props {
     projects: Project[];
@@ -10,7 +10,6 @@
     jumpState: JumpPhase;
     projectJumpLabels: string[];
     getSessionStatus: (sessionId: string) => SessionStatus;
-    getMaintainerStatus: (projectId: string) => MaintainerStatus | null;
     onToggleProject: (projectId: string) => void;
     onProjectFocus: (projectId: string) => void;
     onSessionFocus: (sessionId: string, projectId: string) => void;
@@ -26,7 +25,6 @@
     jumpState,
     projectJumpLabels,
     getSessionStatus,
-    getMaintainerStatus,
     onToggleProject,
     onProjectFocus,
     onSessionFocus,
@@ -45,7 +43,6 @@
     {@const visibleSessions = isArchivedMode()
       ? project.sessions.filter((s) => s.archived)
       : project.sessions.filter((s) => !s.archived)}
-    {@const maintainerStatus = getMaintainerStatus(project.id)}
     <div class="project-item">
       <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -66,16 +63,6 @@
           <kbd class="jump-label">{projectJumpLabels[i]}</kbd>
         {/if}
         <span class="session-count">{visibleSessions.length}</span>
-        {#if maintainerStatus && maintainerStatus !== "idle"}
-          <span
-            class="maintainer-dot"
-            class:passing={maintainerStatus === "passing"}
-            class:warnings={maintainerStatus === "warnings"}
-            class:failing={maintainerStatus === "failing"}
-            class:running={maintainerStatus === "running"}
-            title="Maintainer: {maintainerStatus}"
-          ></span>
-        {/if}
       </div>
 
       {#if expandedProjectSet.has(project.id)}
@@ -267,35 +254,6 @@
     margin-left: auto;
   }
 
-  .maintainer-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #6c7086;
-    flex-shrink: 0;
-  }
-
-  .maintainer-dot.passing {
-    background: #a6e3a1;
-  }
-
-  .maintainer-dot.warnings {
-    background: #f9e2af;
-  }
-
-  .maintainer-dot.failing {
-    background: #f38ba8;
-  }
-
-  .maintainer-dot.running {
-    background: #89b4fa;
-    animation: pulse 1.5s ease-in-out infinite;
-  }
-
-  @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
-  }
 
   .empty-state {
     padding: 24px 16px;

--- a/src/lib/sidebar/ProjectTree.test.ts
+++ b/src/lib/sidebar/ProjectTree.test.ts
@@ -68,7 +68,6 @@ describe("ProjectTree", () => {
       jumpState: { phase: "project" } as JumpPhase,
       projectJumpLabels: ["z"],
       getSessionStatus: (id: string) => statuses.get(id) ?? "idle",
-      getMaintainerStatus: () => null,
       onToggleProject,
       onProjectFocus,
       onSessionFocus,


### PR DESCRIPTION
## Summary
- Removed the colored maintainer status dot from the sidebar project row
- Added explicit text status label ("Running…", "Passing", "Warnings", "Failing", "Error") to the MaintainerPanel header with color coding
- Cleaned up unused `getMaintainerStatus` prop from ProjectTree component

## Test plan
- [x] All 122 frontend tests pass
- [x] All 13 Rust tests pass
- [ ] Visual: sidebar no longer shows maintainer dot next to project name
- [ ] Visual: MaintainerPanel header shows colored text status when maintainer is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)