### PR TITLE
fix: filter escape sequences from prompt capture buffer

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -155,21 +155,27 @@
 
       // Capture the first prompt: buffer keystrokes until Enter
       if (!promptCaptured) {
-        for (const ch of data) {
-          if (ch === "\r" || ch === "\n") {
-            const trimmed = promptBuffer.trim();
-            if (trimmed.length > 0) {
-              promptCaptured = true;
-              saveInitialPrompt(trimmed);
+        // Skip escape sequences (arrow keys, function keys, etc.)
+        // They arrive as multi-char strings like \x1b[A — not typed text
+        if (data.startsWith("\x1b")) {
+          // Still forward to PTY below, just don't buffer
+        } else {
+          for (const ch of data) {
+            if (ch === "\r" || ch === "\n") {
+              const trimmed = promptBuffer.trim();
+              if (trimmed.length > 0) {
+                promptCaptured = true;
+                saveInitialPrompt(trimmed);
+              }
+              promptBuffer = "";
+              break;
+            } else if (ch === "\x7f" || ch === "\b") {
+              // Backspace
+              promptBuffer = promptBuffer.slice(0, -1);
+            } else if (ch >= " ") {
+              // Printable character
+              promptBuffer += ch;
             }
-            promptBuffer = "";
-            break;
-          } else if (ch === "\x7f" || ch === "\b") {
-            // Backspace
-            promptBuffer = promptBuffer.slice(0, -1);
-          } else if (ch >= " ") {
-            // Printable character
-            promptBuffer += ch;
           }
         }
       }


### PR DESCRIPTION
## Summary
- Arrow keys and other escape sequences (e.g. `\x1b[A`) were leaking into the initial prompt text displayed in the SummaryPane
- The ESC byte (`\x1b`) was filtered but the trailing characters (`[`, `A`/`B`/`C`/`D`) passed the printability check and accumulated in `promptBuffer`
- Fix: skip the entire `data` chunk in `term.onData` when it starts with `\x1b`, since it's a control sequence not typed text

## Test plan
- [x] 146 frontend tests pass
- [x] 13 Rust tests pass
- [ ] Manual: type a prompt with arrow key navigation, verify the stored prompt text is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)