### PR TITLE
feat: add complexity prompt to issue creation modal

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -144,7 +144,7 @@
     }
   }
 
-  async function handleIssueSubmit(title: string, priority: "high" | "low") {
+  async function handleIssueSubmit(title: string, priority: "high" | "low", complexity: "high" | "low") {
     const repoPath = createIssueTarget!.repoPath;
     createIssueTarget = null; // close modal immediately
 
@@ -159,14 +159,21 @@
         body,
       });
 
-      const label = `priority: ${priority}`;
       invoke("add_github_label", {
         repoPath,
         issueNumber: issue.number,
-        label,
+        label: `priority: ${priority}`,
         description: priority === "high" ? "Important, should be tackled soon" : "Nice to have, can wait",
         color: priority === "high" ? "F38BA8" : "A6E3A1",
       }).catch((e: unknown) => showToast(`Failed to add priority label: ${e}`, "error"));
+
+      invoke("add_github_label", {
+        repoPath,
+        issueNumber: issue.number,
+        label: `complexity: ${complexity}`,
+        description: complexity === "high" ? "Multi-step task, needs capable agents" : "Quick task, suitable for simple agents",
+        color: complexity === "high" ? "FAB387" : "89DCEB",
+      }).catch((e: unknown) => showToast(`Failed to add complexity label: ${e}`, "error"));
 
       showToast(`Issue #${issue.number} created`, "info");
     } catch (e) {

--- a/src/lib/CreateIssueModal.svelte
+++ b/src/lib/CreateIssueModal.svelte
@@ -2,16 +2,18 @@
   import { onMount } from "svelte";
 
   type Priority = "high" | "low";
+  type Complexity = "high" | "low";
 
   interface Props {
-    onSubmit: (title: string, priority: Priority) => void;
+    onSubmit: (title: string, priority: Priority, complexity: Complexity) => void;
     onClose: () => void;
   }
 
   let { onSubmit, onClose }: Props = $props();
 
   let title = $state("");
-  let stage: "title" | "priority" = $state("title");
+  let stage: "title" | "priority" | "complexity" = $state("title");
+  let selectedPriority: Priority = $state("low");
   let titleInput: HTMLInputElement | undefined = $state();
   let overlayEl: HTMLDivElement | undefined = $state();
 
@@ -23,7 +25,10 @@
     if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
-      if (stage === "priority") {
+      if (stage === "complexity") {
+        stage = "priority";
+        requestAnimationFrame(() => overlayEl?.focus());
+      } else if (stage === "priority") {
         stage = "title";
         requestAnimationFrame(() => titleInput?.focus());
       } else {
@@ -43,10 +48,25 @@
     if (stage === "priority") {
       if (e.key === "j") {
         e.preventDefault();
-        onSubmit(title.trim(), "low");
+        selectedPriority = "low";
+        stage = "complexity";
+        requestAnimationFrame(() => overlayEl?.focus());
       } else if (e.key === "k") {
         e.preventDefault();
-        onSubmit(title.trim(), "high");
+        selectedPriority = "high";
+        stage = "complexity";
+        requestAnimationFrame(() => overlayEl?.focus());
+      }
+      return;
+    }
+
+    if (stage === "complexity") {
+      if (e.key === "j") {
+        e.preventDefault();
+        onSubmit(title.trim(), selectedPriority, "low");
+      } else if (e.key === "k") {
+        e.preventDefault();
+        onSubmit(title.trim(), selectedPriority, "high");
       }
     }
   }
@@ -65,11 +85,19 @@
         class="input"
       />
       <div class="hint">Press Enter to continue</div>
-    {:else}
+    {:else if stage === "priority"}
       <div class="title-preview">{title}</div>
       <div class="priority-prompt">
         <span class="priority-key low">j</span> Low Priority
         <span class="priority-key high">k</span> High Priority
+      </div>
+      <div class="hint">Press Esc to go back</div>
+    {:else}
+      <div class="title-preview">{title}</div>
+      <div class="selected-badge {selectedPriority}">{selectedPriority} priority</div>
+      <div class="priority-prompt">
+        <span class="priority-key simple">j</span> Low Complexity
+        <span class="priority-key complex">k</span> High Complexity
       </div>
       <div class="hint">Press Esc to go back</div>
     {/if}
@@ -158,5 +186,28 @@
   .priority-key.low {
     color: #a6e3a1;
     border-color: #a6e3a1;
+  }
+  .priority-key.simple {
+    color: #89dceb;
+    border-color: #89dceb;
+  }
+  .priority-key.complex {
+    color: #fab387;
+    border-color: #fab387;
+  }
+  .selected-badge {
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    text-align: center;
+    text-transform: capitalize;
+  }
+  .selected-badge.high {
+    color: #f38ba8;
+    background: rgba(243, 139, 168, 0.1);
+  }
+  .selected-badge.low {
+    color: #a6e3a1;
+    background: rgba(166, 227, 161, 0.1);
   }
 </style>


### PR DESCRIPTION
## Summary
- Adds a third step (complexity: low/high) to the new issue creation modal, after title and priority
- Applies a `complexity: low/high` GitHub label alongside the existing priority label
- Escape navigates back through each stage; the complexity step shows the selected priority as a badge

## Test plan
- [x] All 150 frontend tests pass
- [x] All 13 Rust tests pass
- [ ] Manual: create a new issue, verify three-step flow (title → priority → complexity)
- [ ] Manual: verify both priority and complexity labels appear on the created issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)