### PR TITLE
fix: use lowercase keys for ⌘ shortcuts in help modal

### DIFF
--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -52,15 +52,15 @@ describe("command registry", () => {
     const sections = getHelpSections();
     const allKeys = sections.flatMap(s => s.entries.map(e => e.key));
     expect(allKeys).toContain("Esc");
-    expect(allKeys).toContain("⌘S");
-    expect(allKeys).toContain("⌘K");
+    expect(allKeys).toContain("⌘s");
+    expect(allKeys).toContain("⌘k");
   });
 
   it("buildKeyMap excludes external commands", () => {
     const map = buildKeyMap();
     expect(map.has("Esc")).toBe(false);
-    expect(map.has("⌘S")).toBe(false);
-    expect(map.has("⌘K")).toBe(false);
+    expect(map.has("⌘s")).toBe(false);
+    expect(map.has("⌘k")).toBe(false);
   });
 
   it("buildKeyMap includes all internal command keys", () => {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -69,9 +69,9 @@ export const commands: CommandDef[] = [
   { id: "background-worker-claude", key: "C", section: "Sessions", description: "Background worker: Claude (autonomous)", mode: "development" },
   { id: "background-worker-codex", key: "X", section: "Sessions", description: "Background worker: Codex (autonomous)", mode: "development" },
   { id: "finish-branch", key: "m", section: "Sessions", description: "Merge session branch (create PR)", mode: "development" },
-  { id: "screenshot", key: "⌘S", section: "Sessions", description: "Screenshot (full) → new session", handledExternally: true },
-  { id: "screenshot-cropped", key: "⌘D", section: "Sessions", description: "Screenshot (cropped) → new session", handledExternally: true },
-  { id: "screenshot-preview", key: "⌘⇧S / ⌘⇧D", section: "Sessions", description: "Screenshot with preview before sending", handledExternally: true },
+  { id: "screenshot", key: "⌘s", section: "Sessions", description: "Screenshot (full) → new session", handledExternally: true },
+  { id: "screenshot-cropped", key: "⌘d", section: "Sessions", description: "Screenshot (cropped) → new session", handledExternally: true },
+  { id: "screenshot-preview", key: "⌘S / ⌘D", section: "Sessions", description: "Screenshot with preview before sending", handledExternally: true },
 
   // ── Projects ──
   { id: "new-project", key: "n", section: "Projects", description: "New project", mode: "development" },
@@ -86,7 +86,7 @@ export const commands: CommandDef[] = [
   { id: "toggle-sidebar", key: "s", section: "Panels", description: "Toggle sidebar" },
   { id: "toggle-mode", key: "o", section: "Panels", description: "Toggle: (m)aintainer / (w)orker", mode: "development" },
   { id: "toggle-help", key: "?", section: "Panels", description: "Toggle this help" },
-  { id: "keystroke-visualizer", key: "⌘K", section: "Panels", description: "Toggle keystroke visualizer", handledExternally: true },
+  { id: "keystroke-visualizer", key: "⌘k", section: "Panels", description: "Toggle keystroke visualizer", handledExternally: true },
 
   // ── Agents ──
   { id: "toggle-agent", key: "o", section: "Agents", description: "Toggle focused agent on/off", mode: "agents" },


### PR DESCRIPTION
## Summary
- Lowercase ⌘ shortcut keys in help modal to match convention: lowercase = regular, uppercase = shift
- `⌘S`/`⌘D`/`⌘K` → `⌘s`/`⌘d`/`⌘k` for Cmd+key shortcuts
- Shift variants (`⌘⇧S / ⌘⇧D`) now show as `⌘S / ⌘D` (caps implies shift)

## Test plan
- [x] All 166 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)