### PR TITLE
fix: move summary pane to bottom-left overlay on terminal

### DIFF
--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -107,12 +107,16 @@
     flex-direction: column;
     gap: 6px;
     padding: 12px 18px;
-    background: #181825;
-    border-bottom: 1px solid #313244;
+    background: transparent;
     font-size: 18px;
-    flex-shrink: 0;
-    max-height: 540px;
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    max-width: 60%;
+    max-height: 50%;
     overflow-y: auto;
+    z-index: 10;
+    pointer-events: none;
   }
 
   .summary-row {

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -44,12 +44,12 @@
   {#each allSessions as session (session.id)}
     {@const sessionId = session.id}
     <div class="terminal-wrapper" class:visible={activeSession === sessionId}>
-      {#if focusedSessionId === sessionId}
-        <SummaryPane {sessionId} />
-      {/if}
       <div class="terminal-inner">
         <Terminal {sessionId} kind={session.kind} bind:this={terminalComponents[sessionId]} />
       </div>
+      {#if focusedSessionId === sessionId}
+        <SummaryPane {sessionId} />
+      {/if}
     </div>
   {/each}
 


### PR DESCRIPTION
## Summary
- Repositions the summary pane from a top bar above the terminal to an overlay in the bottom-left corner
- Uses transparent background so the terminal's dark background provides contrast
- Removes the pane from the flex layout flow so the terminal takes the full area

## Test plan
- [x] Frontend tests pass (138/138)
- [x] Rust tests pass (13/13)
- [ ] Visual check: summary pane appears at bottom-left of terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)