### PR TITLE
fix: screenshot commands always spawn in the-controller project

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -220,13 +220,11 @@
   }
 
   async function screenshotToNewSession(preview: boolean, cropped: boolean) {
-    // Determine project from current focus or active session
-    const projectId = focusTargetState.current?.projectId
-      ?? projectsState.current.find((p) => p.sessions.some((s) => s.id === activeSessionIdState.current))?.id
-      ?? projectsState.current[0]?.id;
+    // Screenshot sessions always spawn in "the-controller" project
+    const projectId = projectsState.current.find((p) => p.name === "the-controller")?.id;
 
     if (!projectId) {
-      showToast("No project to create session in", "error");
+      showToast("\"the-controller\" project not found", "error");
       return;
     }
 

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -46,8 +46,8 @@ import App from "./App.svelte";
 
 const baseProject = {
   id: "proj-1",
-  name: "project-one",
-  repo_path: "/tmp/project-one",
+  name: "the-controller",
+  repo_path: "/tmp/the-controller",
   created_at: "2026-01-01",
   archived: false,
   sessions: [],


### PR DESCRIPTION
## Summary
- Screenshot commands now always spawn sessions in the "the-controller" project instead of using focus/active session heuristics
- Aborts with an error toast if the "the-controller" project is not found

## Test plan
- [x] All frontend tests pass (166/166)
- [x] All Rust tests pass (152 unit + 13 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)