### PR TITLE
fix: show individually archived sessions in archive view

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -329,7 +329,10 @@ pub fn delete_project(
 pub fn list_archived_projects(state: State<AppState>) -> Result<Vec<Project>, String> {
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
     let projects = storage.list_projects().map_err(|e| e.to_string())?;
-    Ok(projects.into_iter().filter(|p| p.archived).collect())
+    Ok(projects
+        .into_iter()
+        .filter(|p| p.archived || p.sessions.iter().any(|s| s.archived))
+        .collect())
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- `list_archived_projects` only returned projects where `project.archived == true`
- Sessions archived individually within an active project were invisible — filtered out of the active view (by `!s.archived`) and missing from the archive view (project not included)
- Fixed the filter to also include projects that have any archived sessions

## Test plan
- [x] All 132 Rust tests pass
- [ ] Archive a single session in an active project, switch to Archives tab, verify it appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)