### PR TITLE
fix: enable terminal scrolling via SGR mouse wheel sequences

### DIFF
--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -149,13 +149,22 @@
       ),
     );
 
-    // Suppress xterm.js default wheel-to-arrow-key conversion in alternate
-    // screen mode. Without this, scrolling sends Up/Down arrows through tmux
-    // to Claude Code, which interprets them as input history navigation
-    // ("panning to older inputs") instead of scrolling.
+    // In alternate screen mode, xterm.js converts wheel events to arrow keys
+    // (because there's no scrollback). Claude Code interprets those arrows as
+    // input history navigation instead of scrolling. Fix: send SGR mouse wheel
+    // escape sequences directly to the inner process via send_raw_to_pty, which
+    // bypasses tmux's terminal parser. Claude Code's crossterm has mouse capture
+    // enabled and will handle these as scroll events.
     term.attachCustomWheelEventHandler((ev: WheelEvent) => {
       if (term!.buffer.active.type === 'alternate') {
         ev.preventDefault();
+        if (ev.deltaY !== 0) {
+          // SGR mouse encoding: \x1b[<button;col;rowM
+          // Button 64 = scroll up, 65 = scroll down
+          const button = ev.deltaY < 0 ? 64 : 65;
+          const seq = `\x1b[<${button};1;1M`;
+          invoke("send_raw_to_pty", { sessionId, data: seq }).catch(() => {});
+        }
         return false;
       }
       return true;


### PR DESCRIPTION
## Summary
- Fixed terminal scrolling that was broken — wheel events were being converted to arrow keys by xterm.js in alternate screen mode, causing Claude Code to navigate input history instead of scrolling
- Sends SGR mouse wheel escape sequences directly to Claude Code via `send_raw_to_pty` (bypassing tmux's terminal parser) so crossterm processes them as scroll events
- Preserves click and text selection (no tmux mouse mode needed)

## Test plan
- [x] Verified scrolling in terminal sessions scrolls conversation content, not input history
- [x] Verified clicks and text selection still work
- [x] All frontend tests pass (202 tests)
- [x] All Rust tests pass (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)