### PR TITLE
fix: deadlock in handle_cleanup lock ordering

### DIFF
--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -80,6 +80,7 @@ fn handle_connection(stream: UnixStream, app_handle: &AppHandle) {
                 if let Some((status, session_id)) = parse_status_message(msg) {
                     if status == "cleanup" {
                         handle_cleanup(app_handle, session_id);
+                        return; // close connection immediately
                     } else {
                         let event_name = format!("session-status-hook:{}", session_id);
                         if let Err(e) = app_handle.emit(&event_name, status) {
@@ -107,12 +108,10 @@ fn handle_cleanup(app_handle: &AppHandle, session_id: Uuid) {
         }
     };
 
-    // Close the PTY / kill tmux session
-    if let Ok(mut pty_manager) = state.pty_manager.lock() {
-        let _ = pty_manager.close_session(session_id);
-    }
-
     // Find and remove the session from its project, delete worktree
+    // IMPORTANT: acquire storage lock BEFORE pty_manager to match
+    // the lock ordering used by Tauri commands (storage → pty_manager).
+    // Reversed order causes deadlock.
     if let Ok(storage) = state.storage.lock() {
         if let Ok(mut projects) = storage.list_projects() {
             for project in &mut projects {
@@ -137,6 +136,11 @@ fn handle_cleanup(app_handle: &AppHandle, session_id: Uuid) {
                 }
             }
         }
+    }
+
+    // Close the PTY / kill tmux session (after releasing storage lock)
+    if let Ok(mut pty_manager) = state.pty_manager.lock() {
+        let _ = pty_manager.close_session(session_id);
     }
 
     // Tell the frontend to refresh its project list


### PR DESCRIPTION
## Summary

- Fix ABBA deadlock in `handle_cleanup`: was acquiring `pty_manager` then `storage`, but codebase convention is `storage` first. Concurrent Tauri commands holding `storage` and waiting for `pty_manager` caused permanent deadlock.
- Return immediately after handling cleanup message to close the socket connection, avoiding `nc` timeout

Fixes #177

## Test plan

- [x] Rust tests pass (13/13)
- [ ] Manual: run `echo "cleanup:$SESSION_ID" | nc -U -w 2 /tmp/the-controller.sock` — should exit 0 instantly and clean up the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)