### PR TITLE
feat: add e/q hotkeys to cycle thinking level

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -9,6 +9,9 @@
     generateJumpLabels,
     JUMP_KEYS,
     sidebarVisible,
+    sessionStatuses,
+    sessionThinkingLevels,
+    THINKING_LEVELS,
 
     maintainerPanelVisible,
     archiveView,
@@ -19,6 +22,7 @@
     type Project,
     type HotkeyAction,
     type FocusTarget,
+    type ThinkingLevel,
   } from "./stores";
   import { toggleKeystrokeVisualizer, pushKeystroke } from "./keystroke-visualizer";
   import { buildKeyMap, type CommandId } from "./commands";
@@ -46,6 +50,10 @@
   let expandedSet: Set<string> = $derived(expandedProjectsState.current);
   const maintainerPanelVisibleState = fromStore(maintainerPanelVisible);
   let isMaintainerPanelVisible = $derived(maintainerPanelVisibleState.current);
+  const sessionStatusesState = fromStore(sessionStatuses);
+  let statusMap = $derived(sessionStatusesState.current);
+  const thinkingLevelsState = fromStore(sessionThinkingLevels);
+  let thinkingMap = $derived(thinkingLevelsState.current);
 
   const keyMap = buildKeyMap();
 
@@ -233,6 +241,23 @@
     }
   }
 
+  function cycleThinkingLevel(direction: 1 | -1): string | null {
+    if (!activeId) return null;
+    const current = thinkingMap.get(activeId) ?? "medium";
+    const idx = THINKING_LEVELS.indexOf(current);
+    const len = THINKING_LEVELS.length;
+    const next = THINKING_LEVELS[((idx + direction) % len + len) % len];
+    const updated = new Map(thinkingMap);
+    updated.set(activeId, next);
+    sessionThinkingLevels.set(updated);
+
+    // Write /think command to PTY if session is idle
+    if (statusMap.get(activeId) === "idle") {
+      invoke("write_to_pty", { sessionId: activeId, data: `/think ${next}\n` });
+    }
+    return next;
+  }
+
   function dispatchIssuePicker(opts?: { kind?: string; background?: boolean }) {
     const project = getFocusedProject();
     if (!project) return;
@@ -348,6 +373,16 @@
       case "toggle-maintainer-panel":
         dispatchAction({ type: "toggle-maintainer-panel" });
         return true;
+      case "thinking-up": {
+        const lvl = cycleThinkingLevel(1);
+        if (lvl) pushKeystroke(`Think: ${lvl}`);
+        return true;
+      }
+      case "thinking-down": {
+        const lvl = cycleThinkingLevel(-1);
+        if (lvl) pushKeystroke(`Think: ${lvl}`);
+        return true;
+      }
       case "toggle-help":
         dispatchAction({ type: "toggle-help" });
         return true;

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
-import { projects, activeSessionId, hotkeyAction, focusTarget, jumpMode, sidebarVisible, expandedProjects, maintainerPanelVisible } from './stores';
+import { projects, activeSessionId, hotkeyAction, focusTarget, jumpMode, sidebarVisible, expandedProjects, maintainerPanelVisible, sessionThinkingLevels, sessionStatuses } from './stores';
 import HotkeyManager from './HotkeyManager.svelte';
 
 const testProject = {
@@ -61,6 +61,8 @@ describe('HotkeyManager', () => {
     sidebarVisible.set(true);
     maintainerPanelVisible.set(false);
     expandedProjects.set(new Set(['proj-1', 'proj-2']));
+    sessionThinkingLevels.set(new Map());
+    sessionStatuses.set(new Map());
     vi.clearAllMocks();
     render(HotkeyManager);
   });
@@ -205,9 +207,8 @@ describe('HotkeyManager', () => {
 
     it('unrecognized keys do not change state', () => {
       const initial = get(activeSessionId);
-      pressKey('q');
       pressKey('w');
-      pressKey('e');
+      pressKey('y');
       expect(get(activeSessionId)).toBe(initial);
       expect(get(hotkeyAction)).toBeNull();
     });
@@ -650,6 +651,73 @@ describe('HotkeyManager', () => {
       pressKey('o');
       expect(captured).toBeNull();
       unsub();
+    });
+  });
+
+  // ── Thinking level cycle (e/q) ──
+
+  describe('thinking level cycle', () => {
+    it('e increases thinking level from default (medium) to high', () => {
+      pressKey('e');
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('high');
+    });
+
+    it('q decreases thinking level from default (medium) to low', () => {
+      pressKey('q');
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('low');
+    });
+
+    it('e cycles up through all levels and wraps: medium → high → max → low → medium', () => {
+      pressKey('e'); // medium → high
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('high');
+      pressKey('e'); // high → max
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('max');
+      pressKey('e'); // max → low (wrap)
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('low');
+      pressKey('e'); // low → medium
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('medium');
+    });
+
+    it('q cycles down through all levels and wraps: medium → low → max → high → medium', () => {
+      pressKey('q'); // medium → low
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('low');
+      pressKey('q'); // low → max (wrap)
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('max');
+      pressKey('q'); // max → high
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('high');
+      pressKey('q'); // high → medium
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('medium');
+    });
+
+    it('e writes /think command to PTY when session is idle', () => {
+      sessionStatuses.set(new Map([['sess-1', 'idle']]));
+      pressKey('e');
+      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+        sessionId: 'sess-1',
+        data: '/think high\n',
+      });
+    });
+
+    it('q writes /think command to PTY when session is idle', () => {
+      sessionStatuses.set(new Map([['sess-1', 'idle']]));
+      pressKey('q');
+      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+        sessionId: 'sess-1',
+        data: '/think low\n',
+      });
+    });
+
+    it('e does not write to PTY when session is working', () => {
+      sessionStatuses.set(new Map([['sess-1', 'working']]));
+      pressKey('e');
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('high');
+      expect(invoke).not.toHaveBeenCalled();
+    });
+
+    it('e does not write to PTY when session has no status', () => {
+      pressKey('e');
+      expect(get(sessionThinkingLevels).get('sess-1')).toBe('high');
+      expect(invoke).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -60,7 +60,7 @@ describe("command registry", () => {
     expect(nav.entries).toHaveLength(7);
 
     const sess = sections.find(s => s.label === "Sessions")!;
-    expect(sess.entries).toHaveLength(8);
+    expect(sess.entries).toHaveLength(9);
 
     const proj = sections.find(s => s.label === "Projects")!;
     expect(proj.entries).toHaveLength(7);

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -25,6 +25,8 @@ export type CommandId =
   | "toggle-maintainer"
   | "trigger-maintainer-check"
   | "toggle-maintainer-panel"
+  | "thinking-up"
+  | "thinking-down"
   | "toggle-help";
 
 // IDs for commands handled outside handleHotkey (Cmd+key, Escape)
@@ -65,6 +67,8 @@ export const commands: CommandDef[] = [
   { id: "background-worker-claude", key: "C", section: "Sessions", description: "Background worker: Claude (autonomous)" },
   { id: "background-worker-codex", key: "X", section: "Sessions", description: "Background worker: Codex (autonomous)" },
   { id: "finish-branch", key: "m", section: "Sessions", description: "Merge session branch (create PR)" },
+  { id: "thinking-up", key: "e", section: "Sessions", description: "Thinking level up / down", helpKey: "e / q" },
+  { id: "thinking-down", key: "q", section: "Sessions", description: "Thinking level down", hidden: true },
   { id: "screenshot", key: "⌘S", section: "Sessions", description: "Screenshot (full) → new session", handledExternally: true },
   { id: "screenshot-cropped", key: "⌘D", section: "Sessions", description: "Screenshot (cropped) → new session", handledExternally: true },
   { id: "screenshot-preview", key: "⌘⇧S / ⌘⇧D", section: "Sessions", description: "Screenshot with preview before sending", handledExternally: true },

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -103,6 +103,11 @@ export const archiveView = writable<boolean>(false);
 export const archivedProjects = writable<Project[]>([]);
 export const sidebarVisible = writable<boolean>(true);
 
+// Thinking level per session
+export type ThinkingLevel = "low" | "medium" | "high" | "max";
+export const THINKING_LEVELS: ThinkingLevel[] = ["low", "medium", "high", "max"];
+export const sessionThinkingLevels = writable<Map<string, ThinkingLevel>>(new Map());
+
 export const expandedProjects = writable<Set<string>>(new Set());
 
 export function dispatchHotkeyAction(action: NonNullable<HotkeyAction>) {


### PR DESCRIPTION
## Summary
- Adds per-session thinking level tracking (low/medium/high/max) with `e` to increase and `q` to decrease, wrapping around
- Writes `/think <level>` to PTY when session is idle, skips when working
- Shows current level in keystroke visualizer (e.g., "Think: high")
- Appears in hotkey help (`?`) as `e / q — Thinking level up / down`

## Test plan
- [x] 8 new tests covering up/down cycling, wrapping, PTY write on idle, no PTY write when working
- [x] All 146 frontend tests pass
- [x] All 13 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)