### PR TITLE
feat: show summary pane for archived sessions

### DIFF
--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -2,7 +2,7 @@
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-  import { projects, sessionStatuses, type Project, type SessionStatus } from "./stores";
+  import { projects, archivedProjects, sessionStatuses, type Project, type SessionStatus } from "./stores";
 
   interface Props {
     sessionId: string;
@@ -17,12 +17,14 @@
 
   const projectsState = fromStore(projects);
   let projectList: Project[] = $derived(projectsState.current);
+  const archivedProjectsState = fromStore(archivedProjects);
+  let archivedProjectList: Project[] = $derived(archivedProjectsState.current);
   const sessionStatusesState = fromStore(sessionStatuses);
   let statuses: Map<string, SessionStatus> = $derived(sessionStatusesState.current);
   let commits: CommitInfo[] = $state([]);
 
   let session = $derived(
-    projectList.flatMap((p) =>
+    [...projectList, ...archivedProjectList].flatMap((p) =>
       p.sessions.map((s) => ({ ...s, projectId: p.id }))
     ).find((s) => s.id === sessionId) ?? null
   );

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -9,6 +9,9 @@
   const activeSessionIdState = fromStore(activeSessionId);
   let activeSession: string | null = $derived(activeSessionIdState.current);
   let terminalComponents: Record<string, Terminal> = $state({});
+  let allSessionIds: Set<string> = $derived(
+    new Set(projectList.flatMap((p) => p.sessions.map((s) => s.id))),
+  );
 
   $effect(() => {
     const unsub = hotkeyAction.subscribe((action) => {
@@ -53,7 +56,14 @@
     </div>
   {/each}
 
-  {#if !activeSession}
+  {#if focusedSessionId && !allSessionIds.has(focusedSessionId)}
+    <div class="archived-summary visible">
+      <SummaryPane sessionId={focusedSessionId} />
+      <div class="archived-notice">Session archived</div>
+    </div>
+  {/if}
+
+  {#if !activeSession && !(focusedSessionId && !allSessionIds.has(focusedSessionId))}
     <div class="empty-state">
       <div class="empty-content">
         <div class="empty-title">No active session</div>
@@ -90,6 +100,27 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
+  }
+
+  .archived-summary {
+    position: absolute;
+    inset: 0;
+    display: none;
+    flex-direction: column;
+    background: #1e1e2e;
+  }
+
+  .archived-summary.visible {
+    display: flex;
+  }
+
+  .archived-notice {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: #6c7086;
+    font-size: 14px;
   }
 
   .empty-state {


### PR DESCRIPTION
## Summary
- When focusing an archived session in the sidebar, the terminal area now displays its summary pane (prompt and commits) instead of being blank
- `SummaryPane` now searches both active and archived project lists to find session data
- Shows a "Session archived" notice below the summary in the terminal area

## Test plan
- [x] All 138 frontend tests pass
- [x] All 13 Rust tests pass
- [ ] Manual: switch to archive view, focus an archived session, verify summary pane appears with prompt and commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)