### PR TITLE
fix: move keystroke visualizer to top-right with improved clarity

### DIFF
--- a/src/lib/KeystrokeVisualizer.svelte
+++ b/src/lib/KeystrokeVisualizer.svelte
@@ -20,8 +20,8 @@
 <style>
   .keystroke-container {
     position: fixed;
-    bottom: 16px;
-    left: 16px;
+    top: 12px;
+    right: 12px;
     z-index: 1000;
     display: flex;
     flex-direction: row;
@@ -30,13 +30,14 @@
   }
 
   .keystroke-pill {
-    background: rgba(30, 30, 46, 0.85);
+    background: rgba(30, 30, 46, 0.95);
     color: #cdd6f4;
-    border: 1px solid #313244;
-    border-radius: 6px;
-    padding: 4px 10px;
-    font-size: 13px;
+    border: 1px solid #45475a;
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-size: 15px;
     font-family: "JetBrains Mono", "Fira Code", monospace;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     animation: pill-fade 2s ease-out forwards;
   }
 


### PR DESCRIPTION
## Summary
- Move keystroke visualizer (⌘K) from bottom-left to top-right of the terminal
- Improve visual clarity: larger text, higher contrast background, brighter border, subtle shadow

## Test plan
- [ ] Toggle keystroke visualizer with ⌘K
- [ ] Verify overlay appears in top-right corner
- [ ] Verify keystrokes are readable and fade out after 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)