### PR TITLE
fix: prevent session status getting stuck on working

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -266,8 +266,8 @@
     return () => {
       cancelled = true;
       unlisteners.forEach(fn => fn());
-      for (const timer of idleTimers.values()) clearTimeout(timer);
-      idleTimers.clear();
+      // Don't clear idle timers here — pending idle transitions must complete.
+      // Individual session timers are cleaned up by clearSessionTracking().
     };
   });
 


### PR DESCRIPTION
## Summary
- The `$effect` cleanup in `Sidebar.svelte` was clearing all pending idle debounce timers whenever `projectList` changed
- This caused sessions to permanently show "working" (yellow indicator) even when idle at a prompt
- Individual session timers are already cleaned up by `clearSessionTracking()`, so the blanket clear was unnecessary and harmful

## Test plan
- [x] All 166 frontend tests pass
- [x] All 13 Rust tests pass
- [ ] Verify session status indicator turns green after Claude finishes processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)