### PR TITLE
fix: improve keystroke visualizer and hotkey help styling

### DIFF
--- a/src/lib/HotkeyHelp.svelte
+++ b/src/lib/HotkeyHelp.svelte
@@ -113,13 +113,13 @@
     width: 80px;
   }
   kbd {
-    background: #313244;
-    color: #89b4fa;
+    background: #ffffff;
+    color: #1e1e2e;
     padding: 2px 8px;
     border-radius: 4px;
     font-family: monospace;
     font-size: 13px;
-    font-weight: 500;
+    font-weight: 600;
     white-space: nowrap;
   }
   .desc-cell {

--- a/src/lib/KeystrokeVisualizer.svelte
+++ b/src/lib/KeystrokeVisualizer.svelte
@@ -1,7 +1,7 @@
 <!-- src/lib/KeystrokeVisualizer.svelte -->
 <script lang="ts">
   import { fromStore } from "svelte/store";
-  import { keystrokeVisualizerEnabled, keystrokes } from "./keystroke-visualizer";
+  import { keystrokeVisualizerEnabled, keystrokes, FADE_MS } from "./keystroke-visualizer";
 
   const enabledState = fromStore(keystrokeVisualizerEnabled);
   const keystrokesState = fromStore(keystrokes);
@@ -12,7 +12,7 @@
 {#if enabled && list.length > 0}
   <div class="keystroke-container">
     {#each list as ks (ks.id)}
-      <span class="keystroke-pill">{ks.label}</span>
+      <span class="keystroke-pill" style="animation-duration: {FADE_MS}ms">{ks.label}</span>
     {/each}
   </div>
 {/if}
@@ -20,7 +20,7 @@
 <style>
   .keystroke-container {
     position: fixed;
-    top: 12px;
+    bottom: 12px;
     right: 12px;
     z-index: 1000;
     display: flex;
@@ -38,7 +38,7 @@
     font-size: 15px;
     font-family: "JetBrains Mono", "Fira Code", monospace;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
-    animation: pill-fade 2s ease-out forwards;
+    animation: pill-fade ease-out forwards;
   }
 
   @keyframes pill-fade {

--- a/src/lib/keystroke-visualizer.test.ts
+++ b/src/lib/keystroke-visualizer.test.ts
@@ -5,6 +5,7 @@ import {
   keystrokes,
   toggleKeystrokeVisualizer,
   pushKeystroke,
+  FADE_MS,
 } from "./keystroke-visualizer";
 
 describe("keystroke-visualizer", () => {
@@ -40,11 +41,11 @@ describe("keystroke-visualizer", () => {
     expect(get(keystrokes)).toHaveLength(0);
   });
 
-  it("auto-removes keystroke after 2 seconds", () => {
+  it("auto-removes keystroke after FADE_MS", () => {
     keystrokeVisualizerEnabled.set(true);
     pushKeystroke("k");
     expect(get(keystrokes)).toHaveLength(1);
-    vi.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(FADE_MS);
     expect(get(keystrokes)).toHaveLength(0);
   });
 

--- a/src/lib/keystroke-visualizer.ts
+++ b/src/lib/keystroke-visualizer.ts
@@ -9,7 +9,7 @@ export const keystrokeVisualizerEnabled = writable<boolean>(false);
 export const keystrokes = writable<Keystroke[]>([]);
 
 let counter = 0;
-const FADE_MS = 2000;
+export const FADE_MS = 3500;
 
 export function toggleKeystrokeVisualizer() {
   keystrokeVisualizerEnabled.update((v) => {


### PR DESCRIPTION
## Summary
- Move keystroke visualizer from top-right to bottom-right
- Slow keystroke fade duration from 2s to 3.5s, consolidate into single `FADE_MS` constant shared by JS timeout and CSS animation
- Use white background for kbd keys in Cmd+K hotkey help overlay for better readability

## Test plan
- [x] `npx vitest run` — all 138 tests pass
- [x] `cargo test` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)