### PR TITLE
fix: prevent triage panel issue body from overflowing

### DIFF
--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -403,6 +403,7 @@
 
   .issue-card {
     flex: 1;
+    min-width: 0;
     background: #181825;
     border: 1px solid #313244;
     border-radius: 8px;
@@ -442,6 +443,8 @@
     max-height: 160px;
     overflow-y: auto;
     white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: break-word;
     border-top: 1px solid #313244;
     padding-top: 8px;
   }


### PR DESCRIPTION
## Summary
- Add `min-width: 0` to `.issue-card` flex child so it can shrink below content width
- Add `overflow-wrap: break-word` and `word-break: break-word` to `.card-body` so long strings (file paths, URLs) wrap properly
- Fixes the horizontal overflow visible in the triage modal when issue bodies contain long unbroken text

## Test plan
- [ ] Open triage panel with issues that have long file paths or URLs in the body
- [ ] Verify text wraps within the card boundaries instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)