### PR TITLE
simplify FuzzyFinder to single-phase selection

### DIFF
--- a/src/lib/FuzzyFinder.svelte
+++ b/src/lib/FuzzyFinder.svelte
@@ -22,7 +22,6 @@
   );
   let selectedIndex = $state(0);
   let inputEl: HTMLInputElement | undefined = $state();
-  let mode = $state<"search" | "navigate">("search");
 
   onMount(async () => {
     try {
@@ -34,28 +33,6 @@
   });
 
   function handleKeydown(e: KeyboardEvent) {
-    if (mode === "navigate") {
-      if (e.key === "j" || e.key === "ArrowDown") {
-        e.preventDefault();
-        selectedIndex = Math.min(selectedIndex + 1, filtered.length - 1);
-      } else if (e.key === "k" || e.key === "ArrowUp") {
-        e.preventDefault();
-        selectedIndex = Math.max(selectedIndex - 1, 0);
-      } else if (e.key === "l" || e.key === "Enter") {
-        e.preventDefault();
-        if (filtered.length > 0) onSelect(filtered[selectedIndex]);
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        mode = "search";
-        inputEl?.focus();
-      } else if (e.key.length === 1) {
-        // Printable character — switch back to search mode and let it type
-        mode = "search";
-      }
-      return;
-    }
-
-    // Search mode
     if (e.key === "ArrowDown") {
       e.preventDefault();
       selectedIndex = Math.min(selectedIndex + 1, filtered.length - 1);
@@ -64,7 +41,7 @@
       selectedIndex = Math.max(selectedIndex - 1, 0);
     } else if (e.key === "Enter" && filtered.length > 0) {
       e.preventDefault();
-      mode = "navigate";
+      onSelect(filtered[selectedIndex]);
     } else if (e.key === "Escape") {
       e.preventDefault();
       onClose();
@@ -86,8 +63,6 @@
       bind:value={query}
       placeholder="Search projects..."
       class="search-input"
-      class:nav-mode={mode === "navigate"}
-      readonly={mode === "navigate"}
       onkeydown={handleKeydown}
     />
     <div class="results">
@@ -139,10 +114,6 @@
     padding: 14px 16px;
     font-size: 15px;
     outline: none;
-  }
-  .search-input.nav-mode {
-    color: #6c7086;
-    border-bottom-color: #cba6f7;
   }
   .results {
     overflow-y: auto;

--- a/src/lib/FuzzyFinder.test.ts
+++ b/src/lib/FuzzyFinder.test.ts
@@ -54,7 +54,7 @@ describe('FuzzyFinder', () => {
     expect(screen.getByText('No matching directories')).toBeInTheDocument();
   });
 
-  it('calls onClose on Escape in search mode', async () => {
+  it('calls onClose on Escape', async () => {
     const user = userEvent.setup();
     render(FuzzyFinder, { props: { onSelect, onClose } });
     await screen.findByText('alpha-project');
@@ -66,7 +66,7 @@ describe('FuzzyFinder', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('Enter enters navigate mode instead of selecting', async () => {
+  it('Enter selects the highlighted item', async () => {
     const user = userEvent.setup();
     render(FuzzyFinder, { props: { onSelect, onClose } });
     await screen.findByText('alpha-project');
@@ -75,72 +75,35 @@ describe('FuzzyFinder', () => {
     await user.click(input);
     await user.keyboard('{Enter}');
 
-    expect(onSelect).not.toHaveBeenCalled();
-    expect(input).toHaveAttribute('readonly');
+    expect(onSelect).toHaveBeenCalledWith(mockEntries[0]);
   });
 
-  it('j/k navigate and l selects in navigate mode', async () => {
+  it('ArrowDown + Enter selects the second item', async () => {
     const user = userEvent.setup();
     render(FuzzyFinder, { props: { onSelect, onClose } });
     await screen.findByText('alpha-project');
 
     const input = screen.getByPlaceholderText('Search projects...');
     await user.click(input);
-    // Enter nav mode
+    await user.keyboard('{ArrowDown}');
     await user.keyboard('{Enter}');
-    // j moves down to beta-app
-    await user.keyboard('j');
-    // l selects it
-    await user.keyboard('l');
 
     expect(onSelect).toHaveBeenCalledWith(mockEntries[1]);
   });
 
-  it('k moves up in navigate mode', async () => {
+  it('ArrowUp moves selection up', async () => {
     const user = userEvent.setup();
     render(FuzzyFinder, { props: { onSelect, onClose } });
     await screen.findByText('alpha-project');
 
     const input = screen.getByPlaceholderText('Search projects...');
     await user.click(input);
-    // Enter nav mode, move down twice, then up once
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{ArrowUp}');
     await user.keyboard('{Enter}');
-    await user.keyboard('j');
-    await user.keyboard('j');
-    await user.keyboard('k');
-    await user.keyboard('l');
 
     expect(onSelect).toHaveBeenCalledWith(mockEntries[1]);
-  });
-
-  it('Escape in navigate mode returns to search mode', async () => {
-    const user = userEvent.setup();
-    render(FuzzyFinder, { props: { onSelect, onClose } });
-    await screen.findByText('alpha-project');
-
-    const input = screen.getByPlaceholderText('Search projects...');
-    await user.click(input);
-    await user.keyboard('{Enter}');
-    expect(input).toHaveAttribute('readonly');
-
-    await user.keyboard('{Escape}');
-    expect(input).not.toHaveAttribute('readonly');
-    expect(onClose).not.toHaveBeenCalled();
-  });
-
-  it('typing in navigate mode returns to search mode', async () => {
-    const user = userEvent.setup();
-    render(FuzzyFinder, { props: { onSelect, onClose } });
-    await screen.findByText('alpha-project');
-
-    const input = screen.getByPlaceholderText('Search projects...');
-    await user.click(input);
-    await user.keyboard('{Enter}');
-    expect(input).toHaveAttribute('readonly');
-
-    // Typing a non-nav character returns to search mode
-    await user.keyboard('a');
-    expect(input).not.toHaveAttribute('readonly');
   });
 
   it('invokes list_root_directories on mount', async () => {


### PR DESCRIPTION
## Summary
- Remove two-phase search/navigate mode from FuzzyFinder
- Enter now directly selects the highlighted item instead of switching to navigate mode
- Arrow keys (up/down) handle all navigation — no more j/k/l keys needed

## Test plan
- [x] All 164 frontend tests pass
- [x] All 16 Rust tests pass
- [x] FuzzyFinder-specific tests updated and passing (9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)