### PR TITLE
fix: standardize auto-worker issue labels

### DIFF
--- a/docs/plans/2026-03-09-auto-worker-label-standardization.md
+++ b/docs/plans/2026-03-09-auto-worker-label-standardization.md
@@ -1,0 +1,119 @@
+# Auto-Worker Label Standardization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Standardize issue labels across maintainer, triage, manual issue creation, and auto-worker so the worker can reliably pick up tasks, then migrate existing GitHub issues to the standardized taxonomy.
+
+**Architecture:** Keep one canonical label taxonomy: `priority:high|low` and `complexity:simple|high`. Update all frontend label emitters to write the canonical labels. In the auto-worker scheduler, migrate existing GitHub issues from legacy labels to the canonical set before issue selection, then select only canonical labels.
+
+**Tech Stack:** Rust (`gh` CLI, Tauri backend), Svelte 5 frontend, Rust unit tests, Vitest where needed.
+
+---
+
+### Task 1: Lock the behavior with failing Rust tests
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+- standardized labels `priority:high` + `complexity:simple` are eligible
+- legacy labels are mapped to canonical labels during migration
+- legacy labels are removed without adding unrelated labels during migration
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::`
+
+Expected: at least the new eligibility test fails before implementation.
+
+**Step 3: Write minimal implementation**
+
+Add pure helper functions in `auto_worker.rs` that:
+- determine eligibility from canonical labels only
+- compute add/remove label actions for migrating one issue
+
+**Step 4: Run test to verify it passes**
+
+Run the same `cargo test` command and verify green.
+
+### Task 2: Migrate live issues before worker selection
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write the failing test**
+
+Add tests for migration action generation:
+- `priority: high` -> `priority:high`
+- `priority: low` -> `priority:low`
+- `complexity: low` -> `complexity:simple`
+- `complexity: high` -> `complexity:high`
+- migration does not add unrelated labels such as `triaged`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::migration_plan_rewrites_legacy_labels`
+
+Expected: fail until action computation exists.
+
+**Step 3: Write minimal implementation**
+
+In the scheduler path:
+- ensure canonical labels exist
+- fetch issues
+- migrate legacy labels on GitHub with `gh issue edit`
+- update the in-memory issue list before calling `pick_eligible_issue`
+
+**Step 4: Run test to verify it passes**
+
+Run the focused `cargo test` command again.
+
+### Task 3: Update all label emitters to canonical labels
+
+**Files:**
+- Modify: `src/App.svelte`
+- Modify: `src/lib/TriagePanel.svelte`
+- Modify: `src/lib/IssuePickerModal.svelte`
+- Modify: `src/lib/AgentDashboard.svelte`
+
+**Step 1: Write the failing test**
+
+Prefer updating existing UI tests only if they already cover label text or sorting behavior. Otherwise keep this task implementation-only and verify via deterministic code review plus backend tests.
+
+**Step 2: Write minimal implementation**
+
+Update:
+- manual issue creation labels in `App.svelte`
+- triage labels in `TriagePanel.svelte`
+- issue priority grouping in `IssuePickerModal.svelte`
+- policy text in `AgentDashboard.svelte`
+
+**Step 3: Run targeted verification**
+
+Run: `npm test -- --runInBand` only if a directly affected frontend test exists and stays cheap; otherwise rely on `npx vitest run src/lib/commands.test.ts src/App.test.ts` only if relevant.
+
+### Task 4: Validate with live GitHub migration and worker readiness
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run backend verification**
+
+Run: `cd src-tauri && cargo test auto_worker`
+
+**Step 2: Run live migration trigger**
+
+Run the app or a targeted backend path that executes the auto-worker scheduler against the enabled `the-controller` project so existing issues are migrated.
+
+**Step 3: Validate agent behavior**
+
+Verify on the live repo:
+- target issues now carry canonical labels
+- at least one issue has `priority:high` and `complexity:simple`
+- the auto-worker has an eligible issue to spawn against
+
+**Step 4: Record residual risks**
+
+If full end-to-end session spawning cannot be exercised in this turn, explicitly report that gap and the evidence gathered.

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -25,6 +25,28 @@ const POLL_INTERVAL_SECS: u64 = 30;
 const SESSION_TIMEOUT_SECS: u64 = 30 * 60; // 30 minutes
 const MAX_NUDGES: u32 = 3;
 const NUDGE_COOLDOWN_SECS: u64 = 60;
+const LABEL_PRIORITY_HIGH_OLD: &str = "priority: high";
+const LABEL_PRIORITY_LOW_OLD: &str = "priority: low";
+const LABEL_PRIORITY_HIGH: &str = "priority:high";
+const LABEL_PRIORITY_LOW: &str = "priority:low";
+const LABEL_COMPLEXITY_LOW_OLD: &str = "complexity: low";
+const LABEL_COMPLEXITY_HIGH_OLD: &str = "complexity: high";
+const LABEL_COMPLEXITY_SIMPLE: &str = "complexity:simple";
+const LABEL_COMPLEXITY_HIGH: &str = "complexity:high";
+const LABEL_IN_PROGRESS: &str = "in-progress";
+const LABEL_FINISHED_BY_WORKER: &str = "finished-by-worker";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct LabelMigration {
+    add: Vec<String>,
+    remove: Vec<String>,
+}
+
+impl LabelMigration {
+    fn is_empty(&self) -> bool {
+        self.add.is_empty() && self.remove.is_empty()
+    }
+}
 
 struct ActiveSession {
     session_id: Uuid,
@@ -66,15 +88,18 @@ impl AutoWorkerScheduler {
             if !project.auto_worker.enabled || project.archived {
                 continue;
             }
-            let issues = match fetch_issues_sync(&project.repo_path) {
+            let mut issues = match fetch_issues_sync(&project.repo_path) {
                 Ok(issues) => issues,
                 Err(_) => continue,
             };
+            if migrate_issues_sync(&project.repo_path, &mut issues).is_err() {
+                continue;
+            }
             for issue in &issues {
                 let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
-                if labels.contains(&"in-progress") {
+                if labels.contains(&LABEL_IN_PROGRESS) {
                     eprintln!("Auto-worker: removing stale in-progress label from #{}", issue.number);
-                    let _ = remove_label_sync(&project.repo_path, issue.number, "in-progress");
+                    let _ = remove_label_sync(&project.repo_path, issue.number, LABEL_IN_PROGRESS);
                 }
             }
         }
@@ -197,13 +222,18 @@ impl AutoWorkerScheduler {
                         continue;
                     }
 
-                    let issues = match fetch_issues_sync(&project.repo_path) {
+                    let mut issues = match fetch_issues_sync(&project.repo_path) {
                         Ok(issues) => issues,
                         Err(e) => {
                             eprintln!("Auto-worker: failed to fetch issues for {}: {}", project.name, e);
                             continue;
                         }
                     };
+
+                    if let Err(e) = migrate_issues_sync(&project.repo_path, &mut issues) {
+                        eprintln!("Auto-worker: failed to migrate issue labels for {}: {}", project.name, e);
+                        continue;
+                    }
 
                     let eligible = match pick_eligible_issue(&issues) {
                         Some(issue) => issue.clone(),
@@ -212,7 +242,7 @@ impl AutoWorkerScheduler {
 
                     match spawn_auto_worker_session(&state, &app_handle, project, &eligible) {
                         Ok(session_id) => {
-                            let _ = add_label_sync(&project.repo_path, eligible.number, "in-progress");
+                            let _ = add_label_sync(&project.repo_path, eligible.number, LABEL_IN_PROGRESS);
                             emit_status(&app_handle, project.id, "working", None, Some(eligible.number), Some(&eligible.title));
                             active_sessions.insert(project.id, ActiveSession {
                                 session_id,
@@ -291,6 +321,111 @@ fn remove_label_sync(repo_path: &str, issue_number: u64, label: &str) -> Result<
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("gh issue edit failed: {}", stderr));
     }
+    Ok(())
+}
+
+fn ensure_standard_labels_exist_sync(repo_path: &str) -> Result<(), String> {
+    let labels = [
+        (LABEL_PRIORITY_LOW, "Low priority", "a6e3a1"),
+        (LABEL_PRIORITY_HIGH, "High priority", "f38ba8"),
+        (LABEL_COMPLEXITY_SIMPLE, "Simple fix", "89b4fa"),
+        (LABEL_COMPLEXITY_HIGH, "Significant effort", "f9e2af"),
+    ];
+
+    for (label, description, color) in labels {
+        let output = Command::new("gh")
+            .args([
+                "label",
+                "create",
+                label,
+                "--description",
+                description,
+                "--color",
+                color,
+                "--force",
+            ])
+            .current_dir(repo_path)
+            .output()
+            .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("gh label create failed: {}", stderr));
+        }
+    }
+
+    Ok(())
+}
+
+fn dedup_and_sort(values: &mut Vec<String>) {
+    values.sort();
+    values.dedup();
+}
+
+fn migration_for_issue(issue: &GithubIssue) -> LabelMigration {
+    let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
+    let has = |label: &str| labels.contains(&label);
+
+    let mut migration = LabelMigration::default();
+
+    if has(LABEL_PRIORITY_HIGH_OLD) {
+        migration.remove.push(LABEL_PRIORITY_HIGH_OLD.to_string());
+        if !has(LABEL_PRIORITY_HIGH) {
+            migration.add.push(LABEL_PRIORITY_HIGH.to_string());
+        }
+    }
+    if has(LABEL_PRIORITY_LOW_OLD) {
+        migration.remove.push(LABEL_PRIORITY_LOW_OLD.to_string());
+        if !has(LABEL_PRIORITY_LOW) {
+            migration.add.push(LABEL_PRIORITY_LOW.to_string());
+        }
+    }
+    if has(LABEL_COMPLEXITY_LOW_OLD) {
+        migration.remove.push(LABEL_COMPLEXITY_LOW_OLD.to_string());
+        if !has(LABEL_COMPLEXITY_SIMPLE) {
+            migration.add.push(LABEL_COMPLEXITY_SIMPLE.to_string());
+        }
+    }
+    if has(LABEL_COMPLEXITY_HIGH_OLD) {
+        migration.remove.push(LABEL_COMPLEXITY_HIGH_OLD.to_string());
+        if !has(LABEL_COMPLEXITY_HIGH) {
+            migration.add.push(LABEL_COMPLEXITY_HIGH.to_string());
+        }
+    }
+    dedup_and_sort(&mut migration.add);
+    dedup_and_sort(&mut migration.remove);
+    migration
+}
+
+fn apply_issue_migration(issue: &mut GithubIssue, migration: &LabelMigration) {
+    issue.labels
+        .retain(|label| !migration.remove.iter().any(|remove| remove == &label.name));
+    for label in &migration.add {
+        if !issue.labels.iter().any(|existing| existing.name == *label) {
+            issue.labels.push(crate::models::GithubLabel { name: label.clone() });
+        }
+    }
+}
+
+fn migrate_issues_sync(repo_path: &str, issues: &mut [GithubIssue]) -> Result<(), String> {
+    ensure_standard_labels_exist_sync(repo_path)?;
+
+    for issue in issues {
+        let migration = migration_for_issue(issue);
+        if migration.is_empty() {
+            continue;
+        }
+
+        for label in &migration.add {
+            add_label_sync(repo_path, issue.number, label)?;
+        }
+        for label in &migration.remove {
+            remove_label_sync(repo_path, issue.number, label)?;
+        }
+
+        apply_issue_migration(issue, &migration);
+    }
+
     Ok(())
 }
 
@@ -375,7 +510,7 @@ fn kill_session(state: &AppState, session: &ActiveSession) {
     if let Ok(mut pty_manager) = state.pty_manager.lock() {
         let _ = pty_manager.close_session(session.session_id);
     }
-    let _ = remove_label_sync(&session.repo_path, session.issue_number, "in-progress");
+    let _ = remove_label_sync(&session.repo_path, session.issue_number, LABEL_IN_PROGRESS);
     cleanup_session(state, session);
 }
 
@@ -428,9 +563,9 @@ fn close_issue_sync(repo_path: &str, issue_number: u64) -> Result<(), String> {
 }
 
 fn mark_issue_finished(session: &ActiveSession) {
-    let _ = remove_label_sync(&session.repo_path, session.issue_number, "in-progress");
+    let _ = remove_label_sync(&session.repo_path, session.issue_number, LABEL_IN_PROGRESS);
     if has_merged_pr_sync(&session.repo_path, session.issue_number) {
-        let _ = add_label_sync(&session.repo_path, session.issue_number, "finished-by-worker");
+        let _ = add_label_sync(&session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
         let _ = close_issue_sync(&session.repo_path, session.issue_number);
         eprintln!("Auto-worker: closed #{} (merged PR verified)", session.issue_number);
     } else {
@@ -459,11 +594,10 @@ fn cleanup_session(state: &AppState, session: &ActiveSession) {
 /// Check if an issue is eligible for auto-worker processing.
 pub fn is_eligible(issue: &GithubIssue) -> bool {
     let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
-    labels.contains(&"priority: high")
-        && labels.contains(&"complexity: low")
-        && labels.contains(&"triaged")
-        && !labels.contains(&"in-progress")
-        && !labels.contains(&"finished-by-worker")
+    labels.contains(&LABEL_PRIORITY_HIGH)
+        && labels.contains(&LABEL_COMPLEXITY_SIMPLE)
+        && !labels.contains(&LABEL_IN_PROGRESS)
+        && !labels.contains(&LABEL_FINISHED_BY_WORKER)
 }
 
 /// Pick the first eligible issue from a list.
@@ -488,45 +622,51 @@ mod tests {
 
     #[test]
     fn eligible_issue_has_all_required_labels() {
-        let issue = make_issue(&["priority: high", "complexity: low", "triaged"]);
+        let issue = make_issue(&["priority:high", "complexity:simple", "triaged"]);
+        assert!(is_eligible(&issue));
+    }
+
+    #[test]
+    fn standardized_issue_is_eligible() {
+        let issue = make_issue(&["priority:high", "complexity:simple"]);
         assert!(is_eligible(&issue));
     }
 
     #[test]
     fn missing_priority_high_not_eligible() {
-        let issue = make_issue(&["complexity: low", "triaged"]);
+        let issue = make_issue(&["complexity:simple", "triaged"]);
         assert!(!is_eligible(&issue));
     }
 
     #[test]
     fn missing_complexity_low_not_eligible() {
-        let issue = make_issue(&["priority: high", "triaged"]);
+        let issue = make_issue(&["priority:high", "triaged"]);
         assert!(!is_eligible(&issue));
     }
 
     #[test]
-    fn missing_triaged_not_eligible() {
-        let issue = make_issue(&["priority: high", "complexity: low"]);
-        assert!(!is_eligible(&issue));
+    fn triaged_not_required_for_eligibility() {
+        let issue = make_issue(&["priority:high", "complexity:simple"]);
+        assert!(is_eligible(&issue));
     }
 
     #[test]
     fn in_progress_not_eligible() {
-        let issue = make_issue(&["priority: high", "complexity: low", "triaged", "in-progress"]);
+        let issue = make_issue(&["priority:high", "complexity:simple", "triaged", "in-progress"]);
         assert!(!is_eligible(&issue));
     }
 
     #[test]
     fn finished_by_worker_not_eligible() {
-        let issue = make_issue(&["priority: high", "complexity: low", "triaged", "finished-by-worker"]);
+        let issue = make_issue(&["priority:high", "complexity:simple", "triaged", "finished-by-worker"]);
         assert!(!is_eligible(&issue));
     }
 
     #[test]
     fn pick_eligible_returns_first_match() {
         let issues = vec![
-            make_issue(&["priority: low"]),
-            make_issue(&["priority: high", "complexity: low", "triaged"]),
+            make_issue(&["priority:low"]),
+            make_issue(&["priority:high", "complexity:simple"]),
         ];
         let picked = pick_eligible_issue(&issues);
         assert!(picked.is_some());
@@ -535,10 +675,50 @@ mod tests {
     #[test]
     fn pick_eligible_returns_none_when_no_match() {
         let issues = vec![
-            make_issue(&["priority: low"]),
-            make_issue(&["in-progress", "priority: high", "complexity: low", "triaged"]),
+            make_issue(&["priority:low"]),
+            make_issue(&["in-progress", "priority:high", "complexity:simple"]),
         ];
         assert!(pick_eligible_issue(&issues).is_none());
+    }
+
+    #[test]
+    fn migration_plan_rewrites_legacy_labels() {
+        let issue = make_issue(&["priority: high", "complexity: low"]);
+        let migration = migration_for_issue(&issue);
+        assert_eq!(
+            migration,
+            LabelMigration {
+                add: vec!["complexity:simple".to_string(), "priority:high".to_string()],
+                remove: vec!["complexity: low".to_string(), "priority: high".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn migration_plan_does_not_add_triaged_for_maintainer_issues() {
+        let issue = make_issue(&["filed-by-maintainer", "priority:high", "complexity:simple"]);
+        let migration = migration_for_issue(&issue);
+        assert_eq!(
+            migration,
+            LabelMigration {
+                add: vec![],
+                remove: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn apply_issue_migration_updates_issue_labels() {
+        let mut issue = make_issue(&["filed-by-maintainer", "priority: high", "complexity: low"]);
+        let migration = migration_for_issue(&issue);
+        apply_issue_migration(&mut issue, &migration);
+
+        let labels: Vec<&str> = issue.labels.iter().map(|label| label.name.as_str()).collect();
+        assert!(labels.contains(&"filed-by-maintainer"));
+        assert!(labels.contains(&"priority:high"));
+        assert!(labels.contains(&"complexity:simple"));
+        assert!(!labels.contains(&"priority: high"));
+        assert!(!labels.contains(&"complexity: low"));
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -137,7 +137,7 @@
       invoke("add_github_label", {
         repoPath,
         issueNumber: issue.number,
-        label: `priority: ${priority}`,
+        label: `priority:${priority}`,
         description: priority === "high" ? "Important, should be tackled soon" : "Nice to have, can wait",
         color: priority === "high" ? "F38BA8" : "A6E3A1",
       }).catch((e: unknown) => showToast(`Failed to add priority label: ${e}`, "error"));
@@ -145,7 +145,7 @@
       invoke("add_github_label", {
         repoPath,
         issueNumber: issue.number,
-        label: `complexity: ${complexity}`,
+        label: complexity === "high" ? "complexity:high" : "complexity:simple",
         description: complexity === "high" ? "Multi-step task, needs capable agents" : "Quick task, suitable for simple agents",
         color: complexity === "high" ? "FAB387" : "89DCEB",
       }).catch((e: unknown) => showToast(`Failed to add complexity label: ${e}`, "error"));

--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -450,9 +450,8 @@
         <div class="policy-row">
           <span class="policy-label">Required</span>
           <div class="policy-labels">
-            <span class="policy-tag required">priority: high</span>
-            <span class="policy-tag required">complexity: low</span>
-            <span class="policy-tag required">triaged</span>
+            <span class="policy-tag required">priority:high</span>
+            <span class="policy-tag required">complexity:simple</span>
           </div>
         </div>
         <div class="policy-row">

--- a/src/lib/IssuePickerModal.svelte
+++ b/src/lib/IssuePickerModal.svelte
@@ -28,9 +28,9 @@
     const other: IssueGroup = { label: "Unprioritized", items: [] };
 
     issues.forEach((issue, index) => {
-      if (issue.labels.some(l => l.name === "priority: high")) {
+      if (issue.labels.some(l => l.name === "priority:high")) {
         high.items.push({ issue, index });
-      } else if (issue.labels.some(l => l.name === "priority: low")) {
+      } else if (issue.labels.some(l => l.name === "priority:low")) {
         low.items.push({ issue, index });
       } else {
         other.items.push({ issue, index });
@@ -50,8 +50,8 @@
           .filter(issue => !issue.labels.some(l => l.name === "in-progress"))
           .sort((a, b) => {
             const priorityOf = (issue: GithubIssue) => {
-              if (issue.labels.some(l => l.name === "priority: high")) return 0;
-              if (issue.labels.some(l => l.name === "priority: low")) return 2;
+              if (issue.labels.some(l => l.name === "priority:high")) return 0;
+              if (issue.labels.some(l => l.name === "priority:low")) return 2;
               return 1; // unprioritized in the middle
             };
             return priorityOf(a) - priorityOf(b);

--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -119,7 +119,7 @@
       invoke("add_github_label", {
         repoPath: path,
         issueNumber: issue.number,
-        label: `priority: ${priority}`,
+        label: `priority:${priority}`,
         description: priority === "high" ? "Important, should be tackled soon" : "Nice to have, can wait",
         color: priority === "high" ? "F38BA8" : "A6E3A1",
       }).catch((e: unknown) => showToast(`Failed to label #${issue.number}: ${e}`, "error"));
@@ -129,7 +129,7 @@
       invoke("add_github_label", {
         repoPath: path,
         issueNumber: issue.number,
-        label: `complexity: ${complexity}`,
+        label: complexity === "low" ? "complexity:simple" : "complexity:high",
         description: complexity === "low" ? "Quick task, suitable for simple agents" : "Multi-step task, needs capable agents",
         color: complexity === "low" ? "89DCEB" : "FAB387",
       }).catch((e: unknown) => showToast(`Failed to label #${issue.number}: ${e}`, "error"));


### PR DESCRIPTION
## Summary
- standardize auto-worker eligibility and migration around canonical priority/complexity labels
- remove the triaged requirement from worker pickup while keeping in-progress and finished exclusions
- update issue creation, triage, and dashboard policy text to match the canonical labels

## Testing
- npx vitest run
- cd src-tauri && cargo test

Closes #264