### PR TITLE
feat: add assigned-but-uncompleted issues panel

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -880,6 +880,13 @@ pub async fn list_github_issues(
 }
 
 #[tauri::command]
+pub async fn list_assigned_issues(
+    repo_path: String,
+) -> Result<Vec<crate::models::AssignedIssue>, String> {
+    github::list_assigned_issues(repo_path).await
+}
+
+#[tauri::command]
 pub async fn generate_issue_body(title: String) -> Result<String, String> {
     github::generate_issue_body(title).await
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1,6 +1,6 @@
 use tauri::State;
 
-use crate::models::GithubIssue;
+use crate::models::{AssignedIssue, GithubIssue};
 use crate::state::AppState;
 
 /// Parse a GitHub remote URL into an "owner/repo" string.
@@ -307,6 +307,41 @@ pub(crate) async fn remove_github_label(
     }
 
     Ok(())
+}
+
+pub(crate) async fn list_assigned_issues(repo_path: String) -> Result<Vec<AssignedIssue>, String> {
+    let nwo = extract_github_repo_async(repo_path).await?;
+
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            &nwo,
+            "--json",
+            "number,title,url,assignees,updatedAt,labels",
+            "--limit",
+            "100",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh issue list failed: {}", stderr));
+    }
+
+    let all_issues: Vec<AssignedIssue> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    // Filter to only issues that have at least one assignee
+    let assigned = all_issues
+        .into_iter()
+        .filter(|issue| !issue.assignees.is_empty())
+        .collect();
+
+    Ok(assigned)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
             commands::generate_project_names,
             commands::scaffold_project,
             commands::list_github_issues,
+            commands::list_assigned_issues,
             commands::generate_issue_body,
             commands::create_github_issue,
             commands::post_github_comment,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -107,6 +107,23 @@ pub struct GithubLabel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubAssignee {
+    pub login: String,
+}
+
+/// An open issue that has at least one assignee.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssignedIssue {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub assignees: Vec<GithubAssignee>,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    pub labels: Vec<GithubLabel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum MergeResponse {
     #[serde(rename = "pr_created")]
@@ -488,5 +505,65 @@ mod tests {
         let json = serde_json::to_string(&project).expect("serialize");
         let deserialized: Project = serde_json::from_str(&json).expect("deserialize");
         assert!(deserialized.auto_worker.enabled);
+    }
+
+    #[test]
+    fn test_assigned_issue_serialization_roundtrip() {
+        let issue = AssignedIssue {
+            number: 42,
+            title: "Fix the bug".to_string(),
+            url: "https://github.com/owner/repo/issues/42".to_string(),
+            assignees: vec![GithubAssignee {
+                login: "alice".to_string(),
+            }],
+            updated_at: "2026-03-01T12:00:00Z".to_string(),
+            labels: vec![GithubLabel {
+                name: "bug".to_string(),
+            }],
+        };
+        let json = serde_json::to_string(&issue).expect("serialize");
+        let deserialized: AssignedIssue = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized.number, 42);
+        assert_eq!(deserialized.title, "Fix the bug");
+        assert_eq!(deserialized.assignees.len(), 1);
+        assert_eq!(deserialized.assignees[0].login, "alice");
+        assert_eq!(deserialized.updated_at, "2026-03-01T12:00:00Z");
+        assert_eq!(deserialized.labels.len(), 1);
+    }
+
+    #[test]
+    fn test_assigned_issue_deserialization_from_gh_json() {
+        let json = r#"{
+            "number": 10,
+            "title": "Stale issue",
+            "url": "https://github.com/owner/repo/issues/10",
+            "assignees": [
+                {"login": "bob"},
+                {"login": "carol"}
+            ],
+            "updatedAt": "2026-01-15T08:30:00Z",
+            "labels": []
+        }"#;
+        let issue: AssignedIssue = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(issue.number, 10);
+        assert_eq!(issue.assignees.len(), 2);
+        assert_eq!(issue.assignees[0].login, "bob");
+        assert_eq!(issue.assignees[1].login, "carol");
+        assert_eq!(issue.updated_at, "2026-01-15T08:30:00Z");
+    }
+
+    #[test]
+    fn test_assigned_issue_empty_assignees() {
+        let issue = AssignedIssue {
+            number: 1,
+            title: "Unassigned".to_string(),
+            url: "https://github.com/owner/repo/issues/1".to_string(),
+            assignees: vec![],
+            updated_at: "2026-03-09T00:00:00Z".to_string(),
+            labels: vec![],
+        };
+        let json = serde_json::to_string(&issue).expect("serialize");
+        let deserialized: AssignedIssue = serde_json::from_str(&json).expect("deserialize");
+        assert!(deserialized.assignees.is_empty());
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
   import CreateIssueModal from "./lib/CreateIssueModal.svelte";
   import IssuePickerModal from "./lib/IssuePickerModal.svelte";
   import TriagePanel from "./lib/TriagePanel.svelte";
+  import AssignedIssuesPanel from "./lib/AssignedIssuesPanel.svelte";
   import KeystrokeVisualizer from "./lib/KeystrokeVisualizer.svelte";
   import WorkspaceModePicker from "./lib/WorkspaceModePicker.svelte";
   import AgentDashboard from "./lib/AgentDashboard.svelte";
@@ -22,6 +23,7 @@
   let createIssueTarget: { projectId: string; repoPath: string } | null = $state(null);
   let issuePickerTarget: { projectId: string; repoPath: string; kind?: string; background?: boolean } | null = $state(null);
   let triagePanelOpen: TriageCategory | null = $state(null);
+  let assignedIssuesPanelOpen = $state(false);
 
   const sidebarVisibleState = fromStore(sidebarVisible);
   const showKeyHintsState = fromStore(showKeyHints);
@@ -51,6 +53,8 @@
         if (action.category) {
           triagePanelOpen = triagePanelOpen ? null : action.category;
         }
+      } else if (action?.type === "toggle-assigned-issues-panel") {
+        assignedIssuesPanelOpen = !assignedIssuesPanelOpen;
       }
     });
     return unsub;
@@ -283,6 +287,9 @@
     {/if}
     {#if triagePanelOpen}
       <TriagePanel category={triagePanelOpen} onClose={() => { triagePanelOpen = null; }} />
+    {/if}
+    {#if assignedIssuesPanelOpen}
+      <AssignedIssuesPanel onClose={() => { assignedIssuesPanelOpen = false; }} />
     {/if}
     {#if workspaceModePickerVisibleState.current}
       <WorkspaceModePicker />

--- a/src/lib/AssignedIssuesPanel.svelte
+++ b/src/lib/AssignedIssuesPanel.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { fromStore } from "svelte/store";
+  import { invoke } from "@tauri-apps/api/core";
+  import { focusTarget, projects, type AssignedIssue, type Project, type FocusTarget } from "./stores";
+
+  interface Props {
+    onClose: () => void;
+  }
+
+  let { onClose }: Props = $props();
+
+  let issues: AssignedIssue[] = $state([]);
+  let loading = $state(false);
+  let error: string | null = $state(null);
+
+  const projectsState = fromStore(projects);
+  let projectList: Project[] = $derived(projectsState.current);
+  const focusTargetState = fromStore(focusTarget);
+  let currentFocus: FocusTarget = $derived(focusTargetState.current);
+
+  let project: Project | null = $derived(
+    currentFocus?.projectId
+      ? projectList.find((p) => p.id === currentFocus!.projectId) ?? null
+      : projectList[0] ?? null
+  );
+  let repoPath: string | null = $derived(project?.repo_path ?? null);
+
+  $effect(() => {
+    if (repoPath) {
+      fetchAssignedIssues(repoPath);
+    }
+  });
+
+  async function fetchAssignedIssues(path: string) {
+    loading = true;
+    error = null;
+    try {
+      issues = await invoke<AssignedIssue[]>("list_assigned_issues", { repoPath: path });
+      // Sort by updatedAt ascending (stalest first)
+      issues.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+    } catch (e) {
+      error = String(e);
+      issues = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  function formatDate(iso: string): string {
+    const date = new Date(iso);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return "today";
+    if (diffDays === 1) return "1 day ago";
+    if (diffDays < 30) return `${diffDays} days ago`;
+    if (diffDays < 365) {
+      const months = Math.floor(diffDays / 30);
+      return months === 1 ? "1 month ago" : `${months} months ago`;
+    }
+    const years = Math.floor(diffDays / 365);
+    return years === 1 ? "1 year ago" : `${years} years ago`;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeydown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeydown, { capture: true });
+    };
+  });
+</script>
+
+<div class="overlay" onclick={onClose} role="dialog">
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div class="panel-container" onclick={(e) => e.stopPropagation()} role="presentation">
+    <div class="panel-header">
+      <h2>Assigned Issues</h2>
+      <span class="count">{issues.length} issue{issues.length !== 1 ? "s" : ""}</span>
+    </div>
+
+    {#if loading}
+      <div class="status">Loading assigned issues...</div>
+    {:else if error}
+      <div class="status error">{error}</div>
+    {:else if issues.length === 0}
+      <div class="status">No assigned open issues found</div>
+    {:else}
+      <div class="issue-list">
+        {#each issues as issue}
+          <div class="issue-row">
+            <div class="issue-main">
+              <span class="issue-number">#{issue.number}</span>
+              <span class="issue-title">{issue.title}</span>
+            </div>
+            <div class="issue-meta">
+              <span class="assignees">
+                {#each issue.assignees as assignee, i}
+                  <span class="assignee">@{assignee.login}</span>{#if i < issue.assignees.length - 1},{/if}
+                {/each}
+              </span>
+              <span class="updated">{formatDate(issue.updatedAt)}</span>
+            </div>
+            {#if issue.labels.length > 0}
+              <div class="issue-labels">
+                {#each issue.labels as label}
+                  <span class="label">{label.name}</span>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="panel-footer">
+      <kbd>Esc</kbd> close
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+
+  .panel-container {
+    background: #1e1e2e;
+    border: 1px solid #313244;
+    border-radius: 12px;
+    width: 640px;
+    max-height: 80vh;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .panel-header h2 {
+    color: #cdd6f4;
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .count {
+    color: #6c7086;
+    font-size: 13px;
+  }
+
+  .status {
+    padding: 32px;
+    color: #6c7086;
+    font-size: 14px;
+    text-align: center;
+  }
+
+  .status.error {
+    color: #f38ba8;
+  }
+
+  .issue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+    max-height: 60vh;
+  }
+
+  .issue-row {
+    padding: 10px 12px;
+    border-radius: 6px;
+    background: #181825;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .issue-row:hover {
+    background: #1e1e2e;
+    outline: 1px solid #313244;
+  }
+
+  .issue-main {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .issue-number {
+    color: #89b4fa;
+    font-size: 13px;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .issue-title {
+    color: #cdd6f4;
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .issue-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 12px;
+  }
+
+  .assignees {
+    color: #a6e3a1;
+  }
+
+  .assignee {
+    font-weight: 500;
+  }
+
+  .updated {
+    color: #6c7086;
+  }
+
+  .issue-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 2px;
+  }
+
+  .label {
+    font-size: 11px;
+    color: #bac2de;
+    background: #313244;
+    padding: 1px 6px;
+    border-radius: 4px;
+  }
+
+  .panel-footer {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    color: #6c7086;
+    font-size: 12px;
+    padding-top: 8px;
+    border-top: 1px solid #313244;
+  }
+
+  .panel-footer kbd {
+    background: #313244;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    color: #cdd6f4;
+  }
+</style>

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -372,6 +372,9 @@
       case "triage-triaged":
         dispatchAction({ type: "toggle-triage-panel", category: "triaged" });
         return true;
+      case "assigned-issues":
+        dispatchAction({ type: "toggle-assigned-issues-panel" });
+        return true;
       case "expand-collapse":
         if (currentFocus?.type === "project") {
           const next = new Set(expandedSet);

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -104,7 +104,7 @@ describe("command registry", () => {
     expect(sess.entries).toHaveLength(8);
 
     const proj = sections.find(s => s.label === "Projects")!;
-    expect(proj.entries).toHaveLength(7);
+    expect(proj.entries).toHaveLength(8);
 
     const panels = sections.find(s => s.label === "Panels")!;
     expect(panels.entries).toHaveLength(4);

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -23,6 +23,7 @@ export type CommandId =
   | "create-issue"
   | "triage-untriaged"
   | "triage-triaged"
+  | "assigned-issues"
   | "expand-collapse"
   | "toggle-mode"
   | "toggle-agent"
@@ -81,6 +82,7 @@ export const commands: CommandDef[] = [
   { id: "create-issue", key: "i", section: "Projects", description: "Create GitHub issue for focused project", mode: "development" },
   { id: "triage-untriaged", key: "t", section: "Projects", description: "Triage issues (untriaged)", mode: "development" },
   { id: "triage-triaged", key: "T", section: "Projects", description: "View triaged issues", mode: "development" },
+  { id: "assigned-issues", key: "e", section: "Projects", description: "View assigned but uncompleted issues", mode: "development" },
 
   // ── Panels ──
   { id: "toggle-sidebar", key: "s", section: "Panels", description: "Toggle sidebar" },

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -8,6 +8,15 @@ export interface GithubIssue {
   labels: { name: string }[];
 }
 
+export interface AssignedIssue {
+  number: number;
+  title: string;
+  url: string;
+  assignees: { login: string }[];
+  updatedAt: string;
+  labels: { name: string }[];
+}
+
 export interface DirEntry {
   name: string;
   path: string;
@@ -113,6 +122,7 @@ export type HotkeyAction =
   | { type: "toggle-maintainer-enabled" }
   | { type: "toggle-auto-worker-enabled" }
   | { type: "toggle-triage-panel"; category?: TriageCategory }
+  | { type: "toggle-assigned-issues-panel" }
   | { type: "trigger-maintainer-check" }
   | { type: "clear-maintainer-reports" }
   | { type: "agent-panel-navigate"; direction: 1 | -1 }


### PR DESCRIPTION
## Summary
- Add `list_assigned_issues` Tauri command that queries GitHub for open issues with assignees via `gh` CLI
- Add `AssignedIssuesPanel` modal UI showing assigned issues sorted stalest-first with issue number, title, assignee(s), and relative last-activity date
- Add hotkey `e` (development mode) to toggle the panel
- Add `AssignedIssue` / `GithubAssignee` models with serialization tests

## Test plan
- [x] `cargo test` — 174 Rust tests pass (3 new for AssignedIssue model)
- [x] `npx vitest run` — 173 frontend tests pass (1 updated for new command count)
- [ ] Manual: press `e` in development mode to open panel, verify assigned issues display

closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)