### PR TITLE
fix: thinking level hotkeys (e/q) now take immediate effect

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -39,6 +39,9 @@
   // Toggle mode state (o prefix)
   let toggleModeActive = $state(false);
 
+  // Sessions whose thinking level was changed while not idle
+  let pendingThinkingSessions = new Set<string>();
+
   const projectsState = fromStore(projects);
   let projectList: Project[] = $derived(projectsState.current);
   const activeSessionIdState = fromStore(activeSessionId);
@@ -59,6 +62,21 @@
   let thinkingMap = $derived(thinkingLevelsState.current);
 
   const keyMap = buildKeyMap();
+
+  // Flush pending thinking level when a session transitions to idle
+  $effect(() => {
+    // Read statusMap unconditionally to always track it as a dependency
+    const currentStatuses = statusMap;
+    for (const sessionId of pendingThinkingSessions) {
+      if (currentStatuses.get(sessionId) === "idle") {
+        const level = thinkingMap.get(sessionId);
+        if (level) {
+          invoke("write_to_pty", { sessionId, data: `/think ${level}\r` });
+        }
+        pendingThinkingSessions.delete(sessionId);
+      }
+    }
+  });
 
   // Detect if a terminal (xterm) has focus
   function isTerminalFocused(): boolean {
@@ -272,9 +290,11 @@
     updated.set(activeId, next);
     sessionThinkingLevels.set(updated);
 
-    // Write /think command to PTY if session is idle
+    // Write /think command to PTY if session is idle, otherwise mark pending
     if (statusMap.get(activeId) === "idle") {
-      invoke("write_to_pty", { sessionId: activeId, data: `/think ${next}\n` });
+      invoke("write_to_pty", { sessionId: activeId, data: `/think ${next}\r` });
+    } else {
+      pendingThinkingSessions.add(activeId);
     }
     return next;
   }

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
 import { get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
 import { projects, activeSessionId, hotkeyAction, focusTarget, jumpMode, sidebarVisible, expandedProjects, maintainerPanelVisible, sessionThinkingLevels, sessionStatuses } from './stores';
@@ -707,7 +708,7 @@ describe('HotkeyManager', () => {
       pressKey('e');
       expect(invoke).toHaveBeenCalledWith('write_to_pty', {
         sessionId: 'sess-1',
-        data: '/think high\n',
+        data: '/think high\r',
       });
     });
 
@@ -716,7 +717,7 @@ describe('HotkeyManager', () => {
       pressKey('q');
       expect(invoke).toHaveBeenCalledWith('write_to_pty', {
         sessionId: 'sess-1',
-        data: '/think low\n',
+        data: '/think low\r',
       });
     });
 
@@ -731,6 +732,36 @@ describe('HotkeyManager', () => {
       pressKey('e');
       expect(get(sessionThinkingLevels).get('sess-1')).toBe('high');
       expect(invoke).not.toHaveBeenCalled();
+    });
+
+    it('pending thinking level is sent when session transitions to idle', () => {
+      sessionStatuses.set(new Map([['sess-1', 'working']]));
+      pressKey('e');
+      expect(invoke).not.toHaveBeenCalled();
+
+      // Transition to idle — effect should flush the pending /think command
+      flushSync(() => {
+        sessionStatuses.set(new Map([['sess-1', 'idle']]));
+      });
+      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+        sessionId: 'sess-1',
+        data: '/think high\r',
+      });
+    });
+
+    it('multiple cycles while working sends only the final level on idle', () => {
+      sessionStatuses.set(new Map([['sess-1', 'working']]));
+      pressKey('e'); // medium → high
+      pressKey('e'); // high → max
+      expect(invoke).not.toHaveBeenCalled();
+
+      flushSync(() => {
+        sessionStatuses.set(new Map([['sess-1', 'idle']]));
+      });
+      expect(invoke).toHaveBeenCalledWith('write_to_pty', {
+        sessionId: 'sess-1',
+        data: '/think max\r',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Changed `/think` PTY writes from `\n` to `\r` so the command is actually submitted (not just typed)
- Added deferred flush: when e/q is pressed while a session is working, the `/think` command is queued and sent when the session transitions to idle

## Test plan
- [x] Existing thinking level tests updated and passing
- [x] New tests: pending level sent on idle transition, multiple cycles coalesce to final level
- [x] Full test suite passes (152 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)