### PR TITLE
fix: wire maintainer reports to correct project when switching agents

### DIFF
--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -7,7 +7,6 @@
   let reports: MaintainerReport[] = $state([]);
   let loading = $state(false);
   let triggerLoading = $state(false);
-  let currentProjectId: string | null = $state(null);
 
   // Panel navigation state
   let selectedIndex = $state(0);
@@ -37,18 +36,7 @@
     openReportIndex !== null ? reports[openReportIndex] ?? null : null
   );
 
-  // Fetch history when project changes
-  $effect(() => {
-    const pid = project?.id ?? null;
-    if (pid && pid !== currentProjectId) {
-      currentProjectId = pid;
-      if (focusedAgent?.agentKind === "maintainer") {
-        fetchHistory(pid);
-      }
-    }
-  });
-
-  // Reset panel state when switching agents
+  // Fetch history and reset panel state when switching agents
   let prevAgentKey: string | null = $state(null);
   $effect(() => {
     const key = focusedAgent ? `${focusedAgent.projectId}:${focusedAgent.agentKind}` : null;
@@ -57,6 +45,12 @@
       selectedIndex = 0;
       openReportIndex = null;
       detailBlockIndex = 0;
+      reports = [];
+
+      const pid = project?.id ?? null;
+      if (pid && focusedAgent?.agentKind === "maintainer") {
+        fetchHistory(pid);
+      }
     }
   });
 
@@ -131,11 +125,18 @@
   async function fetchHistory(projectId: string) {
     loading = true;
     try {
-      reports = await invoke<MaintainerReport[]>("get_maintainer_history", { projectId });
+      const result = await invoke<MaintainerReport[]>("get_maintainer_history", { projectId });
+      if (prevAgentKey === `${projectId}:maintainer`) {
+        reports = result;
+      }
     } catch {
-      reports = [];
+      if (prevAgentKey === `${projectId}:maintainer`) {
+        reports = [];
+      }
     } finally {
-      loading = false;
+      if (prevAgentKey === `${projectId}:maintainer`) {
+        loading = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed bug where maintainer reports from a previously-viewed project were displayed under a different project when switching agents
- Root cause: the fetch effect only tracked project ID changes, so navigating to a project's auto-worker first then its maintainer skipped the fetch (same project ID), leaving stale reports
- Merged two separate effects into one keyed on `projectId:agentKind`, clearing reports on switch and adding a staleness guard to prevent async race conditions

## Test plan
- [x] All 171 frontend tests pass
- [x] All 16 Rust tests pass
- [ ] Manual: View the-controller > Maintainer reports, then switch to rta-v2 > Auto-worker, then rta-v2 > Maintainer — should show rta-v2's reports (or "No reports yet"), not the-controller's

🤖 Generated with [Claude Code](https://claude.com/claude-code)