### PR TITLE
feat: add maintainer issue browser and closed issue awareness

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1523,6 +1523,41 @@ pub async fn clear_maintainer_reports(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn get_maintainer_issues(
+    state: State<'_, AppState>,
+    project_id: String,
+) -> Result<Vec<crate::models::MaintainerIssue>, String> {
+    let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let (repo_path, github_repo) = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        let project = storage.load_project(project_id).map_err(|e| e.to_string())?;
+        (
+            project.repo_path.clone(),
+            project.maintainer.github_repo.clone(),
+        )
+    };
+    github::get_maintainer_issues(repo_path, github_repo).await
+}
+
+#[tauri::command]
+pub async fn get_maintainer_issue_detail(
+    state: State<'_, AppState>,
+    project_id: String,
+    issue_number: u32,
+) -> Result<crate::models::MaintainerIssueDetail, String> {
+    let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
+    let (repo_path, github_repo) = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        let project = storage.load_project(project_id).map_err(|e| e.to_string())?;
+        (
+            project.repo_path.clone(),
+            project.maintainer.github_repo.clone(),
+        )
+    };
+    github::get_maintainer_issue_detail(repo_path, github_repo, issue_number).await
+}
+
 fn find_main_branch_oid(repo: &git2::Repository) -> Option<git2::Oid> {
     for name in &["refs/heads/master", "refs/heads/main"] {
         if let Ok(reference) = repo.find_reference(name) {

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -309,6 +309,76 @@ pub(crate) async fn remove_github_label(
     Ok(())
 }
 
+pub(crate) async fn get_maintainer_issues(
+    repo_path: String,
+    github_repo: Option<String>,
+) -> Result<Vec<crate::models::MaintainerIssue>, String> {
+    let nwo = match github_repo {
+        Some(ref repo) if !repo.is_empty() => repo.clone(),
+        _ => extract_github_repo_async(repo_path).await?,
+    };
+
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            &nwo,
+            "--label",
+            "filed-by-maintainer",
+            "--state",
+            "all",
+            "--json",
+            "number,title,state,url,labels,createdAt,closedAt",
+            "--limit",
+            "100",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh issue list failed: {}", stderr));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))
+}
+
+pub(crate) async fn get_maintainer_issue_detail(
+    repo_path: String,
+    github_repo: Option<String>,
+    issue_number: u32,
+) -> Result<crate::models::MaintainerIssueDetail, String> {
+    let nwo = match github_repo {
+        Some(ref repo) if !repo.is_empty() => repo.clone(),
+        _ => extract_github_repo_async(repo_path).await?,
+    };
+
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &issue_number.to_string(),
+            "--repo",
+            &nwo,
+            "--json",
+            "number,title,state,body,url,labels,createdAt,closedAt",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh issue view failed: {}", stderr));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))
+}
+
 pub(crate) async fn list_assigned_issues(repo_path: String) -> Result<Vec<AssignedIssue>, String> {
     let nwo = extract_github_repo_async(repo_path).await?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,8 @@ pub fn run() {
             commands::get_maintainer_history,
             commands::trigger_maintainer_check,
             commands::clear_maintainer_reports,
+            commands::get_maintainer_issues,
+            commands::get_maintainer_issue_detail,
             commands::configure_auto_worker,
             commands::list_notes,
             commands::read_note,

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -614,6 +614,40 @@ fn list_open_maintainer_issues(
         .collect())
 }
 
+fn list_closed_maintainer_issues(
+    repo_path: &str,
+    github_repo: Option<&str>,
+) -> Result<Vec<ExistingIssue>, String> {
+    let mut cmd = gh_command(repo_path, github_repo);
+    cmd.args([
+        "issue",
+        "list",
+        "--label",
+        "filed-by-maintainer",
+        "--state",
+        "closed",
+        "--json",
+        "number,title,body,url,labels",
+        "--limit",
+        "200",
+    ]);
+
+    let output = run_gh_checked(cmd, "gh issue list (closed) failed")?;
+    let raw_issues: Vec<RawExistingIssue> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse gh issue list output: {}", e))?;
+
+    Ok(raw_issues
+        .into_iter()
+        .map(|raw| ExistingIssue {
+            number: raw.number,
+            title: raw.title,
+            body: raw.body,
+            url: raw.url,
+            labels: raw.labels.into_iter().map(|l| l.name).collect(),
+        })
+        .collect())
+}
+
 fn parse_issue_number_from_url(url: &str) -> Result<u32, String> {
     let trimmed = url.trim().trim_end_matches('/');
     let last = trimmed
@@ -753,16 +787,24 @@ pub fn run_maintainer_check(
     ensure_labels_exist(repo_path, github_repo)?;
 
     let mut existing_issues = list_open_maintainer_issues(repo_path, github_repo)?;
+    let closed_issues = list_closed_maintainer_issues(repo_path, github_repo)?;
     let existing_issue_count = existing_issues.len();
 
     let mut issues_filed = Vec::new();
     let mut issues_updated = Vec::new();
     let mut updated_issue_numbers = HashSet::new();
+    let mut issues_skipped: u32 = 0;
 
     for finding in &findings_output.findings {
         let fingerprint = build_finding_fingerprint(finding);
         let labels = dedup_labels_for_finding(finding);
         let body = format_issue_body(finding, &fingerprint);
+
+        // Skip findings that match a closed issue (already resolved)
+        if find_duplicate_issue(finding, &closed_issues, DEDUP_SIMILARITY_THRESHOLD).is_some() {
+            issues_skipped += 1;
+            continue;
+        }
 
         if let Some(duplicate_match) =
             find_duplicate_issue(finding, &existing_issues, DEDUP_SIMILARITY_THRESHOLD)
@@ -825,12 +867,15 @@ pub fn run_maintainer_check(
             findings_output.summary
         }
     } else {
-        format!(
-            "Filed {} issue(s), updated {} issue(s), unchanged {}",
-            issues_filed.len(),
-            issues_updated.len(),
-            issues_unchanged
-        )
+        let mut parts = vec![
+            format!("Filed {} issue(s)", issues_filed.len()),
+            format!("updated {} issue(s)", issues_updated.len()),
+            format!("unchanged {}", issues_unchanged),
+        ];
+        if issues_skipped > 0 {
+            parts.push(format!("skipped {} (closed)", issues_skipped));
+        }
+        parts.join(", ")
     };
 
     Ok(MaintainerRunLog {
@@ -840,6 +885,7 @@ pub fn run_maintainer_check(
         issues_filed,
         issues_updated,
         issues_unchanged,
+        issues_skipped,
         summary,
     })
 }
@@ -938,6 +984,7 @@ mod tests {
             }],
             issues_updated: vec![],
             issues_unchanged: 0,
+            issues_skipped: 0,
             summary: "s".to_string(),
         };
         assert!(has_changes(&log));
@@ -952,6 +999,7 @@ mod tests {
             issues_filed: vec![],
             issues_updated: vec![],
             issues_unchanged: 3,
+            issues_skipped: 0,
             summary: "s".to_string(),
         };
         assert!(!has_changes(&log));

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -179,7 +179,36 @@ pub struct MaintainerRunLog {
     pub issues_filed: Vec<IssueSummary>,
     pub issues_updated: Vec<IssueSummary>,
     pub issues_unchanged: u32,
+    #[serde(default)]
+    pub issues_skipped: u32,
     pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaintainerIssue {
+    pub number: u32,
+    pub title: String,
+    pub state: String,
+    pub url: String,
+    pub labels: Vec<GithubLabel>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "closedAt")]
+    pub closed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaintainerIssueDetail {
+    pub number: u32,
+    pub title: String,
+    pub state: String,
+    pub body: String,
+    pub url: String,
+    pub labels: Vec<GithubLabel>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "closedAt")]
+    pub closed_at: Option<String>,
 }
 
 #[cfg(test)]
@@ -481,6 +510,7 @@ mod tests {
             }],
             issues_updated: vec![],
             issues_unchanged: 3,
+            issues_skipped: 0,
             summary: "Filed 1 issue, 3 unchanged".to_string(),
         };
         let json = serde_json::to_string(&run_log).expect("serialize");
@@ -635,5 +665,80 @@ mod tests {
         let staged = deserialized.staged_session.unwrap();
         assert_eq!(staged.original_branch, "master");
         assert_eq!(staged.staging_branch, "staging/session-1-abc123");
+    }
+
+    #[test]
+    fn test_run_log_includes_issues_skipped_field() {
+        let run_log = MaintainerRunLog {
+            id: Uuid::new_v4(),
+            project_id: Uuid::new_v4(),
+            timestamp: "2026-03-09T00:00:00Z".to_string(),
+            issues_filed: vec![],
+            issues_updated: vec![],
+            issues_unchanged: 2,
+            issues_skipped: 5,
+            summary: "Skipped 5 closed issues".to_string(),
+        };
+        let json = serde_json::to_string(&run_log).expect("serialize");
+        let deserialized: MaintainerRunLog = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized.issues_skipped, 5);
+        assert_eq!(deserialized.issues_unchanged, 2);
+
+        // Also verify that issues_skipped defaults to 0 when absent
+        let json_without_skipped = r#"{
+            "id": "550e8400-e29b-41d4-a716-446655440000",
+            "project_id": "550e8400-e29b-41d4-a716-446655440001",
+            "timestamp": "2026-03-09T00:00:00Z",
+            "issues_filed": [],
+            "issues_updated": [],
+            "issues_unchanged": 3,
+            "summary": "test"
+        }"#;
+        let from_old: MaintainerRunLog =
+            serde_json::from_str(json_without_skipped).expect("deserialize without skipped");
+        assert_eq!(from_old.issues_skipped, 0);
+    }
+
+    #[test]
+    fn test_maintainer_issue_serialization_roundtrip() {
+        let issue = MaintainerIssue {
+            number: 42,
+            title: "Test issue".to_string(),
+            state: "OPEN".to_string(),
+            url: "https://github.com/owner/repo/issues/42".to_string(),
+            labels: vec![GithubLabel {
+                name: "filed-by-maintainer".to_string(),
+            }],
+            created_at: "2026-03-09T00:00:00Z".to_string(),
+            closed_at: None,
+        };
+        let json = serde_json::to_string(&issue).expect("serialize");
+        let deserialized: MaintainerIssue = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized.number, 42);
+        assert_eq!(deserialized.state, "OPEN");
+        assert!(deserialized.closed_at.is_none());
+    }
+
+    #[test]
+    fn test_maintainer_issue_detail_serialization_roundtrip() {
+        let detail = MaintainerIssueDetail {
+            number: 10,
+            title: "Detail issue".to_string(),
+            state: "CLOSED".to_string(),
+            body: "Issue body here".to_string(),
+            url: "https://github.com/owner/repo/issues/10".to_string(),
+            labels: vec![],
+            created_at: "2026-03-01T00:00:00Z".to_string(),
+            closed_at: Some("2026-03-05T00:00:00Z".to_string()),
+        };
+        let json = serde_json::to_string(&detail).expect("serialize");
+        let deserialized: MaintainerIssueDetail = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized.number, 10);
+        assert_eq!(deserialized.state, "CLOSED");
+        assert_eq!(deserialized.body, "Issue body here");
+        assert_eq!(
+            deserialized.closed_at.as_deref(),
+            Some("2026-03-05T00:00:00Z")
+        );
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -430,6 +430,7 @@ mod tests {
             }],
             issues_updated: vec![],
             issues_unchanged: 0,
+            issues_skipped: 0,
             summary: "Filed 1 issue".to_string(),
         }
     }

--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -2,7 +2,8 @@
   import { fromStore } from "svelte/store";
   import { untrack } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
-  import { focusTarget, projects, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, type Project, type FocusTarget, type MaintainerRunLog, type MaintainerStatus, type AutoWorkerStatus } from "./stores";
+  import { openUrl } from "@tauri-apps/plugin-opener";
+  import { focusTarget, projects, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, type Project, type FocusTarget, type MaintainerRunLog, type MaintainerStatus, type AutoWorkerStatus, type MaintainerIssue, type MaintainerIssueDetail } from "./stores";
   import { showToast } from "./toast";
 
   let runLogs: MaintainerRunLog[] = $state([]);
@@ -13,6 +14,22 @@
   let selectedIndex = $state(0);
   let openLogIndex: number | null = $state(null);
   let detailBlockIndex = $state(0);
+
+  // View mode: "runs" or "issues"
+  type MaintainerViewMode = "runs" | "issues";
+  let viewMode: MaintainerViewMode = $state("runs");
+
+  // Issues view state
+  let issuesList: MaintainerIssue[] = $state([]);
+  let issuesLoading = $state(false);
+  let issueDetail: MaintainerIssueDetail | null = $state(null);
+  let issueDetailLoading = $state(false);
+  let issueSelectedIndex = $state(0);
+
+  let openIssues = $derived(issuesList.filter(i => i.state === "OPEN"));
+  let closedIssues = $derived(issuesList.filter(i => i.state === "CLOSED"));
+  // Flat list: open issues first, then closed
+  let allSortedIssues = $derived([...openIssues, ...closedIssues]);
 
   const projectsState = fromStore(projects);
   let projectList: Project[] = $derived(projectsState.current);
@@ -53,6 +70,9 @@
       openLogIndex = null;
       detailBlockIndex = 0;
       runLogs = [];
+      issuesList = [];
+      issueDetail = null;
+      issueSelectedIndex = 0;
 
       const pid = untrack(() => project?.id ?? null);
       if (pid && focusedAgent?.agentKind === "maintainer") {
@@ -75,13 +95,84 @@
         triggerCheck();
       } else if (action.type === "clear-maintainer-reports") {
         clearRunLogs();
+      } else if (action.type === "toggle-maintainer-view") {
+        toggleViewMode();
+      } else if (action.type === "open-issue-in-browser") {
+        openSelectedIssueInBrowser();
       }
     });
     return unsub;
   });
 
+  function toggleViewMode() {
+    if (focusedAgent?.agentKind !== "maintainer") return;
+    if (viewMode === "runs") {
+      viewMode = "issues";
+      issueDetail = null;
+      issueSelectedIndex = 0;
+      if (project) fetchIssues(project.id);
+    } else {
+      viewMode = "runs";
+    }
+  }
+
+  async function fetchIssues(projectId: string) {
+    issuesLoading = true;
+    try {
+      const result = await invoke<MaintainerIssue[]>("get_maintainer_issues", { projectId });
+      issuesList = result;
+    } catch {
+      issuesList = [];
+    } finally {
+      issuesLoading = false;
+    }
+  }
+
+  async function fetchIssueDetail(projectId: string, issueNumber: number) {
+    issueDetailLoading = true;
+    try {
+      const result = await invoke<MaintainerIssueDetail>("get_maintainer_issue_detail", { projectId, issueNumber });
+      issueDetail = result;
+    } catch (e) {
+      showToast(String(e), "error");
+      issueDetail = null;
+    } finally {
+      issueDetailLoading = false;
+    }
+  }
+
+  function refreshIssues() {
+    if (project) fetchIssues(project.id);
+  }
+
+  function openSelectedIssueInBrowser() {
+    if (focusedAgent?.agentKind !== "maintainer") return;
+    if (viewMode === "issues") {
+      if (issueDetail) {
+        openUrl(issueDetail.url);
+      } else if (allSortedIssues.length > 0) {
+        const issue = allSortedIssues[issueSelectedIndex];
+        if (issue) openUrl(issue.url);
+      }
+    } else if (viewMode === "runs" && openLog && openLogIssues.length > 0 && detailBlockIndex > 0) {
+      const issue = openLogIssues[detailBlockIndex - 1];
+      if (issue) openUrl(issue.url);
+    }
+  }
+
   function handleNavigate(direction: 1 | -1) {
     if (focusedAgent?.agentKind !== "maintainer") return;
+
+    if (viewMode === "issues") {
+      if (issueDetail) {
+        // In detail popup, no navigation; just scroll
+        return;
+      }
+      if (allSortedIssues.length === 0) return;
+      issueSelectedIndex = Math.max(0, Math.min(allSortedIssues.length - 1, issueSelectedIndex + direction));
+      scrollIssueIntoView();
+      return;
+    }
 
     if (openLogIndex !== null) {
       // Detail view: scroll through issue blocks
@@ -98,6 +189,17 @@
 
   function handleSelect() {
     if (focusedAgent?.agentKind !== "maintainer") return;
+
+    if (viewMode === "issues") {
+      if (issueDetail) return; // already viewing detail
+      if (allSortedIssues.length === 0) return;
+      const issue = allSortedIssues[issueSelectedIndex];
+      if (issue && project) {
+        fetchIssueDetail(project.id, issue.number);
+      }
+      return;
+    }
+
     if (openLogIndex !== null) return;
     if (runLogs.length === 0) return;
     openLogIndex = selectedIndex;
@@ -105,6 +207,14 @@
   }
 
   function handleEscape() {
+    if (viewMode === "issues") {
+      if (issueDetail) {
+        issueDetail = null;
+        return;
+      }
+      // Fall through to default escape behavior
+    }
+
     if (openLogIndex !== null) {
       openLogIndex = null;
       detailBlockIndex = 0;
@@ -123,6 +233,13 @@
   function scrollReportIntoView() {
     requestAnimationFrame(() => {
       const el = document.querySelector(`[data-report-index="${selectedIndex}"]`);
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+  }
+
+  function scrollIssueIntoView() {
+    requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-issue-index="${issueSelectedIndex}"]`);
       if (el) el.scrollIntoView({ behavior: "smooth", block: "nearest" });
     });
   }
@@ -221,8 +338,16 @@
     return new Date(ts).toLocaleString();
   }
 
+  function formatDate(ts: string): string {
+    return new Date(ts).toLocaleDateString();
+  }
+
   function actionColor(action: string): string {
     return action === "filed" ? "#a6e3a1" : "#89b4fa";
+  }
+
+  function stateColor(state: string): string {
+    return state === "OPEN" ? "#a6e3a1" : "#cba6f7";
   }
 </script>
 
@@ -314,84 +439,191 @@
       {/if}
     </section>
 
-    <section class="section report-section">
-      {#if loading}
-        <div class="section-body">
-          <p class="muted">Loading...</p>
-        </div>
-      {:else if openLog}
-        <div class="detail-view">
-          <div class="detail-header">
-            <span class="detail-back">Run logs</span>
-            <span class="detail-timestamp">{formatTimestamp(openLog.timestamp)}</span>
-            <span class="detail-summary">{openLog.summary}</span>
+    <!-- View toggle tabs -->
+    <div class="view-tabs">
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <span class="view-tab" class:active={viewMode === "runs"} onclick={() => { viewMode = "runs"; }}>Runs</span>
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <span class="view-tab" class:active={viewMode === "issues"} onclick={() => { viewMode = "issues"; issueDetail = null; issueSelectedIndex = 0; if (project) fetchIssues(project.id); }}>Issues</span>
+      <span class="view-tab-hint">(t) toggle</span>
+    </div>
+
+    {#if viewMode === "runs"}
+      <section class="section report-section">
+        {#if loading}
+          <div class="section-body">
+            <p class="muted">Loading...</p>
           </div>
-          <div class="detail-blocks">
-            <div
-              class="detail-block"
-              class:block-focused={panelFocused && detailBlockIndex === 0}
-              data-block-index="0"
-            >
-              <div class="run-summary">
-                <span class="summary-stat">{openLog.issues_filed.length} filed</span>
-                <span class="summary-stat">{openLog.issues_updated.length} updated</span>
-                <span class="summary-stat">{openLog.issues_unchanged} unchanged</span>
-              </div>
+        {:else if openLog}
+          <div class="detail-view">
+            <div class="detail-header">
+              <span class="detail-back">Run logs</span>
+              <span class="detail-timestamp">{formatTimestamp(openLog.timestamp)}</span>
+              <span class="detail-summary">{openLog.summary}</span>
             </div>
-            {#each openLogIssues as issue, i}
+            <div class="detail-blocks">
               <div
                 class="detail-block"
-                class:block-focused={panelFocused && detailBlockIndex === i + 1}
-                data-block-index={i + 1}
+                class:block-focused={panelFocused && detailBlockIndex === 0}
+                data-block-index="0"
               >
-                <div class="issue-item">
-                  <span class="issue-action" style="color: {actionColor(issue.action)}">{issue.action}</span>
-                  <span class="issue-number">#{issue.issue_number}</span>
-                  <span class="issue-title">{issue.title}</span>
-                  <div class="issue-labels">
-                    {#each issue.labels.filter(l => l !== "filed-by-maintainer") as label}
-                      <span class="issue-label">{label}</span>
-                    {/each}
-                  </div>
+                <div class="run-summary">
+                  <span class="summary-stat">{openLog.issues_filed.length} filed</span>
+                  <span class="summary-stat">{openLog.issues_updated.length} updated</span>
+                  <span class="summary-stat">{openLog.issues_unchanged} unchanged</span>
+                  {#if openLog.issues_skipped > 0}
+                    <span class="summary-stat skipped">{openLog.issues_skipped} skipped (closed)</span>
+                  {/if}
                 </div>
               </div>
-            {/each}
+              {#each openLogIssues as issue, i}
+                <div
+                  class="detail-block"
+                  class:block-focused={panelFocused && detailBlockIndex === i + 1}
+                  data-block-index={i + 1}
+                >
+                  <div class="issue-item">
+                    <span class="issue-action" style="color: {actionColor(issue.action)}">{issue.action}</span>
+                    <span class="issue-number">#{issue.issue_number}</span>
+                    <span class="issue-title">{issue.title}</span>
+                    <div class="issue-labels">
+                      {#each issue.labels.filter(l => l !== "filed-by-maintainer") as label}
+                        <span class="issue-label">{label}</span>
+                      {/each}
+                    </div>
+                  </div>
+                </div>
+              {/each}
+            </div>
           </div>
-        </div>
-      {:else}
-        <div class="report-list">
-          {#if runLogs.length === 0}
-            <div class="section-body">
-              <p class="muted">No run logs yet</p>
-              {#if project.maintainer.enabled}
-                <button class="btn" onclick={triggerCheck} disabled={triggerLoading}>
-                  {triggerLoading ? "Running..." : "(r) Run check now"}
-                </button>
+        {:else}
+          <div class="report-list">
+            {#if runLogs.length === 0}
+              <div class="section-body">
+                <p class="muted">No run logs yet</p>
+                {#if project.maintainer.enabled}
+                  <button class="btn" onclick={triggerCheck} disabled={triggerLoading}>
+                    {triggerLoading ? "Running..." : "(r) Run check now"}
+                  </button>
+                {/if}
+              </div>
+            {:else}
+              {#each runLogs as log, i}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <div
+                  class="report-item"
+                  class:selected={panelFocused && selectedIndex === i}
+                  data-report-index={i}
+                  onclick={() => { selectedIndex = i; openLogIndex = i; detailBlockIndex = 0; }}
+                >
+                  <span class="log-dot"></span>
+                  <span class="report-timestamp">{formatTimestamp(log.timestamp)}</span>
+                  <span class="report-summary-preview">{log.summary}</span>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        {/if}
+      </section>
+    {:else}
+      <!-- Issues view -->
+      <section class="section report-section">
+        {#if issuesLoading}
+          <div class="section-body">
+            <p class="muted">Loading issues...</p>
+          </div>
+        {:else if issueDetail}
+          <div class="issue-detail-popup">
+            <div class="issue-detail-header">
+              <span class="issue-detail-number">#{issueDetail.number}</span>
+              <span class="issue-detail-state" style="color: {stateColor(issueDetail.state)}">{issueDetail.state}</span>
+              <span class="issue-detail-hint">(o) open in browser / (Esc) back</span>
+            </div>
+            <h3 class="issue-detail-title">{issueDetail.title}</h3>
+            <div class="issue-detail-meta">
+              <span>Created: {formatDate(issueDetail.createdAt)}</span>
+              {#if issueDetail.closedAt}
+                <span>Closed: {formatDate(issueDetail.closedAt)}</span>
               {/if}
             </div>
-          {:else}
-            {#each runLogs as log, i}
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <div
-                class="report-item"
-                class:selected={panelFocused && selectedIndex === i}
-                data-report-index={i}
-                onclick={() => { selectedIndex = i; openLogIndex = i; detailBlockIndex = 0; }}
-              >
-                <span class="log-dot"></span>
-                <span class="report-timestamp">{formatTimestamp(log.timestamp)}</span>
-                <span class="report-summary-preview">{log.summary}</span>
+            {#if issueDetail.labels.length > 0}
+              <div class="issue-detail-labels">
+                {#each issueDetail.labels.filter(l => l.name !== "filed-by-maintainer") as label}
+                  <span class="issue-label">{label.name}</span>
+                {/each}
               </div>
-            {/each}
-          {/if}
-        </div>
-      {/if}
-    </section>
+            {/if}
+            {#if issueDetail.body}
+              <div class="issue-detail-body">{issueDetail.body}</div>
+            {/if}
+          </div>
+        {:else}
+          <div class="issues-list">
+            {#if allSortedIssues.length === 0}
+              <div class="section-body">
+                <p class="muted">No maintainer issues found</p>
+                <button class="btn" onclick={refreshIssues}>Refresh</button>
+              </div>
+            {:else}
+              {#if openIssues.length > 0}
+                <div class="issues-section-label">Open ({openIssues.length})</div>
+              {/if}
+              {#each openIssues as issue, i}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <div
+                  class="issues-item"
+                  class:selected={panelFocused && issueSelectedIndex === i}
+                  data-issue-index={i}
+                  onclick={() => { issueSelectedIndex = i; if (project) fetchIssueDetail(project.id, issue.number); }}
+                >
+                  <span class="issues-state open-dot"></span>
+                  <span class="issues-number">#{issue.number}</span>
+                  <span class="issues-title">{issue.title}</span>
+                  <div class="issues-item-labels">
+                    {#each issue.labels.filter(l => l.name !== "filed-by-maintainer") as label}
+                      <span class="issue-label">{label.name}</span>
+                    {/each}
+                  </div>
+                  <span class="issues-date">{formatDate(issue.createdAt)}</span>
+                </div>
+              {/each}
+              {#if closedIssues.length > 0}
+                <div class="issues-section-label">Closed ({closedIssues.length})</div>
+              {/if}
+              {#each closedIssues as issue, ci}
+                {@const idx = openIssues.length + ci}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <div
+                  class="issues-item closed"
+                  class:selected={panelFocused && issueSelectedIndex === idx}
+                  data-issue-index={idx}
+                  onclick={() => { issueSelectedIndex = idx; if (project) fetchIssueDetail(project.id, issue.number); }}
+                >
+                  <span class="issues-state closed-dot"></span>
+                  <span class="issues-number">#{issue.number}</span>
+                  <span class="issues-title">{issue.title}</span>
+                  <div class="issues-item-labels">
+                    {#each issue.labels.filter(l => l.name !== "filed-by-maintainer") as label}
+                      <span class="issue-label">{label.name}</span>
+                    {/each}
+                  </div>
+                  <span class="issues-date">{formatDate(issue.createdAt)}</span>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        {/if}
+      </section>
+    {/if}
 
     {#if !panelFocused}
       <div class="panel-hint">
-        <span class="muted">Press <kbd>l</kbd> to browse run logs</span>
+        <span class="muted">Press <kbd>l</kbd> to browse {viewMode === "runs" ? "run logs" : "issues"}</span>
       </div>
     {/if}
   {/if}
@@ -425,6 +657,13 @@
   .btn { background: #313244; border: none; color: #cdd6f4; padding: 6px 12px; border-radius: 4px; font-size: 12px; cursor: pointer; box-shadow: none; margin-top: 8px; }
   .btn:hover { background: #45475a; }
   .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  /* View tabs */
+  .view-tabs { display: flex; align-items: center; gap: 0; border-bottom: 1px solid #313244; padding: 0 24px; }
+  .view-tab { padding: 8px 16px; font-size: 12px; color: #6c7086; cursor: pointer; border-bottom: 2px solid transparent; transition: color 0.15s, border-color 0.15s; }
+  .view-tab:hover { color: #cdd6f4; }
+  .view-tab.active { color: #89b4fa; border-bottom-color: #89b4fa; }
+  .view-tab-hint { font-size: 10px; color: #45475a; margin-left: auto; }
 
   /* Run log list */
   .report-section { border-bottom: none; flex: 1; }
@@ -465,8 +704,9 @@
   .detail-block { border-radius: 6px; transition: outline-color 0.15s; outline: 2px solid transparent; outline-offset: 2px; }
   .detail-block.block-focused { outline-color: rgba(137, 180, 250, 0.5); }
 
-  .run-summary { padding: 12px; border-radius: 6px; background: rgba(49, 50, 68, 0.3); display: flex; gap: 16px; border-left: 3px solid #89b4fa; }
+  .run-summary { padding: 12px; border-radius: 6px; background: rgba(49, 50, 68, 0.3); display: flex; gap: 16px; border-left: 3px solid #89b4fa; flex-wrap: wrap; }
   .summary-stat { font-size: 13px; color: #cdd6f4; }
+  .summary-stat.skipped { color: #6c7086; }
 
   .issue-item { padding: 8px 12px; background: rgba(49, 50, 68, 0.2); border-radius: 4px; font-size: 12px; display: flex; flex-direction: column; gap: 2px; }
   .issue-action { font-weight: 600; font-size: 11px; text-transform: uppercase; }
@@ -488,4 +728,42 @@
   .error-message { color: #bac2de; word-break: break-word; }
 
   .panel-hint { padding: 12px 24px; }
+
+  /* Issues list */
+  .issues-list { display: flex; flex-direction: column; }
+  .issues-section-label { padding: 6px 24px; font-size: 11px; font-weight: 600; color: #6c7086; text-transform: uppercase; background: rgba(49, 50, 68, 0.2); border-bottom: 1px solid rgba(49, 50, 68, 0.3); }
+  .issues-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 24px;
+    cursor: pointer;
+    font-size: 12px;
+    border-bottom: 1px solid rgba(49, 50, 68, 0.3);
+  }
+  .issues-item:hover { background: rgba(49, 50, 68, 0.3); }
+  .issues-item.selected {
+    background: rgba(137, 180, 250, 0.1);
+    outline: 1px solid rgba(137, 180, 250, 0.4);
+    outline-offset: -1px;
+  }
+  .issues-item.closed { opacity: 0.6; }
+  .issues-state { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .open-dot { background: #a6e3a1; }
+  .closed-dot { background: #cba6f7; }
+  .issues-number { color: #6c7086; font-size: 11px; flex-shrink: 0; }
+  .issues-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #cdd6f4; }
+  .issues-item-labels { display: flex; gap: 4px; flex-wrap: nowrap; flex-shrink: 0; }
+  .issues-date { color: #45475a; font-size: 10px; flex-shrink: 0; white-space: nowrap; }
+
+  /* Issue detail popup */
+  .issue-detail-popup { padding: 16px 24px; display: flex; flex-direction: column; gap: 12px; }
+  .issue-detail-header { display: flex; align-items: center; gap: 10px; font-size: 12px; }
+  .issue-detail-number { color: #6c7086; font-weight: 600; }
+  .issue-detail-state { font-weight: 600; font-size: 11px; text-transform: uppercase; }
+  .issue-detail-hint { font-size: 10px; color: #45475a; margin-left: auto; }
+  .issue-detail-title { font-size: 15px; font-weight: 600; margin: 0; color: #cdd6f4; }
+  .issue-detail-meta { display: flex; gap: 16px; font-size: 11px; color: #6c7086; }
+  .issue-detail-labels { display: flex; gap: 4px; flex-wrap: wrap; }
+  .issue-detail-body { font-size: 12px; color: #bac2de; white-space: pre-wrap; word-break: break-word; padding: 12px; background: rgba(49, 50, 68, 0.2); border-radius: 6px; max-height: 400px; overflow-y: auto; line-height: 1.6; }
 </style>

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -490,6 +490,9 @@
       case "toggle-note-preview":
         dispatchAction({ type: "toggle-note-preview" });
         return true;
+      case "toggle-maintainer-view":
+        dispatchAction({ type: "toggle-maintainer-view" });
+        return true;
       default: {
         const _exhaustive: never = id;
         return false;
@@ -648,6 +651,13 @@
         e.stopPropagation();
         e.preventDefault();
         dispatchAction({ type: "agent-panel-select" });
+        pushKeystroke(e.key);
+        return;
+      }
+      if (e.key === "o") {
+        e.stopPropagation();
+        e.preventDefault();
+        dispatchAction({ type: "open-issue-in-browser" });
         pushKeystroke(e.key);
         return;
       }

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -142,7 +142,7 @@ describe("command registry", () => {
     expect(panels.entries).toHaveLength(3);
 
     const agents = sections.find(s => s.label === "Agents")!;
-    expect(agents.entries).toHaveLength(3);
+    expect(agents.entries).toHaveLength(4);
   });
 
   it("help sections have correct entry counts for notes mode", () => {
@@ -172,5 +172,10 @@ describe("command registry", () => {
     expect(ids).toContain("toggle-agent");
     expect(ids).toContain("trigger-agent-check");
     expect(ids).toContain("clear-agent-reports");
+  });
+
+  it("includes toggle-maintainer-view command in agents mode", () => {
+    const keyMap = buildKeyMap("agents");
+    expect(keyMap.get("t")).toBe("toggle-maintainer-view");
   });
 });

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -36,7 +36,8 @@ export type CommandId =
   | "toggle-note-preview"
   | "save-prompt"
   | "load-prompt"
-  | "stage-inplace";
+  | "stage-inplace"
+  | "toggle-maintainer-view";
 
 // IDs for commands handled outside handleHotkey (Cmd+key, Escape)
 export type ExternalCommandId =
@@ -104,6 +105,7 @@ export const commands: CommandDef[] = [
   { id: "toggle-agent", key: "o", section: "Agents", description: "Toggle focused agent on/off", mode: "agents" },
   { id: "trigger-agent-check", key: "r", section: "Agents", description: "Run maintainer check for focused project", mode: "agents" },
   { id: "clear-agent-reports", key: "c", section: "Agents", description: "Clear maintainer reports for focused project", mode: "agents" },
+  { id: "toggle-maintainer-view", key: "t", section: "Agents", description: "Toggle between Runs / Issues view", mode: "agents" },
 
   // ── Notes ──
   { id: "create-note", key: "n", section: "Notes", description: "Create new note", mode: "notes" },

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -67,7 +67,29 @@ export interface MaintainerRunLog {
   issues_filed: IssueSummary[];
   issues_updated: IssueSummary[];
   issues_unchanged: number;
+  issues_skipped: number;
   summary: string;
+}
+
+export interface MaintainerIssue {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  labels: { name: string }[];
+  createdAt: string;
+  closedAt: string | null;
+}
+
+export interface MaintainerIssueDetail {
+  number: number;
+  title: string;
+  state: string;
+  body: string;
+  url: string;
+  labels: { name: string }[];
+  createdAt: string;
+  closedAt: string | null;
 }
 
 export type MaintainerStatus = "idle" | "running" | "error";
@@ -162,6 +184,8 @@ export type HotkeyAction =
   | { type: "pick-prompt-for-session"; projectId: string }
   | { type: "stage-session-inplace"; sessionId: string; projectId: string }
   | { type: "unstage-session-inplace"; projectId: string }
+  | { type: "toggle-maintainer-view" }
+  | { type: "open-issue-in-browser" }
   | null;
 
 export const hotkeyAction = writable<HotkeyAction>(null);


### PR DESCRIPTION
## Summary
- Add an Issues view (toggled with `t`) alongside existing Runs view in the maintainer agent panel, showing open/closed issues filed by the maintainer with live GitHub fetch
- Issue detail popup (Enter/l) displays full issue body, labels, and dates; `o` opens in browser
- Maintainer dedup pipeline now checks closed issues before filing — respects closure decisions and skips matching findings
- Adds `get_maintainer_issues` and `get_maintainer_issue_detail` Tauri commands backed by `gh` CLI

## Test plan
- [x] All 192 Rust tests pass (`cargo test`)
- [x] All 199 frontend tests pass (`npx vitest run`)
- [x] Toggle maintainer view command registered in agents mode
- [x] `issues_skipped` field added to `MaintainerRunLog` with serde default

🤖 Generated with [Claude Code](https://claude.com/claude-code)