### PR TITLE
feat: restrict staging to the-controller project only

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -603,6 +603,10 @@ pub async fn stage_session_inplace(
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
         let project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
 
+        if project.name != "the-controller" {
+            return Err("Staging is only supported for the-controller".to_string());
+        }
+
         if project.staged_session.is_some() {
             return Err("A session is already staged — unstage it first".to_string());
         }

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -411,7 +411,7 @@
           dispatchHotkeyAction({ type: "unstage-session-inplace", projectId: stageProj.id });
         } else if (activeId) {
           const proj2 = projectList.find((p) => p.sessions.some((s) => s.id === activeId));
-          if (proj2) {
+          if (proj2 && proj2.name === "the-controller") {
             dispatchHotkeyAction({ type: "stage-session-inplace", sessionId: activeId, projectId: proj2.id });
           }
         }


### PR DESCRIPTION
## Summary
- Staging in-place only makes sense for the-controller itself (checking out session branches in the main repo)
- Added backend guard in `stage_session_inplace` that rejects staging for non-the-controller projects
- Added frontend guard so the `v` hotkey silently skips staging for other projects

## Test plan
- [x] All 212 Rust tests pass
- [x] All 202 frontend tests pass
- [x] Staging on the-controller still works (no change to existing behavior)
- [x] Staging on other projects returns clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)