### PR TITLE
fix: agent panel focus navigation and maintainer error visibility

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1215,11 +1215,18 @@ pub async fn trigger_maintainer_check(
 
     let _ = app_handle.emit(&format!("maintainer-status:{}", project_id), "running");
 
-    let log = crate::maintainer::run_maintainer_check(
+    let log = match crate::maintainer::run_maintainer_check(
         &repo_path,
         project_id,
         github_repo.as_deref(),
-    )?;
+    ) {
+        Ok(log) => log,
+        Err(e) => {
+            let _ = app_handle.emit(&format!("maintainer-status:{}", project_id), "error");
+            let _ = app_handle.emit(&format!("maintainer-error:{}", project_id), e.to_string());
+            return Err(e);
+        }
+    };
 
     {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -85,6 +85,10 @@ impl MaintainerScheduler {
                                 &format!("maintainer-status:{}", project.id),
                                 "error",
                             );
+                            let _ = app_handle.emit(
+                                &format!("maintainer-error:{}", project.id),
+                                e.to_string(),
+                            );
                         }
                     }
                 }

--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -2,7 +2,7 @@
   import { fromStore } from "svelte/store";
   import { untrack } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
-  import { focusTarget, projects, maintainerStatuses, autoWorkerStatuses, hotkeyAction, type Project, type FocusTarget, type MaintainerRunLog, type MaintainerStatus, type AutoWorkerStatus } from "./stores";
+  import { focusTarget, projects, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, type Project, type FocusTarget, type MaintainerRunLog, type MaintainerStatus, type AutoWorkerStatus } from "./stores";
   import { showToast } from "./toast";
 
   let runLogs: MaintainerRunLog[] = $state([]);
@@ -200,9 +200,15 @@
     project ? (maintainerStatusesState.current.get(project.id) ?? null) : null
   );
 
+  const maintainerErrorsState = fromStore(maintainerErrors);
+  let maintainerError: string | null = $derived(
+    project ? (maintainerErrorsState.current.get(project.id) ?? null) : null
+  );
+
   let maintainerStatusText = $derived(
     !project?.maintainer.enabled ? "off"
       : maintainerStatus === "running" ? "running"
+      : maintainerStatus === "error" ? "error"
       : "pending"
   );
 
@@ -220,7 +226,7 @@
   }
 </script>
 
-<div class="dashboard">
+<div class="dashboard" class:panel-focused={panelFocused}>
   {#if !focusedAgent || !project}
     <div class="empty-state">
       <div class="empty-title">No agent selected</div>
@@ -277,6 +283,13 @@
         <span>Timer: {nextRunText}</span>
         <span>Status: {maintainerStatusText}</span>
       </div>
+
+      {#if maintainerError}
+        <div class="error-banner">
+          <span class="error-label">Error</span>
+          <span class="error-message">{maintainerError}</span>
+        </div>
+      {/if}
     </section>
 
     <section class="section report-section">
@@ -363,7 +376,8 @@
 </div>
 
 <style>
-  .dashboard { width: 100%; height: 100%; overflow-y: auto; background: #11111b; color: #cdd6f4; }
+  .dashboard { width: 100%; height: 100%; overflow-y: auto; background: #11111b; color: #cdd6f4; outline: 2px solid transparent; outline-offset: -2px; transition: outline-color 0.15s; }
+  .dashboard.panel-focused { outline-color: rgba(137, 180, 250, 0.4); border-radius: 4px; }
   .empty-state { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 8px; }
   .empty-title { font-size: 16px; font-weight: 500; }
   .empty-hint { color: #6c7086; font-size: 13px; }
@@ -438,6 +452,10 @@
   .issue-title { color: #cdd6f4; }
   .issue-labels { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px; }
   .issue-label { font-size: 10px; padding: 1px 6px; border-radius: 3px; background: #313244; color: #6c7086; }
+
+  .error-banner { padding: 8px 24px; background: rgba(243, 139, 168, 0.1); border-bottom: 1px solid rgba(243, 139, 168, 0.2); display: flex; align-items: baseline; gap: 8px; font-size: 12px; }
+  .error-label { color: #f38ba8; font-weight: 600; font-size: 11px; text-transform: uppercase; flex-shrink: 0; }
+  .error-message { color: #bac2de; word-break: break-word; }
 
   .panel-hint { padding: 12px 24px; }
 </style>

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { listen } from "@tauri-apps/api/event";
-  import { projects, activeSessionId, sessionStatuses, maintainerStatuses, autoWorkerStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, workspaceMode, type Project, type JumpPhase, type FocusTarget, type SessionStatus, type AutoWorkerStatus } from "./stores";
+  import { projects, activeSessionId, sessionStatuses, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, workspaceMode, type Project, type JumpPhase, type FocusTarget, type SessionStatus, type AutoWorkerStatus } from "./stores";
   import { showToast } from "./toast";
   import { focusAfterSessionDelete, focusAfterProjectDelete } from "./focus-helpers";
   import FuzzyFinder from "./FuzzyFinder.svelte";
@@ -86,6 +86,11 @@
           const el = sidebarEl?.querySelector<HTMLElement>(`[data-agent-id="${currentFocus.projectId}:${currentFocus.agentKind}"]`);
           if (el) el.focus();
         });
+      }
+    } else if (currentFocus?.type === "agent-panel") {
+      // Blur sidebar element so visual focus moves to the panel
+      if (document.activeElement instanceof HTMLElement && sidebarEl?.contains(document.activeElement)) {
+        document.activeElement.blur();
       }
     }
   });
@@ -259,6 +264,22 @@
         maintainerStatuses.update(m => {
           const next = new Map(m);
           next.set(project.id, event.payload as MaintainerStatus);
+          return next;
+        });
+        // Clear error when status changes to non-error
+        if (event.payload !== "error") {
+          maintainerErrors.update(m => {
+            const next = new Map(m);
+            next.delete(project.id);
+            return next;
+          });
+        }
+      }).then(unlisten => { if (!cancelled) unlisteners.push(unlisten); else unlisten(); });
+
+      listen<string>(`maintainer-error:${project.id}`, (event) => {
+        maintainerErrors.update(m => {
+          const next = new Map(m);
+          next.set(project.id, event.payload);
           return next;
         });
       }).then(unlisten => { if (!cancelled) unlisteners.push(unlisten); else unlisten(); });

--- a/src/lib/sidebar/AgentTree.svelte
+++ b/src/lib/sidebar/AgentTree.svelte
@@ -25,8 +25,12 @@
 
   function isAgentFocused(projectId: string, kind: AgentKind): boolean {
     if (!currentFocus) return false;
-    if ((currentFocus.type === "agent" || currentFocus.type === "agent-panel") && currentFocus.projectId === projectId && currentFocus.agentKind === kind) return true;
-    return false;
+    return currentFocus.type === "agent" && currentFocus.projectId === projectId && currentFocus.agentKind === kind;
+  }
+
+  function isAgentActive(projectId: string, kind: AgentKind): boolean {
+    if (!currentFocus) return false;
+    return currentFocus.type === "agent-panel" && currentFocus.projectId === projectId && currentFocus.agentKind === kind;
   }
 
   function awIsWorking(projectId: string): boolean {
@@ -65,6 +69,7 @@
         <div
           class="agent-item"
           class:focus-target={isAgentFocused(project.id, "auto-worker")}
+          class:active={isAgentActive(project.id, "auto-worker")}
           data-agent-id="{project.id}:auto-worker"
           tabindex="0"
           onfocusin={() => onAgentFocus("auto-worker", project.id)}
@@ -81,6 +86,7 @@
         <div
           class="agent-item"
           class:focus-target={isAgentFocused(project.id, "maintainer")}
+          class:active={isAgentActive(project.id, "maintainer")}
           data-agent-id="{project.id}:maintainer"
           tabindex="0"
           onfocusin={() => onAgentFocus("maintainer", project.id)}
@@ -171,6 +177,10 @@
     outline: 2px solid #89b4fa;
     outline-offset: -2px;
     border-radius: 4px;
+  }
+
+  .agent-item.active {
+    background: rgba(137, 180, 250, 0.1);
   }
 
   .status-dot {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -90,6 +90,7 @@ export const sessionStatuses = writable<Map<string, SessionStatus>>(new Map());
 export const appConfig = writable<Config | null>(null);
 export const onboardingComplete = writable<boolean>(false);
 export const maintainerStatuses = writable<Map<string, MaintainerStatus>>(new Map());
+export const maintainerErrors = writable<Map<string, string>>(new Map());
 export type AutoWorkerStatus = {
   status: "idle" | "working";
   message?: string;


### PR DESCRIPTION
## Summary
- Fix `l` key not visually moving focus from sidebar agent item to main panel — sidebar kept blue outline because `isAgentFocused` treated both `"agent"` and `"agent-panel"` focus types the same
- Fix maintainer status text showing "pending" when actual status is "error"
- Surface maintainer error messages to the frontend so users can see why a check failed (previously only logged to stderr)
- Fix `trigger_maintainer_check` command leaving status stuck at "running" on failure

## Test plan
- [x] All 173 frontend tests pass
- [x] All 17 Rust tests pass
- [ ] Press `l` on a sidebar agent — blue outline should move from sidebar to panel border
- [ ] Press `Esc` in panel — focus should return to sidebar agent item
- [ ] When maintainer errors, error banner should appear with the actual error message
- [ ] Status row should show "error" not "pending" when maintainer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)