### PR TITLE
feat: switch background agents from Claude to Codex

### DIFF
--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -280,7 +280,7 @@ fn spawn_auto_worker_session(
             worktree_path: wt_path,
             worktree_branch: wt_branch,
             archived: false,
-            kind: "claude".to_string(),
+            kind: "codex".to_string(),
             github_issue: Some(issue.clone()),
             initial_prompt: Some(initial_prompt.clone()),
             done_commits: vec![],
@@ -293,7 +293,7 @@ fn spawn_auto_worker_session(
     pty_manager.spawn_session(
         session_id,
         &session_dir,
-        "claude",
+        "codex",
         app_handle.clone(),
         false,
         Some(&initial_prompt),

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -255,18 +255,19 @@ pub fn run_maintainer_check(
     github_repo: Option<&str>,
 ) -> Result<MaintainerRunLog, String> {
     let prompt = build_issue_filing_prompt(repo_path, github_repo);
-    let output = std::process::Command::new("claude")
-        .arg("--print")
-        .arg("--allowedTools=Bash")
+    let output = std::process::Command::new("codex")
+        .arg("exec")
+        .arg("--sandbox")
+        .arg("danger-full-access")
         .arg(&prompt)
         .current_dir(repo_path)
         .env_remove("CLAUDECODE")
         .output()
-        .map_err(|e| format!("Failed to run claude --print: {}", e))?;
+        .map_err(|e| format!("Failed to run codex exec: {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("claude --print failed: {}", stderr));
+        return Err(format!("codex exec failed: {}", stderr));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary
- Auto-worker sessions now spawn `codex` instead of `claude` for autonomous issue processing
- Maintainer health checks use `codex exec --sandbox danger-full-access` instead of `claude --print --allowedTools=Bash`

## Test plan
- [x] 175 Rust unit tests pass
- [x] 198 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)