### PR TITLE
fix: show Development instead of Projects in sidebar header

### DIFF
--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -481,7 +481,7 @@
 
 <aside class="sidebar" bind:this={sidebarEl}>
   <div class="sidebar-header">
-    <h2>{isArchiveView ? "Archives" : currentMode === "agents" ? "Agents" : "Projects"}</h2>
+    <h2>{isArchiveView ? "Archives" : currentMode === "agents" ? "Agents" : "Development"}</h2>
   </div>
 
   <div class="project-list">


### PR DESCRIPTION
## Summary
- Changed sidebar header label from "Projects" to "Development" when in development workspace mode
- The workspace mode is `"development"` but the header incorrectly displayed "Projects"

## Test plan
- [x] All 164 frontend tests pass
- [x] All 16 Rust tests pass
- [x] Visual: sidebar header shows "Development" in development mode, "Agents" in agents mode, "Archives" in archive view

🤖 Generated with [Claude Code](https://claude.com/claude-code)