### PR TITLE
fix: handle r and c hotkeys in AgentDashboard for proper panel updates

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -45,10 +45,6 @@
         screenshotToNewSession(action.preview ?? false, action.cropped ?? false);
       } else if (action?.type === "toggle-maintainer-enabled") {
         toggleMaintainerEnabled();
-      } else if (action?.type === "trigger-maintainer-check") {
-        triggerMaintainerCheck();
-      } else if (action?.type === "clear-maintainer-reports") {
-        clearMaintainerReports();
       } else if (action?.type === "toggle-auto-worker-enabled") {
         toggleAutoWorkerEnabled();
       } else if (action?.type === "toggle-triage-panel") {
@@ -98,28 +94,6 @@
       const result: Project[] = await invoke("list_projects");
       projects.set(result);
       showToast(`Auto-worker ${newEnabled ? "enabled" : "disabled"}`, "info");
-    } catch (e) {
-      showToast(String(e), "error");
-    }
-  }
-
-  async function triggerMaintainerCheck() {
-    const project = getTargetProject();
-    if (!project) return;
-    try {
-      await invoke<any>("trigger_maintainer_check", { projectId: project.id });
-      showToast("Maintainer check complete", "info");
-    } catch (e) {
-      showToast(String(e), "error");
-    }
-  }
-
-  async function clearMaintainerReports() {
-    const project = getTargetProject();
-    if (!project) return;
-    try {
-      await invoke("clear_maintainer_reports", { projectId: project.id });
-      showToast("Maintainer reports cleared", "info");
     } catch (e) {
       showToast(String(e), "error");
     }

--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -70,6 +70,10 @@
         handleSelect();
       } else if (action.type === "agent-panel-escape") {
         handleEscape();
+      } else if (action.type === "trigger-maintainer-check") {
+        triggerCheck();
+      } else if (action.type === "clear-maintainer-reports") {
+        clearReports();
       }
     });
     return unsub;
@@ -146,6 +150,19 @@
       showToast(String(e), "error");
     } finally {
       triggerLoading = false;
+    }
+  }
+
+  async function clearReports() {
+    if (!project) return;
+    try {
+      await invoke("clear_maintainer_reports", { projectId: project.id });
+      reports = [];
+      openReportIndex = null;
+      selectedIndex = 0;
+      showToast("Maintainer reports cleared", "info");
+    } catch (e) {
+      showToast(String(e), "error");
     }
   }
 

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -726,6 +726,24 @@ describe('HotkeyManager', () => {
       pressKey('j');
       expect(get(focusTarget)).not.toBeNull();
     });
+
+    it('r dispatches trigger-maintainer-check when focus is agent-panel', () => {
+      focusTarget.set({ type: 'agent-panel', agentKind: 'maintainer', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('r');
+      expect(captured).toEqual({ type: 'trigger-maintainer-check' });
+      unsub();
+    });
+
+    it('c dispatches clear-maintainer-reports when focus is agent-panel', () => {
+      focusTarget.set({ type: 'agent-panel', agentKind: 'maintainer', projectId: 'proj-1' });
+      let captured: any = null;
+      const unsub = hotkeyAction.subscribe((v) => { captured = v; });
+      pressKey('c');
+      expect(captured).toEqual({ type: 'clear-maintainer-reports' });
+      unsub();
+    });
   });
 
   // ── Workspace mode (Space) ──


### PR DESCRIPTION
## Summary
- `r` (trigger maintainer check) and `c` (clear reports) hotkeys were handled in App.svelte, which ran the backend call but never updated AgentDashboard's local state
- Moved handling to AgentDashboard where `triggerCheck()` refreshes the reports list and `clearReports()` resets panel state, giving the user visible feedback
- Added tests verifying `r` and `c` dispatch correctly from `agent-panel` focus

## Test plan
- [x] All 166 frontend tests pass (including 2 new agent-panel hotkey tests)
- [x] All 16 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)