### PR TITLE
fix: ignore triage hotkeys when modifier keys are held

### DIFF
--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -147,6 +147,7 @@
       return;
     }
 
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (swipeDirection) return; // animating
 
     if (step === "priority") {


### PR DESCRIPTION
## Summary
- Cmd+S (screenshot) was also triggering the `s` skip hotkey in the triage panel
- Added a guard to ignore all triage hotkeys (j/k/s/arrows) when meta/ctrl/alt modifiers are held
- Escape still works with modifiers since the guard is placed after the Escape handler

## Test plan
- [ ] Open triage panel, press Cmd+S — should not skip the current issue
- [ ] Press `s` alone — should still skip as before
- [ ] Press `j`, `k`, arrows — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)