### PR TITLE
fix: resolve maintainer hotkeys (c/o/r) when panel has focus

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -71,10 +71,20 @@
     return unsub;
   });
 
-  async function toggleMaintainerEnabled() {
+  function getTargetProject(): Project | undefined {
     const focus = focusTargetState.current;
-    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
-    const project = projectsState.current.find((p) => p.id === focus.projectId);
+    if (focus?.type === "project" || focus?.type === "session") {
+      return projectsState.current.find((p) => p.id === focus.projectId);
+    }
+    if (focus?.type === "maintainer") {
+      const aid = activeSessionIdState.current;
+      if (aid) return projectsState.current.find((p) => p.sessions.some((s) => s.id === aid));
+    }
+    return undefined;
+  }
+
+  async function toggleMaintainerEnabled() {
+    const project = getTargetProject();
     if (!project) return;
     const newEnabled = !project.maintainer.enabled;
     try {
@@ -92,9 +102,7 @@
   }
 
   async function triggerMaintainerCheck() {
-    const focus = focusTargetState.current;
-    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
-    const project = projectsState.current.find((p) => p.id === focus.projectId);
+    const project = getTargetProject();
     if (!project) return;
     try {
       await invoke<any>("trigger_maintainer_check", { projectId: project.id });
@@ -105,9 +113,7 @@
   }
 
   async function clearMaintainerReports() {
-    const focus = focusTargetState.current;
-    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
-    const project = projectsState.current.find((p) => p.id === focus.projectId);
+    const project = getTargetProject();
     if (!project) return;
     try {
       await invoke("clear_maintainer_reports", { projectId: project.id });

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -206,8 +206,13 @@
   }
 
   function getFocusedProject(): Project | null {
-    if (currentFocus?.type !== "project" && currentFocus?.type !== "session") return null;
-    return projectList.find((p) => p.id === currentFocus.projectId) ?? null;
+    if (currentFocus?.type === "project" || currentFocus?.type === "session") {
+      return projectList.find((p) => p.id === currentFocus.projectId) ?? null;
+    }
+    if (currentFocus?.type === "maintainer" && activeId) {
+      return projectList.find((p) => p.sessions.some((s) => s.id === activeId)) ?? null;
+    }
+    return null;
   }
 
   function dispatchDeleteAction() {

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -652,6 +652,16 @@ describe('HotkeyManager', () => {
       expect(captured).toBeNull();
       unsub();
     });
+
+    it('o dispatches toggle-maintainer-enabled when focus is maintainer type', () => {
+      maintainerPanelVisible.set(true);
+      focusTarget.set({ type: 'maintainer' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('o');
+      expect(captured).toEqual({ type: 'toggle-maintainer-enabled' });
+      unsub();
+    });
   });
 
   // ── Thinking level cycle (e/q) ──
@@ -727,6 +737,16 @@ describe('HotkeyManager', () => {
     it('c dispatches clear-maintainer-reports when panel visible', () => {
       maintainerPanelVisible.set(true);
       focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('c');
+      expect(captured).toEqual({ type: 'clear-maintainer-reports' });
+      unsub();
+    });
+
+    it('c dispatches clear-maintainer-reports when focus is maintainer type', () => {
+      maintainerPanelVisible.set(true);
+      focusTarget.set({ type: 'maintainer' });
       let captured: any = null;
       const unsub = hotkeyAction.subscribe((v) => { captured = v; });
       pressKey('c');


### PR DESCRIPTION
## Summary
- Opening the maintainer panel (`b`) sets focus to `{ type: "maintainer" }` which has no `projectId`
- All maintainer hotkeys (`c` clear, `o` toggle, `r` check) required `project` or `session` focus type and silently failed
- Now resolves the project from the active session when focus type is `"maintainer"`

## Test plan
- [x] Added test: `o` dispatches `toggle-maintainer-enabled` when focus is `maintainer` type
- [x] Added test: `c` dispatches `clear-maintainer-reports` when focus is `maintainer` type
- [x] All 150 frontend tests pass
- [x] All 13 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)