### PR TITLE
fix: scroll terminal to bottom on resize

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -260,6 +260,7 @@
         }
 
         fitAddon.fit();
+        term.scrollToBottom();
 
         // Guard against bogus dimensions from bad cell measurements
         if (term.cols < 10) return;


### PR DESCRIPTION
## Summary
- Adds `term.scrollToBottom()` after `fitAddon.fit()` in the ResizeObserver handler
- Fixes the issue where toggling SummaryPane (sidebar ↔ terminal focus) resizes the terminal but leaves the cursor/input area scrolled out of view

## Test plan
- [ ] Click a session in the sidebar (SummaryPane appears, terminal shrinks)
- [ ] Click into the terminal area (SummaryPane disappears, terminal grows)
- [ ] Verify the cursor/input is visible without manual scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)