### PR TITLE
chore: remove Task Workflow from default agents.md

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,16 +55,6 @@ const DEFAULT_AGENTS_MD: &str = r#"# {name}
 
 One-line project description.
 
-## Task Workflow (CRITICAL)
-
-For every new task, follow this workflow:
-
-1. **File a GitHub issue** -- Create an issue describing the task before starting work.
-2. **Update with design plan** -- Once the design is complete, update the GitHub issue with the design plan.
-3. **Update with implementation plan** -- Once the implementation plan is ready, update the GitHub issue with it.
-4. **Close the issue** -- Close the GitHub issue once the task is fully completed and verified.
-5. **Update the merge commit/PR** -- After merging, update the merge note to summarize what work was done.
-
 ## Task Structure (CRITICAL -- NEVER SKIP)
 
 **This is the most important rule. Every task, no matter how small, MUST follow this structure before writing any code. No exceptions.**

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -569,7 +569,6 @@ fn test_scaffold_project_creates_template_files() {
     // Verify agents.md contains the project name
     let content = fs::read_to_string(repo_path.join("agents.md")).unwrap();
     assert!(content.starts_with(&format!("# {}", name)));
-    assert!(content.contains("Task Workflow"));
     assert!(content.contains("Task Structure"));
 }
 


### PR DESCRIPTION
## Summary
- Removed the overly prescriptive "Task Workflow" section from the default `agents.md` template that required filing GitHub issues for every task
- Updated integration test that asserted on the removed section

## Test plan
- [x] All 16 Rust tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)