### PR TITLE
revert: move summary pane back to top bar above terminal

### DIFF
--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -107,16 +107,12 @@
     flex-direction: column;
     gap: 6px;
     padding: 12px 18px;
-    background: transparent;
+    background: #181825;
+    border-bottom: 1px solid #313244;
     font-size: 18px;
-    position: absolute;
-    bottom: 8px;
-    left: 8px;
-    max-width: 60%;
-    max-height: 50%;
+    flex-shrink: 0;
+    max-height: 540px;
     overflow-y: auto;
-    z-index: 10;
-    pointer-events: none;
   }
 
   .summary-row {

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -44,12 +44,12 @@
   {#each allSessions as session (session.id)}
     {@const sessionId = session.id}
     <div class="terminal-wrapper" class:visible={activeSession === sessionId}>
-      <div class="terminal-inner">
-        <Terminal {sessionId} kind={session.kind} bind:this={terminalComponents[sessionId]} />
-      </div>
       {#if focusedSessionId === sessionId}
         <SummaryPane {sessionId} />
       {/if}
+      <div class="terminal-inner">
+        <Terminal {sessionId} kind={session.kind} bind:this={terminalComponents[sessionId]} />
+      </div>
     </div>
   {/each}
 


### PR DESCRIPTION
## Summary
- Reverts PR #197 which moved the summary pane to a bottom-left overlay on the terminal
- Restores the summary pane to its original position as a top bar above the terminal

## Test plan
- [x] Frontend tests pass (138/138)
- [x] Rust tests pass (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)