### PR TITLE
feat: add focus highlight to maintainer panel

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,7 +42,20 @@
       } else if (action?.type === "screenshot-to-session") {
         screenshotToNewSession(action.preview ?? false, action.cropped ?? false);
       } else if (action?.type === "toggle-maintainer-panel") {
-        maintainerPanelVisible.update(v => !v);
+        maintainerPanelVisible.update(v => {
+          if (!v) {
+            focusTarget.set({ type: "maintainer" });
+          } else {
+            // Closing panel — restore focus to terminal
+            const proj = focusTargetState.current?.type === "maintainer"
+              ? projectsState.current.find((p) => p.sessions.some((s) => s.id === activeSessionIdState.current))
+              : null;
+            if (proj) {
+              focusTarget.set({ type: "terminal", projectId: proj.id });
+            }
+          }
+          return !v;
+        });
       } else if (action?.type === "toggle-maintainer-enabled") {
         toggleMaintainerEnabled();
       } else if (action?.type === "trigger-maintainer-check") {

--- a/src/lib/MaintainerPanel.svelte
+++ b/src/lib/MaintainerPanel.svelte
@@ -104,6 +104,12 @@
     project ? (maintainerStatusMap.get(project.id) ?? null) : null
   );
 
+  let isFocused = $derived(focusTargetState.current?.type === "maintainer");
+
+  function handleFocusIn() {
+    focusTarget.set({ type: "maintainer" });
+  }
+
   function severityColor(severity: string): string {
     switch (severity) {
       case "error": return "#f38ba8";
@@ -120,7 +126,8 @@
   }
 </script>
 
-<aside class="maintainer-panel">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<aside class="maintainer-panel" class:focused={isFocused} onfocusin={handleFocusIn}>
   <div class="panel-header">
     <span class="panel-title">Maintainer</span>
     {#if maintainerStatus && maintainerStatus !== "idle"}
@@ -190,6 +197,11 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+  }
+
+  .maintainer-panel.focused {
+    outline: 2px solid #89b4fa;
+    outline-offset: -2px;
   }
 
   .panel-header {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -119,6 +119,7 @@ export type FocusTarget =
   | { type: "terminal"; projectId: string }
   | { type: "session"; sessionId: string; projectId: string }
   | { type: "project"; projectId: string }
+  | { type: "maintainer" }
   | null;
 export const focusTarget = writable<FocusTarget>(null);
 


### PR DESCRIPTION
## Summary
- Adds a blue outline (`#89b4fa`) focus indicator to the maintainer/agents panel, matching the terminal's existing focus highlight style
- Opening the panel via `b` sets focus to the panel; closing restores focus to the terminal
- Clicking inside the panel also sets focus via `focusin` handler

## Test plan
- [x] All 138 frontend tests pass
- [x] All 13 Rust tests pass
- [ ] Open maintainer panel via `b` — blue outline appears
- [ ] Click terminal — outline moves to terminal
- [ ] Click back inside panel — outline returns to panel
- [ ] Press `b` to close — focus returns to terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)