### PR TITLE
feat: categorize keyboard shortcuts help panel into sections

### DIFF
--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -7,31 +7,54 @@
 
   let { onClose }: Props = $props();
 
-  const shortcuts: { key: string; description: string }[] = [
-    { key: "j / k", description: "Next / previous item (project or session)" },
-    { key: "J / K", description: "Next / previous project (skip sessions)" },
-    { key: "l / Enter", description: "Expand/collapse project or focus terminal" },
-    { key: "g", description: "Go to project / session (jump mode)" },
-    { key: "c", description: "Create Claude session with issue" },
-    { key: "x", description: "Create Codex session with issue" },
-    { key: "C", description: "Background worker: Claude (autonomous)" },
-    { key: "X", description: "Background worker: Codex (autonomous)" },
-    { key: "d", description: "Delete focused item (session or project)" },
-    { key: "a", description: "Archive focused item (session or project)" },
-    { key: "A", description: "View archived projects" },
-    { key: "m", description: "Merge session branch (create PR)" },
-    { key: "f", description: "Find project (fuzzy finder)" },
-    { key: "n", description: "New project" },
-    { key: "s", description: "Toggle sidebar" },
-    { key: "t", description: "Triage issues (untagged + low priority)" },
-    { key: "T", description: "Triage issues (pick category)" },
-    { key: "i", description: "Create GitHub issue for focused project" },
-    { key: "⌘S", description: "Screenshot app → new session with image" },
-    { key: "b", description: "Toggle background agent panel" },
-    { key: "o", description: "Toggle maintainer on/off (when panel open)" },
-    { key: "r", description: "Run maintainer check now (when panel open)" },
-    { key: "Esc", description: "Move focus up (terminal → session → project)" },
-    { key: "?", description: "Toggle this help" },
+  interface Shortcut { key: string; description: string }
+  interface Section { label: string; shortcuts: Shortcut[] }
+
+  const sections: Section[] = [
+    {
+      label: "Navigation",
+      shortcuts: [
+        { key: "j / k", description: "Next / previous item (project or session)" },
+        { key: "J / K", description: "Next / previous project (skip sessions)" },
+        { key: "l / Enter", description: "Expand/collapse project or focus terminal" },
+        { key: "g", description: "Go to project / session (jump mode)" },
+        { key: "f", description: "Find project (fuzzy finder)" },
+        { key: "Esc", description: "Move focus up (terminal → session → project)" },
+      ],
+    },
+    {
+      label: "Sessions",
+      shortcuts: [
+        { key: "c", description: "Create Claude session with issue" },
+        { key: "x", description: "Create Codex session with issue" },
+        { key: "C", description: "Background worker: Claude (autonomous)" },
+        { key: "X", description: "Background worker: Codex (autonomous)" },
+        { key: "m", description: "Merge session branch (create PR)" },
+        { key: "⌘S", description: "Screenshot app → new session with image" },
+      ],
+    },
+    {
+      label: "Projects",
+      shortcuts: [
+        { key: "n", description: "New project" },
+        { key: "d", description: "Delete focused item (session or project)" },
+        { key: "a", description: "Archive focused item (session or project)" },
+        { key: "A", description: "View archived projects" },
+        { key: "i", description: "Create GitHub issue for focused project" },
+        { key: "t", description: "Triage issues (untagged + low priority)" },
+        { key: "T", description: "Triage issues (pick category)" },
+      ],
+    },
+    {
+      label: "Panels",
+      shortcuts: [
+        { key: "s", description: "Toggle sidebar" },
+        { key: "b", description: "Toggle background agent panel" },
+        { key: "o", description: "Toggle maintainer on/off (when panel open)" },
+        { key: "r", description: "Run maintainer check now (when panel open)" },
+        { key: "?", description: "Toggle this help" },
+      ],
+    },
   ];
 
   function handleKeydown(e: KeyboardEvent) {
@@ -55,22 +78,23 @@
   <div class="modal" onclick={(e) => e.stopPropagation()} role="presentation">
     <div class="modal-header">Keyboard Shortcuts</div>
     <p class="subtitle">Keys work directly. Press Escape first when terminal is focused.</p>
-    <table class="shortcut-table">
-      <thead>
-        <tr>
-          <th class="col-key">Key</th>
-          <th class="col-desc">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each shortcuts as { key, description }}
-          <tr>
-            <td class="key-cell"><kbd>{key}</kbd></td>
-            <td class="desc-cell">{description}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+    <div class="sections-grid">
+      {#each sections as section}
+        <div class="section">
+          <div class="section-label">{section.label}</div>
+          <table class="shortcut-table">
+            <tbody>
+              {#each section.shortcuts as { key, description }}
+                <tr>
+                  <td class="key-cell"><kbd>{key}</kbd></td>
+                  <td class="desc-cell">{description}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/each}
+    </div>
   </div>
 </div>
 
@@ -89,11 +113,13 @@
     background: #1e1e2e;
     border: 1px solid #313244;
     border-radius: 8px;
-    width: 420px;
+    width: 720px;
+    max-height: 70vh;
     padding: 24px;
     display: flex;
     flex-direction: column;
     gap: 12px;
+    overflow-y: auto;
   }
   .modal-header {
     font-size: 16px;
@@ -105,22 +131,27 @@
     font-size: 13px;
     margin: 0;
   }
+  .sections-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+  .section-label {
+    color: #a6adc8;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0 8px 6px;
+    border-bottom: 1px solid #313244;
+    margin-bottom: 2px;
+  }
   .shortcut-table {
     width: 100%;
     border-collapse: collapse;
   }
-  .shortcut-table th {
-    text-align: left;
-    color: #6c7086;
-    font-size: 11px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 6px 8px;
-    border-bottom: 1px solid #313244;
-  }
   .shortcut-table td {
-    padding: 7px 8px;
+    padding: 5px 8px;
   }
   .shortcut-table tr:not(:last-child) td {
     border-bottom: 1px solid rgba(49, 50, 68, 0.5);


### PR DESCRIPTION
## Summary
- Group shortcuts into 4 categories: Navigation, Sessions, Projects, and Panels
- Use 2-column grid layout so all sections are visible at once
- Widen modal from 420px to 720px with max-height overflow safety

## Test plan
- [x] Frontend tests pass (122 tests)
- [x] Rust tests pass (13 tests)
- [ ] Open app, press `?` to verify categorized layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)