### PR TITLE
Fix integration test compile errors for Project.staged_session

### DIFF
--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -27,6 +27,7 @@ fn test_project_lifecycle() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -81,6 +82,7 @@ fn test_agents_md_lifecycle() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -160,6 +162,7 @@ fn test_sessions_persist_across_restarts() {
                 auto_worker_session: false,
             },
         ],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -198,6 +201,7 @@ fn test_no_duplicate_project_names() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project_a).expect("save first project");
 
@@ -214,6 +218,7 @@ fn test_no_duplicate_project_names() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project_b).expect("save second project");
 
@@ -246,6 +251,7 @@ fn test_archived_project_name_can_be_reused() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save archived project");
 
@@ -317,6 +323,7 @@ fn test_worktrees_persist_across_restarts() {
             done_commits: vec![],
             auto_worker_session: false,
         }],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -360,6 +367,7 @@ fn test_migrate_worktree_paths_renames_uuid_dir() {
             done_commits: vec![],
             auto_worker_session: false,
         }],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -409,6 +417,7 @@ fn test_migrate_worktree_paths_noop_when_no_uuid_dir() {
             done_commits: vec![],
             auto_worker_session: false,
         }],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -463,6 +472,7 @@ fn test_migrate_worktree_paths_noop_on_name_collision() {
             done_commits: vec![],
             auto_worker_session: false,
         }],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -507,6 +517,7 @@ fn test_archive_project_with_no_sessions() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -569,6 +580,7 @@ fn test_create_session_uses_project_name_in_path() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 
@@ -739,6 +751,7 @@ fn test_load_archived_project_by_repo_path_unarchives_it() {
         auto_worker: AutoWorkerConfig::default(),
         prompts: vec![],
         sessions: vec![],
+        staged_session: None,
     };
     storage.save_project(&project).expect("save project");
 


### PR DESCRIPTION
## Summary
- add missing `staged_session: None` to all `Project` initializers in `src-tauri/tests/integration.rs`
- keep the fix scoped to integration test fixtures so runtime behavior is unchanged

## Verification
- cd src-tauri && cargo test --test integration
- cd src-tauri && cargo test
- cd src-tauri && cargo clippy --all-targets --all-features

closes #288
