### PR TITLE
feat: add h key to go back to priority step in triage panel

### DIFF
--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -86,6 +86,11 @@
     step = "complexity";
   }
 
+  function goBackToPriority() {
+    step = "priority";
+    pendingPriority = null;
+  }
+
   async function assignComplexity(complexity: "low" | "high") {
     if (!currentIssue || !repoPath) return;
 
@@ -159,7 +164,11 @@
         assignPriority("low");
       }
     } else {
-      if (e.key === "ArrowRight" || e.key === "k") {
+      if (e.key === "h") {
+        e.preventDefault();
+        e.stopPropagation();
+        goBackToPriority();
+      } else if (e.key === "ArrowRight" || e.key === "k") {
         e.preventDefault();
         e.stopPropagation();
         assignComplexity("high");
@@ -253,6 +262,10 @@
                   <span class="ranking-label">High complexity</span>
                   {#if currentComplexityLabel === "high"}<span class="current-tag">(current)</span>{/if}
                 </span>
+              </button>
+              <button class="ranking-option back-option" onclick={() => goBackToPriority()}>
+                <span class="ranking-key">h</span>
+                <span class="ranking-label">Back</span>
               </button>
             </div>
           {/if}
@@ -365,6 +378,17 @@
     font-size: 13px;
     font-weight: 600;
     color: #cdd6f4;
+  }
+
+  .back-option {
+    margin-top: 4px;
+    border-color: transparent;
+    background: transparent;
+  }
+
+  .back-option .ranking-label {
+    color: #6c7086;
+    font-weight: 400;
   }
 
   .current-tag {


### PR DESCRIPTION
## Summary
- Adds `h` key binding in the triage panel's complexity step to go back to the priority step
- Adds a subtle "Back" button in the ranking panel UI when on the complexity step
- Allows users to change their priority selection before committing

## Test plan
- [x] Frontend tests pass (138/138)
- [x] Rust tests pass (13/13)
- [ ] Manual: open triage panel, select a priority, verify pressing `h` returns to priority step
- [ ] Manual: verify clicking the "Back" button also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)