### PR TITLE
fix: fuzzy finder arrow skip and add vim-style navigation

### DIFF
--- a/src/lib/FuzzyFinder.svelte
+++ b/src/lib/FuzzyFinder.svelte
@@ -22,6 +22,7 @@
   );
   let selectedIndex = $state(0);
   let inputEl: HTMLInputElement | undefined = $state();
+  let mode = $state<"search" | "navigate">("search");
 
   onMount(async () => {
     try {
@@ -33,6 +34,28 @@
   });
 
   function handleKeydown(e: KeyboardEvent) {
+    if (mode === "navigate") {
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        selectedIndex = Math.min(selectedIndex + 1, filtered.length - 1);
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        selectedIndex = Math.max(selectedIndex - 1, 0);
+      } else if (e.key === "l" || e.key === "Enter") {
+        e.preventDefault();
+        if (filtered.length > 0) onSelect(filtered[selectedIndex]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        mode = "search";
+        inputEl?.focus();
+      } else if (e.key.length === 1) {
+        // Printable character — switch back to search mode and let it type
+        mode = "search";
+      }
+      return;
+    }
+
+    // Search mode
     if (e.key === "ArrowDown") {
       e.preventDefault();
       selectedIndex = Math.min(selectedIndex + 1, filtered.length - 1);
@@ -41,7 +64,7 @@
       selectedIndex = Math.max(selectedIndex - 1, 0);
     } else if (e.key === "Enter" && filtered.length > 0) {
       e.preventDefault();
-      onSelect(filtered[selectedIndex]);
+      mode = "navigate";
     } else if (e.key === "Escape") {
       e.preventDefault();
       onClose();
@@ -55,7 +78,7 @@
   });
 </script>
 
-<div class="overlay" onclick={onClose} onkeydown={handleKeydown} role="dialog">
+<div class="overlay" onclick={onClose} role="dialog">
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div class="modal" onclick={(e) => e.stopPropagation()} role="presentation">
     <input
@@ -63,6 +86,8 @@
       bind:value={query}
       placeholder="Search projects..."
       class="search-input"
+      class:nav-mode={mode === "navigate"}
+      readonly={mode === "navigate"}
       onkeydown={handleKeydown}
     />
     <div class="results">
@@ -114,6 +139,10 @@
     padding: 14px 16px;
     font-size: 15px;
     outline: none;
+  }
+  .search-input.nav-mode {
+    color: #6c7086;
+    border-bottom-color: #cba6f7;
   }
   .results {
     overflow-y: auto;

--- a/src/lib/FuzzyFinder.test.ts
+++ b/src/lib/FuzzyFinder.test.ts
@@ -54,7 +54,7 @@ describe('FuzzyFinder', () => {
     expect(screen.getByText('No matching directories')).toBeInTheDocument();
   });
 
-  it('calls onClose on Escape', async () => {
+  it('calls onClose on Escape in search mode', async () => {
     const user = userEvent.setup();
     render(FuzzyFinder, { props: { onSelect, onClose } });
     await screen.findByText('alpha-project');
@@ -66,7 +66,7 @@ describe('FuzzyFinder', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('calls onSelect on Enter', async () => {
+  it('Enter enters navigate mode instead of selecting', async () => {
     const user = userEvent.setup();
     render(FuzzyFinder, { props: { onSelect, onClose } });
     await screen.findByText('alpha-project');
@@ -75,7 +75,72 @@ describe('FuzzyFinder', () => {
     await user.click(input);
     await user.keyboard('{Enter}');
 
-    expect(onSelect).toHaveBeenCalledWith(mockEntries[0]);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(input).toHaveAttribute('readonly');
+  });
+
+  it('j/k navigate and l selects in navigate mode', async () => {
+    const user = userEvent.setup();
+    render(FuzzyFinder, { props: { onSelect, onClose } });
+    await screen.findByText('alpha-project');
+
+    const input = screen.getByPlaceholderText('Search projects...');
+    await user.click(input);
+    // Enter nav mode
+    await user.keyboard('{Enter}');
+    // j moves down to beta-app
+    await user.keyboard('j');
+    // l selects it
+    await user.keyboard('l');
+
+    expect(onSelect).toHaveBeenCalledWith(mockEntries[1]);
+  });
+
+  it('k moves up in navigate mode', async () => {
+    const user = userEvent.setup();
+    render(FuzzyFinder, { props: { onSelect, onClose } });
+    await screen.findByText('alpha-project');
+
+    const input = screen.getByPlaceholderText('Search projects...');
+    await user.click(input);
+    // Enter nav mode, move down twice, then up once
+    await user.keyboard('{Enter}');
+    await user.keyboard('j');
+    await user.keyboard('j');
+    await user.keyboard('k');
+    await user.keyboard('l');
+
+    expect(onSelect).toHaveBeenCalledWith(mockEntries[1]);
+  });
+
+  it('Escape in navigate mode returns to search mode', async () => {
+    const user = userEvent.setup();
+    render(FuzzyFinder, { props: { onSelect, onClose } });
+    await screen.findByText('alpha-project');
+
+    const input = screen.getByPlaceholderText('Search projects...');
+    await user.click(input);
+    await user.keyboard('{Enter}');
+    expect(input).toHaveAttribute('readonly');
+
+    await user.keyboard('{Escape}');
+    expect(input).not.toHaveAttribute('readonly');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('typing in navigate mode returns to search mode', async () => {
+    const user = userEvent.setup();
+    render(FuzzyFinder, { props: { onSelect, onClose } });
+    await screen.findByText('alpha-project');
+
+    const input = screen.getByPlaceholderText('Search projects...');
+    await user.click(input);
+    await user.keyboard('{Enter}');
+    expect(input).toHaveAttribute('readonly');
+
+    // Typing a non-nav character returns to search mode
+    await user.keyboard('a');
+    expect(input).not.toHaveAttribute('readonly');
   });
 
   it('invokes list_root_directories on mount', async () => {


### PR DESCRIPTION
## Summary
- Fix arrow keys skipping items in fuzzy finder (duplicate `onkeydown` handler caused double-fire via event bubbling)
- Add two-mode interaction: search mode (type to filter, Enter to lock in) and navigate mode (`j`/`k` to move, `l` to load, Escape to return)
- Input becomes readonly with visual indicator (dimmed text, purple border) in nav mode

## Test plan
- [x] All 156 frontend tests pass (11 FuzzyFinder tests, 4 new)
- [x] All 13 Rust tests pass
- [x] Arrow keys now move one item at a time (no skipping)
- [x] Enter → j/k/l workflow works as expected
- [x] Escape in nav mode returns to search; Escape in search mode closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)