### PR TITLE
fix: add priority criteria to maintainer agent prompt

### DIFF
--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -207,11 +207,17 @@ IMPORTANT:
 For each finding, provide:
 - `title`: short actionable issue title
 - `body`: markdown body with concrete evidence and remediation
-- `priority`: `high` or `low`
+- `priority`: `high` or `low` (see criteria below)
 - `complexity`: `high` or `simple`
 - `affected_files`: list of file paths (when applicable)
 - `symptom_type`: short invariant symptom phrase (e.g. `startup panic`, `missing coverage`)
 - `keywords`: stable semantic keywords (e.g. `appstate`, `filesystem`, `initialization`)
+
+PRIORITY CRITERIA — most findings should be low priority:
+- `high`: Affects correctness, reliability, or data integrity. Examples: logic bugs, panics, race conditions, data loss, security vulnerabilities, broken core functionality.
+- `low`: Everything else. Examples: missing tests, style issues, documentation gaps, minor code quality improvements, refactoring opportunities, non-critical TODOs.
+
+When in doubt, use `low`. Reserve `high` for issues that could cause wrong behavior or failures in production.
 
 Return ONLY this JSON object:
 
@@ -221,7 +227,7 @@ Return ONLY this JSON object:
     {{
       "title": "<title>",
       "body": "<markdown body>",
-      "priority": "high",
+      "priority": "low",
       "complexity": "simple",
       "affected_files": ["<path>"],
       "symptom_type": "<symptom>",


### PR DESCRIPTION
## Summary
- The maintainer agent was filing nearly all issues as high priority because the prompt lacked priority criteria and the example JSON defaulted to `"high"`
- Added explicit priority definitions: high = correctness/reliability/security issues; low = everything else
- Changed example JSON default from `"high"` to `"low"` and added "when in doubt, use low" guidance

## Test plan
- [x] Rust tests pass (17/17)
- [x] Frontend tests pass (202/202)
- [ ] Verify next maintainer run produces a more balanced priority distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)