### PR TITLE
docs: clarify npm install required for new worktrees

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -38,7 +38,8 @@ git branch -d <feature-branch>
 
 ## Dependencies
 
-After merging a branch that modifies `package.json`, run `npm install` in the project root (not the worktree). The dev server won't auto-install — missing packages cause a white screen.
+- **New worktrees:** Always run `npm install` immediately after creating a worktree. Worktrees don't share `node_modules` — without this, `npx vitest run` and the dev server will fail.
+- **After merging:** Run `npm install` in the project root (not the worktree) if `package.json` was modified. The dev server won't auto-install — missing packages cause a white screen.
 
 ## Dev Commands
 


### PR DESCRIPTION
## Summary
- Clarifies in `agents.md` (which `CLAUDE.md` symlinks to) that `npm install` must be run immediately after creating a new worktree
- Worktrees don't share `node_modules`, so without this step `npx vitest run` and the dev server fail

## Test plan
- [x] Verified `npx vitest run` fails in a fresh worktree without `npm install`
- [x] Verified all 138 frontend tests and 13 Rust tests pass after `npm install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)