### PR TITLE
fix: scroll terminal to bottom when navigating to a session

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -299,6 +299,8 @@
 
         // Force full repaint — canvas content may be stale after display:none
         term.refresh(0, term.rows - 1);
+        // Scroll to bottom so the user sees the latest output / input area
+        term.scrollToBottom();
         // Notify PTY of dimensions so the program gets SIGWINCH and redraws its TUI
         invoke("resize_pty", {
           sessionId,


### PR DESCRIPTION
## Summary
- When switching sessions, the terminal now scrolls to the bottom so the user lands at the input area instead of mid-history
- Adds `term.scrollToBottom()` in the MutationObserver visibility callback in `Terminal.svelte`

## Test plan
- [ ] Open the app with multiple sessions that have scrollback history
- [ ] Navigate between sessions using sidebar clicks or j/k hotkeys
- [ ] Verify the terminal is scrolled to the bottom each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)