### PR TITLE
fix: make toggle-agent hotkey focus-aware in agents mode

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -62,7 +62,7 @@
 
   function getTargetProject(): Project | undefined {
     const focus = focusTargetState.current;
-    if (focus?.type === "project" || focus?.type === "session") {
+    if (focus?.type === "project" || focus?.type === "session" || focus?.type === "agent") {
       return projectsState.current.find((p) => p.id === focus.projectId);
     }
     return undefined;
@@ -88,7 +88,7 @@
 
   async function toggleAutoWorkerEnabled() {
     const focus = focusTargetState.current;
-    if (!focus || (focus.type !== "project" && focus.type !== "session")) return;
+    if (!focus || (focus.type !== "project" && focus.type !== "session" && focus.type !== "agent")) return;
     const project = projectsState.current.find((p) => p.id === focus.projectId);
     if (!project) return;
     const newEnabled = !project.auto_worker.enabled;

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -387,7 +387,11 @@
         toggleModeActive = true;
         return true;
       case "toggle-agent":
-        dispatchAction({ type: "toggle-auto-worker-enabled" });
+        if (currentFocus?.type === "agent" && currentFocus.agentKind === "maintainer") {
+          dispatchAction({ type: "toggle-maintainer-enabled" });
+        } else {
+          dispatchAction({ type: "toggle-auto-worker-enabled" });
+        }
         return true;
       case "trigger-agent-check":
         dispatchAction({ type: "trigger-maintainer-check" });


### PR DESCRIPTION
## Summary
- Pressing `o` in agents workspace mode now toggles the **focused** agent (auto-worker or maintainer) instead of always toggling auto-worker
- Fixed `getTargetProject()` and `toggleAutoWorkerEnabled()` to handle `focus.type === "agent"`

## Test plan
- [x] All 164 frontend tests pass
- [x] All 16 Rust tests pass
- [ ] Focus on auto-worker row → press `o` → auto-worker toggles
- [ ] Focus on maintainer row → press `o` → maintainer toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)