### PR TITLE
fix: remove CLAUDECODE env var in maintainer health check

### DIFF
--- a/docs/domain-knowledge.md
+++ b/docs/domain-knowledge.md
@@ -59,6 +59,7 @@ Affected locations:
 - `src-tauri/src/tmux.rs` — `create_session` (removes CLAUDECODE for tmux-backed sessions)
 - `src-tauri/src/pty_manager.rs` — `spawn_command` (removes CLAUDECODE for direct commands)
 - `src-tauri/src/config.rs` — `check_claude_cli_status`, `generate_names_via_cli`
+- `src-tauri/src/maintainer.rs` — `run_health_check` (removes CLAUDECODE for health check subprocess)
 
 ## Session Status Detection via Hooks
 

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -232,6 +232,7 @@ pub fn run_health_check(repo_path: &str, project_id: Uuid) -> Result<MaintainerR
         .arg("--print")
         .arg(&prompt)
         .current_dir(repo_path)
+        .env_remove("CLAUDECODE")
         .output()
         .map_err(|e| format!("Failed to run claude --print: {}", e))?;
 


### PR DESCRIPTION
## Summary
- Added `.env_remove("CLAUDECODE")` to `run_health_check()` in `maintainer.rs` to prevent nested Claude session errors when running maintainer checks
- Updated `docs/domain-knowledge.md` to list `maintainer.rs` as an affected location for the CLAUDECODE env var pattern

## Root cause
The `run_health_check` function was the only `Command::new("claude")` call site missing `.env_remove("CLAUDECODE")`. When the app runs within a Claude context, the inherited `CLAUDECODE` env var causes `claude --print` to fail with "cannot be launched inside another Claude Code session".

## Test plan
- [x] `cargo test` — all Rust tests pass (0 failures)
- [x] `npx vitest run` — all 138 frontend tests pass
- [x] Verified fix matches pattern used in all 6 other call sites (tmux.rs, pty_manager.rs, config.rs, github.rs)

closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)