### PR TITLE
fix: maintainer --allowedTools arg parsing

### DIFF
--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -257,8 +257,7 @@ pub fn run_maintainer_check(
     let prompt = build_issue_filing_prompt(repo_path, github_repo);
     let output = std::process::Command::new("claude")
         .arg("--print")
-        .arg("--allowedTools")
-        .arg("Bash")
+        .arg("--allowedTools=Bash")
         .arg(&prompt)
         .current_dir(repo_path)
         .env_remove("CLAUDECODE")


### PR DESCRIPTION
## Summary
- Fixed `claude --print` failing with "Input must be provided either through stdin or as a prompt argument" error
- Root cause: `--allowedTools` and `Bash` were passed as separate `.arg()` calls, causing the Claude CLI to consume the prompt as a tool name
- Changed to `--allowedTools=Bash` single-arg format so the prompt is correctly passed as input

## Test plan
- [x] Rust tests pass (17/17)
- [x] Frontend tests pass (173/173)
- [ ] Manually verify maintainer check runs without the "Input must be provided" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)