### PR TITLE
fix: translate focus target when switching workspace modes

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -23,6 +23,7 @@
   } from "./stores";
   import { toggleKeystrokeVisualizer, pushKeystroke } from "./keystroke-visualizer";
   import { buildKeyMap, type CommandId } from "./commands";
+  import { focusForModeSwitch } from "./focus-helpers";
 
   let lastEscapeTime = 0;
 
@@ -167,10 +168,14 @@
     workspaceModePickerVisible.set(false);
     if (key === "d") {
       workspaceMode.set("development");
+      const newFocus = focusForModeSwitch(currentFocus, "development", activeId, projectList);
+      if (newFocus !== currentFocus) focusTarget.set(newFocus);
       return;
     }
     if (key === "a") {
       workspaceMode.set("agents");
+      const newFocus = focusForModeSwitch(currentFocus, "agents", activeId, projectList);
+      if (newFocus !== currentFocus) focusTarget.set(newFocus);
       return;
     }
     // Any other key (including Escape) cancels

--- a/src/lib/focus-helpers.test.ts
+++ b/src/lib/focus-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { focusAfterSessionDelete, focusAfterProjectDelete } from "./focus-helpers";
+import { focusAfterSessionDelete, focusAfterProjectDelete, focusForModeSwitch } from "./focus-helpers";
 import type { Project } from "./stores";
 
 function makeProject(id: string, sessionIds: string[]): Project {
@@ -91,5 +91,74 @@ describe("focusAfterProjectDelete", () => {
     const expanded = new Set<string>();
     const result = focusAfterProjectDelete(projects, "unknown", expanded, false);
     expect(result).toBeNull();
+  });
+});
+
+describe("focusForModeSwitch", () => {
+  it("translates agent focus to active session when switching to development", () => {
+    const projects = [makeProject("p1", ["s1", "s2"])];
+    const result = focusForModeSwitch(
+      { type: "agent", agentKind: "auto-worker", projectId: "p1" },
+      "development",
+      "s1",
+      projects,
+    );
+    expect(result).toEqual({ type: "session", sessionId: "s1", projectId: "p1" });
+  });
+
+  it("translates agent-panel focus to active session when switching to development", () => {
+    const projects = [makeProject("p1", ["s1"])];
+    const result = focusForModeSwitch(
+      { type: "agent-panel", agentKind: "maintainer", projectId: "p1" },
+      "development",
+      "s1",
+      projects,
+    );
+    expect(result).toEqual({ type: "session", sessionId: "s1", projectId: "p1" });
+  });
+
+  it("falls back to project when active session is not in the focused project", () => {
+    const projects = [makeProject("p1", ["s1"]), makeProject("p2", ["s2"])];
+    const result = focusForModeSwitch(
+      { type: "agent", agentKind: "auto-worker", projectId: "p1" },
+      "development",
+      "s2", // active session is in p2, not p1
+      projects,
+    );
+    expect(result).toEqual({ type: "project", projectId: "p1" });
+  });
+
+  it("falls back to project when no active session exists", () => {
+    const projects = [makeProject("p1", ["s1"])];
+    const result = focusForModeSwitch(
+      { type: "agent", agentKind: "auto-worker", projectId: "p1" },
+      "development",
+      null,
+      projects,
+    );
+    expect(result).toEqual({ type: "project", projectId: "p1" });
+  });
+
+  it("translates session focus to project when switching to agents", () => {
+    const projects = [makeProject("p1", ["s1"])];
+    const result = focusForModeSwitch(
+      { type: "session", sessionId: "s1", projectId: "p1" },
+      "agents",
+      "s1",
+      projects,
+    );
+    expect(result).toEqual({ type: "project", projectId: "p1" });
+  });
+
+  it("preserves project focus across mode switches", () => {
+    const projects = [makeProject("p1", ["s1"])];
+    const focus = { type: "project" as const, projectId: "p1" };
+    expect(focusForModeSwitch(focus, "development", "s1", projects)).toBe(focus);
+    expect(focusForModeSwitch(focus, "agents", "s1", projects)).toBe(focus);
+  });
+
+  it("returns null when current focus is null", () => {
+    expect(focusForModeSwitch(null, "development", null, [])).toBeNull();
+    expect(focusForModeSwitch(null, "agents", null, [])).toBeNull();
   });
 });

--- a/src/lib/focus-helpers.ts
+++ b/src/lib/focus-helpers.ts
@@ -1,4 +1,4 @@
-import type { Project, FocusTarget } from "./stores";
+import type { Project, FocusTarget, WorkspaceMode } from "./stores";
 
 /**
  * Compute the focus target after deleting a session.
@@ -47,4 +47,41 @@ export function focusAfterProjectDelete(
     }
   }
   return { type: "project", projectId: prevProject.id };
+}
+
+/**
+ * Translate focus target when switching workspace modes.
+ * Keeps the same project context but changes focus type to match the new mode.
+ *
+ * - Switching to development: agent/agent-panel → active session (if in same project) or project
+ * - Switching to agents: session → project
+ */
+export function focusForModeSwitch(
+  current: FocusTarget,
+  newMode: WorkspaceMode,
+  activeSessionId: string | null,
+  projectList: Project[],
+): FocusTarget {
+  if (!current) return null;
+
+  if (newMode === "development") {
+    if (current.type === "agent" || current.type === "agent-panel") {
+      // Try to focus the active session if it belongs to the same project
+      if (activeSessionId) {
+        const project = projectList.find(p => p.id === current.projectId);
+        if (project?.sessions.some(s => s.id === activeSessionId && !s.archived)) {
+          return { type: "session", sessionId: activeSessionId, projectId: current.projectId };
+        }
+      }
+      return { type: "project", projectId: current.projectId };
+    }
+  }
+
+  if (newMode === "agents") {
+    if (current.type === "session") {
+      return { type: "project", projectId: current.projectId };
+    }
+  }
+
+  return current;
 }


### PR DESCRIPTION
## Summary
- When switching between agent/development modes via `Space → d/a`, the `focusTarget` was not updated to match the new mode
- This caused no visible sidebar selection and broken j/k navigation (especially when `agent-panel` was focused, which intercepted j/k keys)
- Added `focusForModeSwitch()` helper that translates focus: agent/agent-panel → active session or project (when switching to dev), session → project (when switching to agents)

## Test plan
- [x] Unit tests for `focusForModeSwitch` covering all focus type transitions
- [x] All 171 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)