### PR TITLE
feat: add c hotkey to clear maintainer reports

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1191,6 +1191,21 @@ pub async fn trigger_maintainer_check(
     Ok(report)
 }
 
+#[tauri::command]
+pub async fn clear_maintainer_reports(
+    state: State<'_, AppState>,
+    app_handle: AppHandle,
+    project_id: String,
+) -> Result<(), String> {
+    let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let storage = state.storage.lock().map_err(|e| e.to_string())?;
+    storage
+        .clear_maintainer_reports(project_id)
+        .map_err(|e| e.to_string())?;
+    let _ = app_handle.emit(&format!("maintainer-status:{}", project_id), "idle");
+    Ok(())
+}
+
 fn find_main_branch_oid(repo: &git2::Repository) -> Option<git2::Oid> {
     for name in &["refs/heads/master", "refs/heads/main"] {
         if let Ok(reference) = repo.find_reference(name) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run() {
             commands::get_maintainer_status,
             commands::get_maintainer_history,
             commands::trigger_maintainer_check,
+            commands::clear_maintainer_reports,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -193,6 +193,15 @@ impl Storage {
         Ok(reports)
     }
 
+    /// Delete all maintainer reports for a project.
+    pub fn clear_maintainer_reports(&self, project_id: Uuid) -> std::io::Result<()> {
+        let dir = self.maintainer_reports_dir(project_id);
+        if dir.exists() {
+            fs::remove_dir_all(&dir)?;
+        }
+        Ok(())
+    }
+
     fn load_maintainer_reports_from_dir(&self, dir: &std::path::Path) -> std::io::Result<Vec<MaintainerReport>> {
         let mut reports = Vec::new();
         for entry in fs::read_dir(dir)? {
@@ -442,6 +451,35 @@ mod tests {
 
         let latest = storage.latest_maintainer_report(project_id).expect("load");
         assert!(latest.is_none());
+    }
+
+    #[test]
+    fn test_clear_maintainer_reports() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+        let project_id = Uuid::new_v4();
+
+        let r1 = make_report(project_id, "2026-03-07T01:00:00Z");
+        let r2 = make_report(project_id, "2026-03-07T02:00:00Z");
+        storage.save_maintainer_report(&r1).expect("save r1");
+        storage.save_maintainer_report(&r2).expect("save r2");
+
+        assert!(storage.latest_maintainer_report(project_id).unwrap().is_some());
+
+        storage.clear_maintainer_reports(project_id).expect("clear");
+
+        assert!(storage.latest_maintainer_report(project_id).unwrap().is_none());
+        assert!(storage.maintainer_report_history(project_id, 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_clear_maintainer_reports_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+        let project_id = Uuid::new_v4();
+
+        // Clearing when no reports exist should succeed
+        assert!(storage.clear_maintainer_reports(project_id).is_ok());
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -60,6 +60,8 @@
         toggleMaintainerEnabled();
       } else if (action?.type === "trigger-maintainer-check") {
         triggerMaintainerCheck();
+      } else if (action?.type === "clear-maintainer-reports") {
+        clearMaintainerReports();
       } else if (action?.type === "toggle-triage-panel") {
         if (action.category) {
           triagePanelOpen = triagePanelOpen ? null : action.category;
@@ -97,6 +99,19 @@
     try {
       await invoke<any>("trigger_maintainer_check", { projectId: project.id });
       showToast("Maintainer check complete", "info");
+    } catch (e) {
+      showToast(String(e), "error");
+    }
+  }
+
+  async function clearMaintainerReports() {
+    const focus = focusTargetState.current;
+    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
+    const project = projectsState.current.find((p) => p.id === focus.projectId);
+    if (!project) return;
+    try {
+      await invoke("clear_maintainer_reports", { projectId: project.id });
+      showToast("Maintainer reports cleared", "info");
     } catch (e) {
       showToast(String(e), "error");
     }

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -277,6 +277,12 @@
   }
 
   function handleHotkey(key: string): boolean {
+    // Context-sensitive override: c clears reports when maintainer panel is open
+    if (key === "c" && isMaintainerPanelVisible) {
+      dispatchAction({ type: "clear-maintainer-reports" });
+      return true;
+    }
+
     const id = keyMap.get(key);
     if (id === undefined) return false;
 

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -721,6 +721,30 @@ describe('HotkeyManager', () => {
     });
   });
 
+  // ── Clear maintainer reports (c) ──
+
+  describe('clear maintainer reports (c)', () => {
+    it('c dispatches clear-maintainer-reports when panel visible', () => {
+      maintainerPanelVisible.set(true);
+      focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('c');
+      expect(captured).toEqual({ type: 'clear-maintainer-reports' });
+      unsub();
+    });
+
+    it('c dispatches pick-issue-for-session when panel hidden', () => {
+      maintainerPanelVisible.set(false);
+      focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('c');
+      expect(captured).toEqual({ type: 'pick-issue-for-session', projectId: 'proj-1', repoPath: '/tmp/test' });
+      unsub();
+    });
+  });
+
   // ── Input field passthrough ──
 
   describe('input field passthrough', () => {

--- a/src/lib/MaintainerPanel.svelte
+++ b/src/lib/MaintainerPanel.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
-  import { focusTarget, projects, maintainerStatuses, type Project, type FocusTarget, type MaintainerReport, type MaintainerStatus } from "./stores";
+  import { focusTarget, projects, maintainerStatuses, dispatchHotkeyAction, type Project, type FocusTarget, type MaintainerReport, type MaintainerStatus } from "./stores";
   import { showToast } from "./toast";
 
   let report: MaintainerReport | null = $state(null);
@@ -183,6 +183,9 @@
       <button class="btn-run" onclick={triggerCheck} disabled={triggerLoading}>
         {triggerLoading ? "Running..." : "(r) Run again"}
       </button>
+      <button class="btn-clear" onclick={() => dispatchHotkeyAction({ type: "clear-maintainer-reports" })}>
+        (c) Clear
+      </button>
     </div>
   {/if}
 </aside>
@@ -322,5 +325,20 @@
   .panel-actions {
     padding: 12px 16px;
     border-top: 1px solid #313244;
+    display: flex;
+    gap: 8px;
   }
+
+  .btn-clear {
+    background: #313244;
+    border: none;
+    color: #cdd6f4;
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    box-shadow: none;
+  }
+
+  .btn-clear:hover { background: #45475a; }
 </style>

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -66,6 +66,6 @@ describe("command registry", () => {
     expect(proj.entries).toHaveLength(7);
 
     const panels = sections.find(s => s.label === "Panels")!;
-    expect(panels.entries).toHaveLength(6);
+    expect(panels.entries).toHaveLength(7);
   });
 });

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -36,7 +36,8 @@ export type ExternalCommandId =
   | "screenshot-preview"
   | "keystroke-visualizer"
   | "escape-focus"
-  | "escape-forward";
+  | "escape-forward"
+  | "clear-maintainer-reports";
 
 export interface CommandDef {
   id: CommandId | ExternalCommandId;
@@ -87,6 +88,7 @@ export const commands: CommandDef[] = [
   { id: "toggle-maintainer-panel", key: "b", section: "Panels", description: "Toggle background agent panel" },
   { id: "toggle-maintainer", key: "o", section: "Panels", description: "Toggle maintainer on/off (when panel open)" },
   { id: "trigger-maintainer-check", key: "r", section: "Panels", description: "Run maintainer check now (when panel open)" },
+  { id: "clear-maintainer-reports", key: "c", section: "Panels", description: "Clear maintainer reports (when panel open)", handledExternally: true },
   { id: "toggle-help", key: "?", section: "Panels", description: "Toggle this help" },
   { id: "keystroke-visualizer", key: "⌘K", section: "Panels", description: "Toggle keystroke visualizer", handledExternally: true },
 ];

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -95,6 +95,7 @@ export type HotkeyAction =
   | { type: "toggle-maintainer-enabled" }
   | { type: "toggle-triage-panel"; category?: TriageCategory }
   | { type: "trigger-maintainer-check" }
+  | { type: "clear-maintainer-reports" }
   | null;
 
 export const hotkeyAction = writable<HotkeyAction>(null);


### PR DESCRIPTION
## Summary
- Adds `c` keyboard shortcut to clear all maintainer reports when the maintainer panel is open
- When panel is closed, `c` retains its default "create Claude session" behavior
- Adds `(c) Clear` button to the maintainer panel UI
- Backend: new `clear_maintainer_reports` Tauri command and `Storage::clear_maintainer_reports()` method

## Test plan
- [x] Rust tests: `test_clear_maintainer_reports` and `test_clear_maintainer_reports_idempotent`
- [x] Frontend tests: `c` dispatches `clear-maintainer-reports` when panel visible, falls through to `pick-issue-for-session` when hidden
- [x] Full test suite passes (140 frontend, 13 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)