### PR TITLE
fix: show current tag on newline in triage panel

### DIFF
--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -359,6 +359,7 @@
   }
 
   .current-tag {
+    display: block;
     font-size: 11px;
     color: #6c7086;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- Move the `(current)` tag to its own line below the priority/complexity label in the triage panel for visual uniformity

## Test plan
- [x] Open triage panel and verify `(current)` appears on a new line below the priority label
- [x] All frontend and Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)