### PR TITLE
fix: retry cleanup signal in finish-branch skill

### DIFF
--- a/skills/the-controller-finishing-a-development-branch/SKILL.md
+++ b/skills/the-controller-finishing-a-development-branch/SKILL.md
@@ -33,12 +33,16 @@ Run the project's test suite. If tests fail, fix them before proceeding.
    fi
    ```
 7. Close the associated issue with a summary of what was done
-8. If running inside The Controller (i.e. `$THE_CONTROLLER_SESSION_ID` is set), signal it to clean up this session's worktree:
+8. If running inside The Controller (i.e. `$THE_CONTROLLER_SESSION_ID` is set), signal it to clean up this session's worktree. Retry up to 3 times if the signal fails:
    ```bash
    if [ -z "$THE_CONTROLLER_SESSION_ID" ]; then
      echo "ERROR: THE_CONTROLLER_SESSION_ID is not set, cannot signal cleanup"
    else
-     echo "cleanup:$THE_CONTROLLER_SESSION_ID" | nc -U -w 2 /tmp/the-controller.sock
+     for i in 1 2 3; do
+       echo "cleanup:$THE_CONTROLLER_SESSION_ID" | nc -U -w 2 /tmp/the-controller.sock && break
+       echo "Cleanup signal failed (attempt $i/3), retrying in 2s..."
+       sleep 2
+     done
    fi
    ```
 


### PR DESCRIPTION
## Summary
- The cleanup socket signal (`nc`) in the finish-branch skill can fail transiently (socket busy, timeout)
- Added retry loop: up to 3 attempts with 2s delays between each
- If `nc` succeeds, breaks out immediately via `&& break`

## Test plan
- [x] All 138 frontend tests pass
- [x] All 140 Rust tests pass
- [x] Verified skill YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)