### PR TITLE
Add deterministic dedup guard for maintainer issue filing

### DIFF
--- a/docs/plans/2026-03-09-maintainer-dedup-guard-design.md
+++ b/docs/plans/2026-03-09-maintainer-dedup-guard-design.md
@@ -1,0 +1,45 @@
+# Deterministic Maintainer Dedup Guard Design
+
+## Definition
+
+Issue #292 reports that the maintainer pipeline creates semantically duplicate `filed-by-maintainer` issues because dedup is left to model judgment in prompt text. We need a deterministic guard that routes duplicate findings to update/comment on the existing issue and only files new issues when no sufficiently similar issue exists.
+
+## Constraints
+
+- Keep current maintainer scheduler and `MaintainerRunLog` data model behavior intact.
+- Enforce dedup in Rust code (deterministic/testable), not solely in LLM prompt instructions.
+- Reuse existing `gh` CLI workflow (`issue list`, `issue create`, `issue edit`, `issue comment`).
+- Match semantic duplicates using normalized fingerprint data from finding metadata (`affected_files`, `symptom_type`, `keywords`) with deterministic thresholding.
+- Provide unit tests in `src-tauri/src/maintainer.rs` using mocked existing issues and candidate findings.
+
+## Approaches Considered
+
+1. Prompt-only dedup (reject): still nondeterministic; same failure mode as current pipeline.
+2. Hybrid model-proposed dedup + Rust fallback (reject): improved, but still relies on model routing.
+3. Rust-owned dedup and issue actions (selected): deterministic and fully unit-testable.
+
+## Selected Architecture
+
+1. Codex returns findings JSON only (no direct `gh issue create/edit/comment`).
+2. Rust fetches open `filed-by-maintainer` issues.
+3. Rust computes candidate fingerprints from:
+   - normalized `affected_files`
+   - normalized `symptom_type`
+   - normalized `keywords`
+4. Rust computes existing issue comparison tokens from:
+   - explicit fingerprint metadata in issue body (if present)
+   - fallback normalized tokens from existing issue title/body
+5. Similarity score = deterministic token overlap ratio against candidate fingerprint.
+6. If best score >= threshold, Rust updates/comments matched issue; otherwise creates new issue.
+7. New/updated issue bodies include fingerprint metadata for stronger future matching.
+
+## Validation Strategy
+
+- TDD unit tests first for:
+  - fingerprint normalization stability
+  - duplicate detection against mocked existing issues
+  - non-duplicate path below threshold
+  - deterministic tie-breaking behavior
+- Parsing tests for findings JSON shape.
+- Integration-level unit tests for run-log summary assembly from deterministic routing logic.
+- `cargo test` focused on `maintainer` module, then full `cargo test` for regression safety.

--- a/docs/plans/2026-03-09-maintainer-dedup-guard.md
+++ b/docs/plans/2026-03-09-maintainer-dedup-guard.md
@@ -1,0 +1,58 @@
+# Deterministic Maintainer Dedup Guard Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a deterministic dedup guard so semantically duplicate maintainer findings update existing `filed-by-maintainer` issues instead of creating new duplicates.
+
+**Architecture:** Codex will return structured findings only; Rust in `maintainer.rs` will fetch existing issues, compute normalized fingerprints, apply deterministic similarity matching, and execute `gh issue create/edit/comment` actions accordingly.
+
+**Tech Stack:** Rust (Tauri v2), serde JSON parsing, `gh` CLI, unit tests in `maintainer.rs`.
+
+---
+
+### Task 1: Add failing dedup tests (RED)
+
+**Files:**
+- Modify: `src-tauri/src/maintainer.rs`
+
+1. Add tests for fingerprint normalization and semantic duplicate matching with mocked existing issues.
+2. Run: `cd src-tauri && cargo test maintainer::tests::test_find_duplicate -- --nocapture`
+3. Verify failure due to missing dedup functions/types.
+
+### Task 2: Implement fingerprint + matching logic (GREEN)
+
+**Files:**
+- Modify: `src-tauri/src/maintainer.rs`
+
+1. Add normalized token extraction and deterministic fingerprint generation.
+2. Add duplicate matching with explicit threshold and deterministic tie-break.
+3. Re-run targeted maintainer tests until green.
+
+### Task 3: Integrate deterministic routing into maintainer pipeline
+
+**Files:**
+- Modify: `src-tauri/src/maintainer.rs`
+
+1. Replace prompt contract to findings-only JSON.
+2. Add GH helper functions to list/create/edit/comment issues from Rust.
+3. Apply dedup matching before deciding update vs create.
+4. Keep `MaintainerRunLog` compatibility and produce action summary.
+
+### Task 4: Validate and self-review
+
+**Files:**
+- Modify: `src-tauri/src/maintainer.rs`
+- Create: `docs/plans/2026-03-09-maintainer-dedup-guard-design.md`
+- Create: `docs/plans/2026-03-09-maintainer-dedup-guard.md`
+
+1. Run targeted tests: `cd src-tauri && cargo test maintainer::tests -- --nocapture`
+2. Run full backend tests: `cd src-tauri && cargo test`
+3. Self-review diff for determinism, error handling, and backward compatibility.
+4. Commit with message including `closes #292`.
+
+### Task 5: PR/merge/sync
+
+1. Push branch and open PR with body containing `closes #292`.
+2. Wait for checks; merge squash.
+3. Delete remote branch.
+4. Sync local `master` from origin.

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -8,6 +8,116 @@ use uuid::Uuid;
 
 use crate::models::{IssueAction, IssueSummary, MaintainerRunLog};
 use crate::state::AppState;
+
+const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.6;
+const MIN_FINGERPRINT_TOKENS: usize = 3;
+
+const STOPWORDS: &[&str] = &[
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "with",
+    "when",
+    "during",
+    "issue",
+    "issues",
+    "problem",
+    "fix",
+    "needs",
+    "need",
+    "code",
+    "project",
+    "maintainer",
+    "filed",
+    "update",
+    "updated",
+    "new",
+    "run",
+    "agent",
+    "src",
+    "lib",
+    "tauri",
+    "rs",
+    "svelte",
+];
+
+#[derive(Debug, Clone, Deserialize)]
+struct CandidateFinding {
+    title: String,
+    body: String,
+    #[serde(default)]
+    priority: String,
+    #[serde(default)]
+    complexity: String,
+    #[serde(default)]
+    affected_files: Vec<String>,
+    #[serde(default)]
+    symptom_type: String,
+    #[serde(default)]
+    keywords: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFindingsOutput {
+    findings: Vec<CandidateFinding>,
+    #[serde(default)]
+    summary: String,
+}
+
+#[derive(Debug)]
+struct FindingsOutput {
+    findings: Vec<CandidateFinding>,
+    summary: String,
+}
+
+#[derive(Debug, Clone)]
+struct ExistingIssue {
+    number: u32,
+    title: String,
+    body: String,
+    url: String,
+    labels: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawExistingIssue {
+    number: u32,
+    title: String,
+    #[serde(default)]
+    body: String,
+    url: String,
+    #[serde(default)]
+    labels: Vec<RawIssueLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawIssueLabel {
+    name: String,
+}
+
+#[derive(Debug, Clone)]
+struct DuplicateMatch {
+    issue: ExistingIssue,
+    similarity: f32,
+}
 
 pub struct MaintainerScheduler;
 
@@ -42,8 +152,7 @@ impl MaintainerScheduler {
                         continue;
                     }
 
-                    let interval =
-                        Duration::from_secs(project.maintainer.interval_minutes * 60);
+                    let interval = Duration::from_secs(project.maintainer.interval_minutes * 60);
                     let should_run = last_run
                         .get(&project.id)
                         .map_or(true, |t| t.elapsed() >= interval);
@@ -54,10 +163,8 @@ impl MaintainerScheduler {
 
                     last_run.insert(project.id, Instant::now());
 
-                    let _ = app_handle.emit(
-                        &format!("maintainer-status:{}", project.id),
-                        "running",
-                    );
+                    let _ =
+                        app_handle.emit(&format!("maintainer-status:{}", project.id), "running");
 
                     let github_repo = project.maintainer.github_repo.as_deref();
                     let result = run_maintainer_check(&project.repo_path, project.id, github_repo);
@@ -71,24 +178,15 @@ impl MaintainerScheduler {
                                 }
                             }
 
-                            let _ = app_handle.emit(
-                                &format!("maintainer-status:{}", project.id),
-                                "idle",
-                            );
+                            let _ = app_handle
+                                .emit(&format!("maintainer-status:{}", project.id), "idle");
                         }
                         Err(e) => {
-                            eprintln!(
-                                "Maintainer check failed for {}: {}",
-                                project.name, e
-                            );
-                            let _ = app_handle.emit(
-                                &format!("maintainer-status:{}", project.id),
-                                "error",
-                            );
-                            let _ = app_handle.emit(
-                                &format!("maintainer-error:{}", project.id),
-                                e.to_string(),
-                            );
+                            eprintln!("Maintainer check failed for {}: {}", project.name, e);
+                            let _ = app_handle
+                                .emit(&format!("maintainer-status:{}", project.id), "error");
+                            let _ = app_handle
+                                .emit(&format!("maintainer-error:{}", project.id), e.to_string());
                         }
                     }
                 }
@@ -97,71 +195,52 @@ impl MaintainerScheduler {
     }
 }
 
-pub fn build_issue_filing_prompt(repo_path: &str, github_repo: Option<&str>) -> String {
-    let repo_flag = match github_repo {
-        Some(repo) => format!(" -R {repo}"),
-        None => String::new(),
-    };
-
+pub fn build_issue_filing_prompt(repo_path: &str, _github_repo: Option<&str>) -> String {
     format!(
         r#"You are a maintainer agent. Analyze the project at {repo_path} for code quality, test robustness, architecture, and documentation issues.
 
-For each issue you find, you must either file a new GitHub issue or update an existing one.
+IMPORTANT:
+- Do NOT run any `gh issue create`, `gh issue edit`, or `gh issue comment` commands.
+- The deterministic issue dedup and issue filing/update logic is handled by the Rust pipeline.
+- Return findings only in structured JSON.
 
-## Step 1: Ensure labels exist
+For each finding, provide:
+- `title`: short actionable issue title
+- `body`: markdown body with concrete evidence and remediation
+- `priority`: `high` or `low`
+- `complexity`: `high` or `simple`
+- `affected_files`: list of file paths (when applicable)
+- `symptom_type`: short invariant symptom phrase (e.g. `startup panic`, `missing coverage`)
+- `keywords`: stable semantic keywords (e.g. `appstate`, `filesystem`, `initialization`)
 
-Run these commands to create labels if they don't already exist (ignore errors if they already exist):
-
-gh label create "filed-by-maintainer" --description "Issue filed by maintainer agent" --color "6c7086" --force{repo_flag}
-gh label create "priority: low" --description "Low priority" --color "a6e3a1" --force{repo_flag}
-gh label create "priority: high" --description "High priority" --color "f38ba8" --force{repo_flag}
-gh label create "complexity: low" --description "Simple fix" --color "89b4fa" --force{repo_flag}
-gh label create "complexity: high" --description "Significant effort" --color "f9e2af" --force{repo_flag}
-
-## Step 2: Check existing issues
-
-gh issue list --label filed-by-maintainer --state open --json number,title,body,labels{repo_flag}
-
-## Step 3: Analyze and act
-
-For each finding:
-1. Determine if it semantically matches an existing open `filed-by-maintainer` issue (same underlying problem, not just string match)
-2. If it matches: update the issue body with current analysis via `gh issue edit <number> --body "..."{repo_flag}`, then add a comment noting what changed via `gh issue comment <number> --body "..."{repo_flag}`
-3. If no match: file a new issue via `gh issue create --title "..." --body "..." --label filed-by-maintainer --label <priority> --label <complexity>{repo_flag}`
-
-Each issue should be specific and actionable (one issue per finding, not grouped).
-
-Assign priority: low or priority: high based on impact.
-Assign complexity: low or complexity: high based on effort.
-
-## Step 4: Return summary
-
-After completing all gh commands, respond with ONLY a JSON block:
+Return ONLY this JSON object:
 
 ```json
 {{
-  "issues_filed": [
+  "findings": [
     {{
-      "issue_number": <number>,
       "title": "<title>",
-      "url": "<issue url>",
-      "labels": ["filed-by-maintainer", "<priority>", "<complexity>"]
+      "body": "<markdown body>",
+      "priority": "high",
+      "complexity": "simple",
+      "affected_files": ["<path>"],
+      "symptom_type": "<symptom>",
+      "keywords": ["<keyword>"]
     }}
   ],
-  "issues_updated": [
-    {{
-      "issue_number": <number>,
-      "title": "<title>",
-      "url": "<issue url>",
-      "labels": ["filed-by-maintainer", "<priority>", "<complexity>"]
-    }}
-  ],
-  "issues_unchanged": <count of existing issues with no change needed>,
-  "summary": "<one-line summary of actions taken>"
+  "summary": "<one-line summary>"
 }}
 ```
 
-If there are no issues to file or update, return empty arrays and a positive summary."#
+If no issues are found, return:
+
+```json
+{{
+  "findings": [],
+  "summary": "No actionable maintainer issues found"
+}}
+```
+"#
     )
 }
 
@@ -186,62 +265,461 @@ pub fn extract_json(output: &str) -> Option<&str> {
     None
 }
 
-#[derive(Deserialize)]
-struct RawRunLog {
-    issues_filed: Vec<RawIssueSummary>,
-    issues_updated: Vec<RawIssueSummary>,
-    #[serde(default)]
-    issues_unchanged: u32,
-    summary: String,
-}
-
-#[derive(Deserialize)]
-struct RawIssueSummary {
-    issue_number: u32,
-    title: String,
-    url: String,
-    #[serde(default)]
-    labels: Vec<String>,
-}
-
-pub fn parse_run_log_output(output: &str, project_id: Uuid) -> Result<MaintainerRunLog, String> {
+fn parse_findings_output(output: &str) -> Result<FindingsOutput, String> {
     let json_str = extract_json(output).ok_or("No JSON found in output")?;
-    let raw: RawRunLog =
+    let raw: RawFindingsOutput =
         serde_json::from_str(json_str).map_err(|e| format!("Failed to parse JSON: {}", e))?;
 
-    let issues_filed: Vec<IssueSummary> = raw
-        .issues_filed
-        .into_iter()
-        .map(|r| IssueSummary {
-            issue_number: r.issue_number,
-            title: r.title,
-            url: r.url,
-            labels: r.labels,
-            action: IssueAction::Filed,
-        })
-        .collect();
+    let mut findings = Vec::with_capacity(raw.findings.len());
+    for (idx, finding) in raw.findings.into_iter().enumerate() {
+        let sanitized =
+            sanitize_finding(finding).ok_or_else(|| format!("Invalid finding at index {}", idx))?;
+        findings.push(sanitized);
+    }
 
-    let issues_updated: Vec<IssueSummary> = raw
-        .issues_updated
-        .into_iter()
-        .map(|r| IssueSummary {
-            issue_number: r.issue_number,
-            title: r.title,
-            url: r.url,
-            labels: r.labels,
-            action: IssueAction::Updated,
-        })
-        .collect();
-
-    Ok(MaintainerRunLog {
-        id: Uuid::new_v4(),
-        project_id,
-        timestamp: Utc::now().to_rfc3339(),
-        issues_filed,
-        issues_updated,
-        issues_unchanged: raw.issues_unchanged,
+    Ok(FindingsOutput {
+        findings,
         summary: raw.summary,
     })
+}
+
+fn sanitize_finding(finding: CandidateFinding) -> Option<CandidateFinding> {
+    let title = finding.title.trim();
+    let body = finding.body.trim();
+    if title.is_empty() || body.is_empty() {
+        return None;
+    }
+
+    Some(CandidateFinding {
+        title: title.to_string(),
+        body: body.to_string(),
+        priority: normalize_priority(&finding.priority),
+        complexity: normalize_complexity(&finding.complexity),
+        affected_files: finding
+            .affected_files
+            .into_iter()
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect(),
+        symptom_type: finding.symptom_type.trim().to_string(),
+        keywords: finding
+            .keywords
+            .into_iter()
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty())
+            .collect(),
+    })
+}
+
+fn normalize_priority(priority: &str) -> String {
+    let p = priority.to_ascii_lowercase();
+    if p.contains("high") {
+        "high".to_string()
+    } else {
+        "low".to_string()
+    }
+}
+
+fn normalize_complexity(complexity: &str) -> String {
+    let c = complexity.to_ascii_lowercase();
+    if c.contains("high") {
+        "high".to_string()
+    } else {
+        "simple".to_string()
+    }
+}
+
+fn normalize_priority_label(priority: &str) -> String {
+    format!("priority:{}", normalize_priority(priority))
+}
+
+fn normalize_complexity_label(complexity: &str) -> String {
+    format!("complexity:{}", normalize_complexity(complexity))
+}
+
+fn normalize_tokens(input: &str) -> Vec<String> {
+    let lowered = input
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>();
+
+    lowered
+        .split_whitespace()
+        .filter(|token| token.len() >= 2)
+        .filter(|token| !STOPWORDS.contains(token))
+        .map(|token| token.to_string())
+        .collect()
+}
+
+fn unique_sorted_tokens(mut tokens: Vec<String>) -> Vec<String> {
+    tokens.sort();
+    tokens.dedup();
+    tokens
+}
+
+fn finding_fingerprint_tokens(finding: &CandidateFinding) -> Vec<String> {
+    let mut tokens = Vec::new();
+
+    for file in &finding.affected_files {
+        tokens.extend(normalize_tokens(file));
+    }
+    tokens.extend(normalize_tokens(&finding.symptom_type));
+
+    for keyword in &finding.keywords {
+        tokens.extend(normalize_tokens(keyword));
+    }
+
+    if tokens.is_empty() {
+        tokens.extend(normalize_tokens(&finding.title));
+        tokens.extend(normalize_tokens(&finding.body));
+    }
+
+    unique_sorted_tokens(tokens)
+}
+
+fn build_finding_fingerprint(finding: &CandidateFinding) -> String {
+    finding_fingerprint_tokens(finding).join("|")
+}
+
+fn extract_embedded_fingerprint_tokens(body: &str) -> Option<Vec<String>> {
+    for line in body.lines() {
+        let lowercase = line.to_ascii_lowercase();
+        if !lowercase.contains("fingerprint") {
+            continue;
+        }
+
+        if let Some(start) = line.find('`') {
+            if let Some(end_rel) = line[start + 1..].find('`') {
+                let raw = &line[start + 1..start + 1 + end_rel];
+                let tokens = unique_sorted_tokens(
+                    raw.split(|ch: char| ch == '|' || ch == ',' || ch.is_whitespace())
+                        .flat_map(normalize_tokens)
+                        .collect(),
+                );
+                if !tokens.is_empty() {
+                    return Some(tokens);
+                }
+            }
+        }
+
+        if let Some(colon_idx) = line.find(':') {
+            let raw = line[colon_idx + 1..].trim();
+            let tokens = unique_sorted_tokens(
+                raw.split(|ch: char| ch == '|' || ch == ',' || ch.is_whitespace())
+                    .flat_map(normalize_tokens)
+                    .collect(),
+            );
+            if !tokens.is_empty() {
+                return Some(tokens);
+            }
+        }
+    }
+
+    None
+}
+
+fn existing_issue_tokens(issue: &ExistingIssue) -> Vec<String> {
+    if let Some(tokens) = extract_embedded_fingerprint_tokens(&issue.body) {
+        return tokens;
+    }
+
+    let mut tokens = normalize_tokens(&issue.title);
+    tokens.extend(normalize_tokens(&issue.body));
+    unique_sorted_tokens(tokens)
+}
+
+fn similarity_score(candidate_tokens: &[String], existing_tokens: &[String]) -> f32 {
+    if candidate_tokens.is_empty() || existing_tokens.is_empty() {
+        return 0.0;
+    }
+
+    let existing_set = existing_tokens.iter().collect::<HashSet<_>>();
+    let overlap = candidate_tokens
+        .iter()
+        .filter(|token| existing_set.contains(token))
+        .count();
+
+    overlap as f32 / candidate_tokens.len() as f32
+}
+
+fn find_duplicate_issue(
+    finding: &CandidateFinding,
+    existing_issues: &[ExistingIssue],
+    threshold: f32,
+) -> Option<DuplicateMatch> {
+    let candidate_tokens = finding_fingerprint_tokens(finding);
+    if candidate_tokens.len() < MIN_FINGERPRINT_TOKENS {
+        return None;
+    }
+    let mut best: Option<DuplicateMatch> = None;
+
+    for issue in existing_issues {
+        let issue_tokens = existing_issue_tokens(issue);
+        let similarity = similarity_score(&candidate_tokens, &issue_tokens);
+        if similarity < threshold {
+            continue;
+        }
+
+        let should_replace = match &best {
+            None => true,
+            Some(current) => {
+                similarity > current.similarity
+                    || ((similarity - current.similarity).abs() < f32::EPSILON
+                        && issue.number < current.issue.number)
+            }
+        };
+
+        if should_replace {
+            best = Some(DuplicateMatch {
+                issue: issue.clone(),
+                similarity,
+            });
+        }
+    }
+
+    best
+}
+
+fn format_issue_body(finding: &CandidateFinding, fingerprint: &str) -> String {
+    let affected_files = if finding.affected_files.is_empty() {
+        "(none provided)".to_string()
+    } else {
+        finding.affected_files.join(", ")
+    };
+
+    let keywords = if finding.keywords.is_empty() {
+        "(none provided)".to_string()
+    } else {
+        finding.keywords.join(", ")
+    };
+
+    let symptom_type = if finding.symptom_type.trim().is_empty() {
+        "unspecified".to_string()
+    } else {
+        finding.symptom_type.trim().to_string()
+    };
+
+    format!(
+        "## Summary\n\n{}\n\n## Maintainer Metadata\n\n- Fingerprint: `{}`\n- Symptom Type: `{}`\n- Affected Files: {}\n- Keywords: {}\n",
+        finding.body.trim(),
+        fingerprint,
+        symptom_type,
+        affected_files,
+        keywords
+    )
+}
+
+fn format_update_comment(finding: &CandidateFinding, similarity: f32, fingerprint: &str) -> String {
+    format!(
+        "Maintainer rerun matched this issue as a semantic duplicate (similarity {:.2}). Updated with the latest analysis for **{}**.\n\nFingerprint: `{}`",
+        similarity,
+        finding.title,
+        fingerprint
+    )
+}
+
+fn gh_command(repo_path: &str, github_repo: Option<&str>) -> std::process::Command {
+    let mut cmd = std::process::Command::new("gh");
+    if let Some(repo) = github_repo {
+        cmd.args(["-R", repo]);
+    }
+    cmd.current_dir(repo_path);
+    cmd
+}
+
+fn run_gh_checked(
+    mut command: std::process::Command,
+    failure_prefix: &str,
+) -> Result<std::process::Output, String> {
+    let output = command
+        .output()
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("{}: {}", failure_prefix, stderr.trim()));
+    }
+
+    Ok(output)
+}
+
+fn ensure_labels_exist(repo_path: &str, github_repo: Option<&str>) -> Result<(), String> {
+    let labels = [
+        (
+            "filed-by-maintainer",
+            "Issue filed by maintainer agent",
+            "6c7086",
+        ),
+        ("priority:low", "Low priority", "a6e3a1"),
+        ("priority:high", "High priority", "f38ba8"),
+        ("complexity:simple", "Simple fix", "89b4fa"),
+        ("complexity:high", "Significant effort", "f9e2af"),
+    ];
+
+    for (label, description, color) in labels {
+        let mut cmd = gh_command(repo_path, github_repo);
+        cmd.args([
+            "label",
+            "create",
+            label,
+            "--description",
+            description,
+            "--color",
+            color,
+            "--force",
+        ]);
+        run_gh_checked(cmd, "gh label create failed")?;
+    }
+
+    Ok(())
+}
+
+fn list_open_maintainer_issues(
+    repo_path: &str,
+    github_repo: Option<&str>,
+) -> Result<Vec<ExistingIssue>, String> {
+    let mut cmd = gh_command(repo_path, github_repo);
+    cmd.args([
+        "issue",
+        "list",
+        "--label",
+        "filed-by-maintainer",
+        "--state",
+        "open",
+        "--json",
+        "number,title,body,url,labels",
+        "--limit",
+        "200",
+    ]);
+
+    let output = run_gh_checked(cmd, "gh issue list failed")?;
+    let raw_issues: Vec<RawExistingIssue> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse gh issue list output: {}", e))?;
+
+    Ok(raw_issues
+        .into_iter()
+        .map(|raw| ExistingIssue {
+            number: raw.number,
+            title: raw.title,
+            body: raw.body,
+            url: raw.url,
+            labels: raw.labels.into_iter().map(|l| l.name).collect(),
+        })
+        .collect())
+}
+
+fn parse_issue_number_from_url(url: &str) -> Result<u32, String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    let last = trimmed
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| format!("Could not parse issue number from URL: {}", url))?;
+    last.parse::<u32>()
+        .map_err(|_| format!("Could not parse issue number from URL: {}", url))
+}
+
+fn create_issue(
+    repo_path: &str,
+    github_repo: Option<&str>,
+    finding: &CandidateFinding,
+    body: &str,
+    labels: &[String],
+) -> Result<IssueSummary, String> {
+    let mut cmd = gh_command(repo_path, github_repo);
+    cmd.arg("issue")
+        .arg("create")
+        .arg("--title")
+        .arg(&finding.title)
+        .arg("--body")
+        .arg(body);
+
+    for label in labels {
+        cmd.arg("--label").arg(label);
+    }
+
+    let output = run_gh_checked(cmd, "gh issue create failed")?;
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let issue_number = parse_issue_number_from_url(&url)?;
+
+    Ok(IssueSummary {
+        issue_number,
+        title: finding.title.clone(),
+        url,
+        labels: labels.to_vec(),
+        action: IssueAction::Filed,
+    })
+}
+
+fn update_issue(
+    repo_path: &str,
+    github_repo: Option<&str>,
+    issue_number: u32,
+    body: &str,
+    labels: &[String],
+    labels_to_remove: &[String],
+) -> Result<(), String> {
+    let issue_number_arg = issue_number.to_string();
+    let mut cmd = gh_command(repo_path, github_repo);
+    cmd.arg("issue")
+        .arg("edit")
+        .arg(&issue_number_arg)
+        .arg("--body")
+        .arg(body);
+
+    for label in labels {
+        cmd.arg("--add-label").arg(label);
+    }
+    for label in labels_to_remove {
+        cmd.arg("--remove-label").arg(label);
+    }
+
+    run_gh_checked(cmd, "gh issue edit failed")?;
+    Ok(())
+}
+
+fn comment_issue(
+    repo_path: &str,
+    github_repo: Option<&str>,
+    issue_number: u32,
+    body: &str,
+) -> Result<(), String> {
+    let issue_number_arg = issue_number.to_string();
+    let mut cmd = gh_command(repo_path, github_repo);
+    cmd.arg("issue")
+        .arg("comment")
+        .arg(&issue_number_arg)
+        .arg("--body")
+        .arg(body);
+
+    run_gh_checked(cmd, "gh issue comment failed")?;
+    Ok(())
+}
+
+fn dedup_labels_for_finding(finding: &CandidateFinding) -> Vec<String> {
+    let mut labels = vec![
+        "filed-by-maintainer".to_string(),
+        normalize_priority_label(&finding.priority),
+        normalize_complexity_label(&finding.complexity),
+    ];
+    labels.sort();
+    labels.dedup();
+    labels
+}
+
+fn labels_to_remove(existing_labels: &[String], desired_labels: &[String]) -> Vec<String> {
+    let desired = desired_labels.iter().collect::<HashSet<_>>();
+    existing_labels
+        .iter()
+        .filter(|label| label.starts_with("priority:") || label.starts_with("complexity:"))
+        .filter(|label| !desired.contains(label))
+        .cloned()
+        .collect()
 }
 
 /// Returns true if the run produced any filed or updated issues.
@@ -270,8 +748,100 @@ pub fn run_maintainer_check(
         return Err(format!("codex exec failed: {}", stderr));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_run_log_output(&stdout, project_id)
+    let findings_output = parse_findings_output(&String::from_utf8_lossy(&output.stdout))?;
+
+    ensure_labels_exist(repo_path, github_repo)?;
+
+    let mut existing_issues = list_open_maintainer_issues(repo_path, github_repo)?;
+    let existing_issue_count = existing_issues.len();
+
+    let mut issues_filed = Vec::new();
+    let mut issues_updated = Vec::new();
+    let mut updated_issue_numbers = HashSet::new();
+
+    for finding in &findings_output.findings {
+        let fingerprint = build_finding_fingerprint(finding);
+        let labels = dedup_labels_for_finding(finding);
+        let body = format_issue_body(finding, &fingerprint);
+
+        if let Some(duplicate_match) =
+            find_duplicate_issue(finding, &existing_issues, DEDUP_SIMILARITY_THRESHOLD)
+        {
+            if updated_issue_numbers.contains(&duplicate_match.issue.number) {
+                continue;
+            }
+            let remove_labels = labels_to_remove(&duplicate_match.issue.labels, &labels);
+            update_issue(
+                repo_path,
+                github_repo,
+                duplicate_match.issue.number,
+                &body,
+                &labels,
+                &remove_labels,
+            )?;
+            comment_issue(
+                repo_path,
+                github_repo,
+                duplicate_match.issue.number,
+                &format_update_comment(finding, duplicate_match.similarity, &fingerprint),
+            )?;
+
+            updated_issue_numbers.insert(duplicate_match.issue.number);
+            issues_updated.push(IssueSummary {
+                issue_number: duplicate_match.issue.number,
+                title: finding.title.clone(),
+                url: duplicate_match.issue.url.clone(),
+                labels: labels.clone(),
+                action: IssueAction::Updated,
+            });
+
+            if let Some(existing_issue) = existing_issues
+                .iter_mut()
+                .find(|issue| issue.number == duplicate_match.issue.number)
+            {
+                existing_issue.title = finding.title.clone();
+                existing_issue.body = body.clone();
+                existing_issue.labels = labels.clone();
+            }
+        } else {
+            let filed = create_issue(repo_path, github_repo, finding, &body, &labels)?;
+            existing_issues.push(ExistingIssue {
+                number: filed.issue_number,
+                title: finding.title.clone(),
+                body,
+                url: filed.url.clone(),
+                labels: labels.clone(),
+            });
+            issues_filed.push(filed);
+        }
+    }
+
+    let issues_unchanged = existing_issue_count.saturating_sub(updated_issue_numbers.len()) as u32;
+
+    let summary = if issues_filed.is_empty() && issues_updated.is_empty() {
+        if findings_output.summary.trim().is_empty() {
+            "No actionable maintainer issues found".to_string()
+        } else {
+            findings_output.summary
+        }
+    } else {
+        format!(
+            "Filed {} issue(s), updated {} issue(s), unchanged {}",
+            issues_filed.len(),
+            issues_updated.len(),
+            issues_unchanged
+        )
+    };
+
+    Ok(MaintainerRunLog {
+        id: Uuid::new_v4(),
+        project_id,
+        timestamp: Utc::now().to_rfc3339(),
+        issues_filed,
+        issues_updated,
+        issues_unchanged,
+        summary,
+    })
 }
 
 #[cfg(test)]
@@ -282,70 +852,74 @@ mod tests {
     fn test_build_issue_filing_prompt_contains_repo_path() {
         let prompt = build_issue_filing_prompt("/tmp/my-project", None);
         assert!(prompt.contains("/tmp/my-project"));
-        assert!(prompt.contains("gh issue"));
-        assert!(prompt.contains("filed-by-maintainer"));
+        assert!(prompt.contains("Return ONLY this JSON object"));
+        assert!(prompt.contains("Do NOT run any `gh issue create`"));
     }
 
     #[test]
-    fn test_build_issue_filing_prompt_uses_github_repo_override() {
-        let prompt = build_issue_filing_prompt("/tmp/my-project", Some("owner/custom-repo"));
-        assert!(prompt.contains("owner/custom-repo"));
+    fn test_extract_json_from_fenced_block() {
+        let output = "before\n```json\n{\"a\":1}\n```\nafter";
+        assert_eq!(extract_json(output), Some("{\"a\":1}"));
     }
 
     #[test]
-    fn test_parse_run_log_output_files_and_updates() {
+    fn test_parse_findings_output_parses_valid_json() {
         let output = r#"```json
 {
-  "issues_filed": [
+  "findings": [
     {
-      "issue_number": 42,
-      "title": "Fix flaky test in utils",
-      "url": "https://github.com/owner/repo/issues/42",
-      "labels": ["filed-by-maintainer", "priority: high", "complexity: low"]
+      "title": "AppState startup panic",
+      "body": "Startup panics when storage init fails.",
+      "priority": "high",
+      "complexity": "simple",
+      "affected_files": ["src-tauri/src/state.rs"],
+      "symptom_type": "startup panic",
+      "keywords": ["appstate", "filesystem", "initialization"]
     }
   ],
-  "issues_updated": [
-    {
-      "issue_number": 10,
-      "title": "Improve error handling",
-      "url": "https://github.com/owner/repo/issues/10",
-      "labels": ["filed-by-maintainer", "priority: low"]
-    }
-  ],
-  "issues_unchanged": 2,
-  "summary": "Filed 1 new issue, updated 1 existing issue"
+  "summary": "Found one issue"
 }
 ```"#;
-        let project_id = Uuid::new_v4();
-        let result = parse_run_log_output(output, project_id);
-        assert!(result.is_ok());
-        let log = result.unwrap();
-        assert_eq!(log.issues_filed.len(), 1);
-        assert_eq!(log.issues_filed[0].issue_number, 42);
-        assert_eq!(log.issues_filed[0].action, IssueAction::Filed);
-        assert_eq!(log.issues_updated.len(), 1);
-        assert_eq!(log.issues_updated[0].issue_number, 10);
-        assert_eq!(log.issues_updated[0].action, IssueAction::Updated);
-        assert_eq!(log.issues_unchanged, 2);
+
+        let parsed = parse_findings_output(output).expect("should parse");
+        assert_eq!(parsed.findings.len(), 1);
+        assert_eq!(parsed.findings[0].priority, "high");
+        assert_eq!(parsed.findings[0].complexity, "simple");
+        assert_eq!(parsed.summary, "Found one issue");
     }
 
     #[test]
-    fn test_parse_run_log_output_no_changes() {
-        let output = r#"{"issues_filed":[],"issues_updated":[],"issues_unchanged":5,"summary":"No changes detected"}"#;
-        let project_id = Uuid::new_v4();
-        let result = parse_run_log_output(output, project_id);
-        assert!(result.is_ok());
-        let log = result.unwrap();
-        assert!(log.issues_filed.is_empty());
-        assert!(log.issues_updated.is_empty());
-        assert_eq!(log.issues_unchanged, 5);
+    fn test_parse_findings_output_invalid_finding_returns_error() {
+        let output = r#"{
+          "findings": [
+            {
+              "title": "",
+              "body": "",
+              "priority": "high",
+              "complexity": "simple",
+              "affected_files": [],
+              "symptom_type": "",
+              "keywords": []
+            }
+          ],
+          "summary": "nothing"
+        }"#;
+
+        let parsed = parse_findings_output(output);
+        assert!(parsed.is_err());
     }
 
     #[test]
-    fn test_parse_run_log_output_invalid() {
+    fn test_parse_findings_output_missing_findings_key_returns_error() {
+        let output = r#"{"summary":"missing findings"}"#;
+        let parsed = parse_findings_output(output);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn test_parse_findings_output_invalid_payload_returns_error() {
         let output = "I couldn't analyze the project";
-        let project_id = Uuid::new_v4();
-        let result = parse_run_log_output(output, project_id);
+        let result = parse_findings_output(output);
         assert!(result.is_err());
     }
 
@@ -381,5 +955,205 @@ mod tests {
             summary: "s".to_string(),
         };
         assert!(!has_changes(&log));
+    }
+
+    #[test]
+    fn test_build_finding_fingerprint_normalizes_and_sorts_tokens() {
+        let finding = CandidateFinding {
+            title: "AppState startup panic".to_string(),
+            body: "App fails at startup when storage init fails.".to_string(),
+            priority: "high".to_string(),
+            complexity: "simple".to_string(),
+            affected_files: vec![
+                "src-tauri/src/state.rs".to_string(),
+                "src-tauri/src/state.rs".to_string(),
+            ],
+            symptom_type: "Startup Panic".to_string(),
+            keywords: vec![
+                "AppState::new".to_string(),
+                "filesystem".to_string(),
+                "panic".to_string(),
+            ],
+        };
+
+        let fingerprint = build_finding_fingerprint(&finding);
+
+        assert!(fingerprint.contains("appstate"));
+        assert!(fingerprint.contains("startup"));
+        assert!(fingerprint.contains("panic"));
+        assert!(fingerprint.contains("state"));
+        assert!(!fingerprint.contains("::"));
+    }
+
+    #[test]
+    fn test_find_duplicate_issue_matches_semantic_duplicate_with_mocked_issues() {
+        let finding = CandidateFinding {
+            title: "AppState startup panic when init fails".to_string(),
+            body: "App crashes at startup if filesystem init fails in AppState::new.".to_string(),
+            priority: "high".to_string(),
+            complexity: "simple".to_string(),
+            affected_files: vec!["src-tauri/src/state.rs".to_string()],
+            symptom_type: "startup panic".to_string(),
+            keywords: vec![
+                "appstate".to_string(),
+                "filesystem".to_string(),
+                "initialization".to_string(),
+            ],
+        };
+
+        let existing = vec![
+            ExistingIssue {
+                number: 285,
+                title: "AppState::new() panics on startup when storage init fails".to_string(),
+                body: "Summary: startup panic in AppState::new during filesystem initialization."
+                    .to_string(),
+                url: "https://github.com/owner/repo/issues/285".to_string(),
+                labels: vec!["filed-by-maintainer".to_string()],
+            },
+            ExistingIssue {
+                number: 266,
+                title: "Sidebar.svelte is too large and needs refactor".to_string(),
+                body: "Monolith component architecture concern.".to_string(),
+                url: "https://github.com/owner/repo/issues/266".to_string(),
+                labels: vec!["filed-by-maintainer".to_string()],
+            },
+        ];
+
+        let duplicate = find_duplicate_issue(&finding, &existing, 0.6);
+        assert!(duplicate.is_some());
+        let duplicate = duplicate.unwrap();
+        assert_eq!(duplicate.issue.number, 285);
+        assert!(duplicate.similarity >= 0.6);
+    }
+
+    #[test]
+    fn test_find_duplicate_issue_returns_none_when_similarity_below_threshold() {
+        let finding = CandidateFinding {
+            title: "Improve onboarding modal copy".to_string(),
+            body: "Minor UX improvements for onboarding instructions.".to_string(),
+            priority: "low".to_string(),
+            complexity: "simple".to_string(),
+            affected_files: vec!["src/lib/Onboarding.svelte".to_string()],
+            symptom_type: "copy tweak".to_string(),
+            keywords: vec![
+                "ux".to_string(),
+                "copy".to_string(),
+                "onboarding".to_string(),
+            ],
+        };
+
+        let existing = vec![ExistingIssue {
+            number: 267,
+            title: "Missing tests for Sidebar.svelte components".to_string(),
+            body: "Need better component test coverage for sidebar tree interactions.".to_string(),
+            url: "https://github.com/owner/repo/issues/267".to_string(),
+            labels: vec!["filed-by-maintainer".to_string()],
+        }];
+
+        let duplicate = find_duplicate_issue(&finding, &existing, 0.75);
+        assert!(duplicate.is_none());
+    }
+
+    #[test]
+    fn test_find_duplicate_issue_returns_none_for_sparse_fingerprint() {
+        let finding = CandidateFinding {
+            title: "panic".to_string(),
+            body: "panic".to_string(),
+            priority: "high".to_string(),
+            complexity: "simple".to_string(),
+            affected_files: vec![],
+            symptom_type: "panic".to_string(),
+            keywords: vec![],
+        };
+
+        let existing = vec![ExistingIssue {
+            number: 285,
+            title: "Startup panic in AppState::new".to_string(),
+            body: "Summary panic during startup.".to_string(),
+            url: "https://github.com/owner/repo/issues/285".to_string(),
+            labels: vec!["filed-by-maintainer".to_string()],
+        }];
+
+        let duplicate = find_duplicate_issue(&finding, &existing, 0.6);
+        assert!(duplicate.is_none());
+    }
+
+    #[test]
+    fn test_find_duplicate_issue_uses_embedded_fingerprint_metadata() {
+        let finding = CandidateFinding {
+            title: "AppState startup panic when init fails".to_string(),
+            body: "Body".to_string(),
+            priority: "high".to_string(),
+            complexity: "simple".to_string(),
+            affected_files: vec!["src-tauri/src/state.rs".to_string()],
+            symptom_type: "startup panic".to_string(),
+            keywords: vec!["appstate".to_string(), "filesystem".to_string()],
+        };
+
+        let existing = vec![ExistingIssue {
+            number: 277,
+            title: "Old title".to_string(),
+            body: "## Maintainer Metadata\n- Fingerprint: `appstate|filesystem|panic|src|state|startup|tauri`"
+                .to_string(),
+            url: "https://github.com/owner/repo/issues/277".to_string(),
+            labels: vec!["filed-by-maintainer".to_string()],
+        }];
+
+        let duplicate = find_duplicate_issue(&finding, &existing, 0.6).expect("match expected");
+        assert_eq!(duplicate.issue.number, 277);
+    }
+
+    #[test]
+    fn test_find_duplicate_issue_tie_breaks_by_lowest_issue_number() {
+        let finding = CandidateFinding {
+            title: "AppState startup panic when init fails".to_string(),
+            body: "Body".to_string(),
+            priority: "high".to_string(),
+            complexity: "simple".to_string(),
+            affected_files: vec!["src-tauri/src/state.rs".to_string()],
+            symptom_type: "startup panic".to_string(),
+            keywords: vec!["appstate".to_string(), "filesystem".to_string()],
+        };
+
+        let existing = vec![
+            ExistingIssue {
+                number: 301,
+                title: "A".to_string(),
+                body: "Fingerprint: `appstate|filesystem|panic|state|startup`".to_string(),
+                url: "https://github.com/owner/repo/issues/301".to_string(),
+                labels: vec!["filed-by-maintainer".to_string()],
+            },
+            ExistingIssue {
+                number: 277,
+                title: "B".to_string(),
+                body: "Fingerprint: `appstate|filesystem|panic|state|startup`".to_string(),
+                url: "https://github.com/owner/repo/issues/277".to_string(),
+                labels: vec!["filed-by-maintainer".to_string()],
+            },
+        ];
+
+        let duplicate = find_duplicate_issue(&finding, &existing, 0.5).expect("match expected");
+        assert_eq!(duplicate.issue.number, 277);
+    }
+
+    #[test]
+    fn test_labels_to_remove_replaces_conflicting_priority_and_complexity() {
+        let existing = vec![
+            "filed-by-maintainer".to_string(),
+            "priority:low".to_string(),
+            "complexity:simple".to_string(),
+            "triaged".to_string(),
+        ];
+        let desired = vec![
+            "filed-by-maintainer".to_string(),
+            "priority:high".to_string(),
+            "complexity:high".to_string(),
+        ];
+
+        let remove = labels_to_remove(&existing, &desired);
+        assert_eq!(
+            remove,
+            vec!["priority:low".to_string(), "complexity:simple".to_string()]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- move maintainer output contract to findings-only JSON so Rust owns create/update routing
- add deterministic fingerprint + similarity matching against open `filed-by-maintainer` issues before any issue creation
- enforce safer dedup behavior: minimum fingerprint token floor, strict findings schema validation, one-update-per-issue per run, and label replacement (remove stale priority/complexity labels)
- add/refresh maintainer unit tests for semantic matching, tie-breaking, sparse-token false-positive prevention, label replacement, and parse contract checks
- add design and implementation docs for issue #292

## Validation
- `cd src-tauri && cargo test --lib maintainer::tests -- --nocapture`
- `cd src-tauri && cargo test --lib`
- `npx vitest run`

closes #292
