### PR TITLE
test: cover scaffold rollback on GitHub creation failure

### DIFF
--- a/docs/plans/2026-03-10-scaffold-rollback-design.md
+++ b/docs/plans/2026-03-10-scaffold-rollback-design.md
@@ -1,0 +1,57 @@
+# Scaffold Rollback On GitHub Failure Design
+
+## Summary
+
+`scaffold_project` creates the repo directory, initializes git, writes template files, and commits them before it publishes to GitHub. Without rollback, a failed GitHub publish leaves partial scaffold state behind. That can be a local repo directory after `gh repo create` fails, or both a local directory and an orphaned remote if the GitHub repo is created but the initial push fails.
+
+## Goals
+
+- Make `scaffold_project` transactional with respect to local and remote scaffold state created by the command.
+- Preserve the current success path: template files, initial commit, pushed GitHub repo, then saved project entry.
+- Keep rollback narrow so we only delete the directory and remote this command created, never a pre-existing user directory or unrelated remote.
+
+## Approach Options
+
+### Option 1: Roll back local and remote state on publish failure
+
+Split publishing into two steps:
+- `gh repo create --remote=origin` to create the remote and wire up `origin`
+- `git push --set-upstream origin HEAD` to publish the initial commit
+
+If `gh repo create` fails, remove the local directory. If the push fails after the remote exists, delete the remote with `gh repo delete --yes` and then remove the local directory.
+
+Pros:
+- Matches the current UX expectation: failed scaffold means no partially created project is left behind.
+- Covers both failure points in the publish flow.
+- Keeps retry behavior simple.
+
+Cons:
+- Requires extra cleanup logic for the remote-delete path.
+
+### Option 2: Persist a recoverable partial project entry
+
+Save a project record before the GitHub step and mark it as incomplete so the app can resume or repair it later.
+
+Pros:
+- Preserves work for recovery.
+
+Cons:
+- Requires new persisted state, new UI handling, and follow-up repair flows that do not exist today.
+- Larger surface area than the issue asks for.
+
+## Recommended Design
+
+Use Option 1. Keep project persistence after the GitHub publish succeeds so failed scaffolds do not write project metadata. On `gh repo create` failure, best-effort delete the newly created local repo directory. On initial push failure, best-effort delete the created GitHub remote first, then remove the local repo directory. Return the original failure message and append cleanup failures when rollback is incomplete.
+
+## Error Handling
+
+- Preserve the original failure message from the step that failed.
+- If rollback also fails, return an error that includes both the original failure and the cleanup failure so the user still knows manual cleanup may be required.
+- Only attempt remote deletion when a remote was created and can be identified from `origin`.
+- Do not attempt rollback for directories that existed before the command; those are rejected before creation.
+
+## Testing
+
+- Add a command-level regression test that forces `gh repo create` to fail and verifies the repo directory is removed and retry works.
+- Add a command-level regression test that lets `gh repo create` succeed but forces the initial push to fail and verifies both the local repo and created remote are deleted.
+- Verify no project metadata is persisted after either failure mode.

--- a/docs/plans/2026-03-10-scaffold-rollback-implementation.md
+++ b/docs/plans/2026-03-10-scaffold-rollback-implementation.md
@@ -1,0 +1,93 @@
+# Scaffold Rollback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `scaffold_project` clean up partial local and remote scaffold state when GitHub publishing fails so the user can retry immediately.
+
+**Architecture:** Keep scaffolding local setup the same, but split GitHub publishing into `gh repo create --remote=origin` and `git push --set-upstream origin HEAD`. Roll back the local directory when repo creation fails, and roll back both the created remote and local directory when the initial push fails. Keep project persistence after publish success so there is no partial storage state to clean up.
+
+**Tech Stack:** Rust, git2, std::fs, existing command tests in `src-tauri/src/commands.rs`
+
+---
+
+### Task 1: Document the failing behavior with a regression test
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/commands.rs`
+
+**Step 1: Write the failing test**
+
+Add a command-level test that:
+- Creates a temp projects root.
+- Uses fake `gh` and `git` binaries to force `gh repo create` to fail.
+- Calls `scaffold_project`.
+- Asserts the repo directory no longer exists.
+- Asserts no project metadata was saved.
+- Retries with successful fake binaries and asserts the directory exists.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test test_scaffold_project_rolls_back_directory_when_github_creation_fails --manifest-path src-tauri/Cargo.toml -- --exact`
+
+Expected: FAIL because the repo directory is still present after the simulated GitHub failure.
+
+### Task 2: Implement rollback for both publish failure points
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+
+**Step 1: Write minimal implementation**
+
+- Add helper functions for `gh` and `git` command construction plus rollback of local and remote scaffold state.
+- Change `scaffold_project` to call `gh repo create --remote=origin` first and `git push --set-upstream origin HEAD` second.
+- On `gh repo create` failure, remove the local repo directory.
+- On push failure, delete the created remote and then remove the local repo directory.
+
+**Step 2: Run targeted test to verify it passes**
+
+Run: `cargo test test_scaffold_project_rolls_back_directory_when_github_creation_fails --manifest-path src-tauri/Cargo.toml -- --exact`
+
+Expected: PASS.
+
+### Task 3: Cover the push-failure edge case and surrounding behavior
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/commands.rs`
+
+**Step 1: Add push-failure regression**
+
+Add a second command-level test that:
+- Uses fake `gh` to create an `origin` remote successfully.
+- Uses fake `git` to fail the first push and succeed on retry.
+- Verifies both local directory cleanup and remote deletion on failure.
+- Verifies retry recreates the remote and saves the project.
+
+**Step 2: Run relevant command and integration tests**
+
+Run: `cargo test commands::tests:: --manifest-path src-tauri/Cargo.toml`
+
+Run: `cargo test test_scaffold --manifest-path src-tauri/Cargo.toml`
+
+Expected: PASS.
+
+### Task 4: Review and ship
+
+**Files:**
+- Modify: `docs/plans/2026-03-10-scaffold-rollback-design.md`
+- Modify: `docs/plans/2026-03-10-scaffold-rollback-implementation.md`
+
+**Step 1: Self-review diff**
+
+Run: `git diff -- src-tauri/src/commands.rs src-tauri/tests/integration.rs docs/plans/2026-03-10-scaffold-rollback-design.md docs/plans/2026-03-10-scaffold-rollback-implementation.md`
+
+**Step 2: Verify before commit**
+
+Run the full verification command chosen for this fix and confirm fresh passing output before commit/PR.
+
+**Step 3: Commit**
+
+Use a commit message that includes `closes #328` in the body and ends with:
+
+`Contributed-by: auto-worker`

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -548,7 +548,12 @@ pub fn create_session(
     // Build initial prompt: explicit prompt takes priority, then GitHub issue context
     let initial_prompt = initial_prompt.or_else(|| {
         github_issue.as_ref().map(|issue| {
-            crate::session_args::build_issue_prompt(issue.number, &issue.title, &issue.url, background)
+            crate::session_args::build_issue_prompt(
+                issue.number,
+                &issue.title,
+                &issue.url,
+                background,
+            )
         })
     });
 
@@ -669,7 +674,9 @@ pub async fn stage_session_inplace(
     // Extract data under a short-lived storage lock to avoid deadlock with pty_manager
     let (repo_path, branch, worktree_path) = {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
+        let project = storage
+            .load_project(project_uuid)
+            .map_err(|e| e.to_string())?;
 
         if project.name != "the-controller" {
             return Err("Staging is only supported for the-controller".to_string());
@@ -703,11 +710,9 @@ pub async fn stage_session_inplace(
     // 1. Ensure worktree is clean — prompt Claude to commit if needed
     {
         let wt = worktree_path.clone();
-        let is_clean = tokio::task::spawn_blocking(move || {
-            WorktreeManager::is_worktree_clean(&wt)
-        })
-        .await
-        .map_err(|e| format!("Task failed: {}", e))??;
+        let is_clean = tokio::task::spawn_blocking(move || WorktreeManager::is_worktree_clean(&wt))
+            .await
+            .map_err(|e| format!("Task failed: {}", e))??;
 
         if !is_clean {
             let prompt = "\nYou have uncommitted changes. Please commit all your work now.\r";
@@ -734,7 +739,9 @@ pub async fn stage_session_inplace(
                 }
             }
             if !committed {
-                return Err("Timed out waiting for commit. Please commit manually and retry.".to_string());
+                return Err(
+                    "Timed out waiting for commit. Please commit manually and retry.".to_string(),
+                );
             }
         }
     }
@@ -742,35 +749,29 @@ pub async fn stage_session_inplace(
     // 2. Rebase onto main if needed
     {
         let rp = repo_path.clone();
-        let main_branch = tokio::task::spawn_blocking(move || {
-            WorktreeManager::detect_main_branch(&rp)
-        })
-        .await
-        .map_err(|e| format!("Task failed: {}", e))??;
+        let main_branch =
+            tokio::task::spawn_blocking(move || WorktreeManager::detect_main_branch(&rp))
+                .await
+                .map_err(|e| format!("Task failed: {}", e))??;
 
         let rp = repo_path.clone();
-        let _ = tokio::task::spawn_blocking(move || {
-            WorktreeManager::sync_main(&rp)
-        })
-        .await;
+        let _ = tokio::task::spawn_blocking(move || WorktreeManager::sync_main(&rp)).await;
 
         let rp = repo_path.clone();
         let br = branch.clone();
         let mb = main_branch.clone();
-        let is_behind = tokio::task::spawn_blocking(move || {
-            WorktreeManager::is_branch_behind(&rp, &br, &mb)
-        })
-        .await
-        .map_err(|e| format!("Task failed: {}", e))??;
+        let is_behind =
+            tokio::task::spawn_blocking(move || WorktreeManager::is_branch_behind(&rp, &br, &mb))
+                .await
+                .map_err(|e| format!("Task failed: {}", e))??;
 
         if is_behind {
             let wt = worktree_path.clone();
             let mb = main_branch.clone();
-            let rebase_clean = tokio::task::spawn_blocking(move || {
-                WorktreeManager::rebase_onto(&wt, &mb)
-            })
-            .await
-            .map_err(|e| format!("Task failed: {}", e))??;
+            let rebase_clean =
+                tokio::task::spawn_blocking(move || WorktreeManager::rebase_onto(&wt, &mb))
+                    .await
+                    .map_err(|e| format!("Task failed: {}", e))??;
 
             if !rebase_clean {
                 // Rebase has conflicts — ask Claude to resolve
@@ -780,13 +781,15 @@ pub async fn stage_session_inplace(
                     let _ = pty_manager.write_to_session(session_uuid, prompt.as_bytes());
                 }
 
-                let _ = app_handle.emit("staging-status", "Rebase conflicts. Claude is resolving...");
+                let _ =
+                    app_handle.emit("staging-status", "Rebase conflicts. Claude is resolving...");
 
                 // Poll until rebase is no longer in progress
                 let max_polls = MAX_REBASE_WAIT_SECS / REBASE_POLL_INTERVAL_SECS;
                 let mut resolved = false;
                 for _ in 0..max_polls {
-                    tokio::time::sleep(std::time::Duration::from_secs(REBASE_POLL_INTERVAL_SECS)).await;
+                    tokio::time::sleep(std::time::Duration::from_secs(REBASE_POLL_INTERVAL_SECS))
+                        .await;
                     let wt_check = worktree_path.clone();
                     let still_rebasing = tokio::task::spawn_blocking(move || {
                         WorktreeManager::is_rebase_in_progress(&wt_check)
@@ -808,14 +811,15 @@ pub async fn stage_session_inplace(
     // 3. Proceed with staging — re-acquire storage lock
     let rp = repo_path.clone();
     let br = branch.clone();
-    let original_branch = tokio::task::spawn_blocking(move || {
-        WorktreeManager::stage_inplace(&rp, &br)
-    })
-    .await
-    .map_err(|e| format!("Task failed: {}", e))??;
+    let original_branch =
+        tokio::task::spawn_blocking(move || WorktreeManager::stage_inplace(&rp, &br))
+            .await
+            .map_err(|e| format!("Task failed: {}", e))??;
 
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let mut project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
+    let mut project = storage
+        .load_project(project_uuid)
+        .map_err(|e| e.to_string())?;
 
     let staging_branch = format!("staging/{}", branch);
     project.staged_session = Some(StagedSession {
@@ -830,14 +834,13 @@ pub async fn stage_session_inplace(
 }
 
 #[tauri::command]
-pub fn unstage_session_inplace(
-    state: State<AppState>,
-    project_id: String,
-) -> Result<(), String> {
+pub fn unstage_session_inplace(state: State<AppState>, project_id: String) -> Result<(), String> {
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
 
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let mut project = storage.load_project(project_uuid).map_err(|e| e.to_string())?;
+    let mut project = storage
+        .load_project(project_uuid)
+        .map_err(|e| e.to_string())?;
 
     let staged = project
         .staged_session
@@ -856,14 +859,13 @@ pub fn unstage_session_inplace(
 
 #[tauri::command]
 pub fn get_repo_head(repo_path: String) -> Result<(String, String), String> {
-    let repo = git2::Repository::open(&repo_path)
-        .map_err(|e| format!("Failed to open repo: {}", e))?;
+    let repo =
+        git2::Repository::open(&repo_path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-    let head = repo.head().map_err(|e| format!("Failed to get HEAD: {}", e))?;
-    let branch = head
-        .shorthand()
-        .unwrap_or("HEAD")
-        .to_string();
+    let head = repo
+        .head()
+        .map_err(|e| format!("Failed to get HEAD: {}", e))?;
+    let branch = head.shorthand().unwrap_or("HEAD").to_string();
 
     let commit = head
         .peel_to_commit()
@@ -1593,7 +1595,9 @@ pub async fn configure_maintainer(
     validate_maintainer_interval(interval_minutes)?;
     let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let mut project = storage.load_project(project_id).map_err(|e| e.to_string())?;
+    let mut project = storage
+        .load_project(project_id)
+        .map_err(|e| e.to_string())?;
     project.maintainer.enabled = enabled;
     project.maintainer.interval_minutes = interval_minutes;
     project.maintainer.github_repo = github_repo;
@@ -1609,7 +1613,9 @@ pub async fn configure_auto_worker(
 ) -> Result<(), String> {
     let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let mut project = storage.load_project(project_id).map_err(|e| e.to_string())?;
+    let mut project = storage
+        .load_project(project_id)
+        .map_err(|e| e.to_string())?;
     project.auto_worker.enabled = enabled;
     storage.save_project(&project).map_err(|e| e.to_string())?;
     Ok(())
@@ -1654,8 +1660,13 @@ pub async fn trigger_maintainer_check(
 
     let (repo_path, github_repo) = {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let project = storage.load_project(project_id).map_err(|e| e.to_string())?;
-        (project.repo_path.clone(), project.maintainer.github_repo.clone())
+        let project = storage
+            .load_project(project_id)
+            .map_err(|e| e.to_string())?;
+        (
+            project.repo_path.clone(),
+            project.maintainer.github_repo.clone(),
+        )
     };
 
     let _ = app_handle.emit(&format!("maintainer-status:{}", project_id), "running");
@@ -1708,7 +1719,9 @@ pub async fn get_maintainer_issues(
     let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let (repo_path, github_repo) = {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let project = storage.load_project(project_id).map_err(|e| e.to_string())?;
+        let project = storage
+            .load_project(project_id)
+            .map_err(|e| e.to_string())?;
         (
             project.repo_path.clone(),
             project.maintainer.github_repo.clone(),
@@ -1726,7 +1739,9 @@ pub async fn get_maintainer_issue_detail(
     let project_id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let (repo_path, github_repo) = {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let project = storage.load_project(project_id).map_err(|e| e.to_string())?;
+        let project = storage
+            .load_project(project_id)
+            .map_err(|e| e.to_string())?;
         (
             project.repo_path.clone(),
             project.maintainer.github_repo.clone(),
@@ -1874,7 +1889,11 @@ mod tests {
     fn test_next_session_label_empty() {
         let sessions: Vec<SessionConfig> = vec![];
         let label = next_session_label(&sessions);
-        assert!(label.starts_with("session-1-"), "expected session-1-<uuid>, got {}", label);
+        assert!(
+            label.starts_with("session-1-"),
+            "expected session-1-<uuid>, got {}",
+            label
+        );
         assert_eq!(label.len(), "session-1-".len() + 6);
     }
 
@@ -1907,7 +1926,11 @@ mod tests {
             },
         ];
         let label = next_session_label(&sessions);
-        assert!(label.starts_with("session-3-"), "expected session-3-<uuid>, got {}", label);
+        assert!(
+            label.starts_with("session-3-"),
+            "expected session-3-<uuid>, got {}",
+            label
+        );
     }
 
     #[test]
@@ -1953,7 +1976,11 @@ mod tests {
         ];
         // Max is session-3, so next is session-4
         let label = next_session_label(&sessions);
-        assert!(label.starts_with("session-4-"), "expected session-4-<uuid>, got {}", label);
+        assert!(
+            label.starts_with("session-4-"),
+            "expected session-4-<uuid>, got {}",
+            label
+        );
     }
 
     #[test]
@@ -1972,7 +1999,11 @@ mod tests {
             auto_worker_session: false,
         }];
         let label = next_session_label(&sessions);
-        assert!(label.starts_with("session-4-"), "expected session-4-<uuid>, got {}", label);
+        assert!(
+            label.starts_with("session-4-"),
+            "expected session-4-<uuid>, got {}",
+            label
+        );
     }
 
     // --- render_agents_md tests ---
@@ -1988,6 +2019,70 @@ mod tests {
     fn test_render_agents_md_empty_name() {
         let result = render_agents_md("");
         assert!(result.starts_with("# \n"));
+    }
+
+    #[test]
+    fn test_scaffold_project_rolls_back_directory_when_github_creation_fails() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+        let repo_path = projects_root.path().join("gh-create-failure-test");
+        let real_git = real_git_path();
+
+        with_fake_cli_bins(|gh_path, git_path, state_dir| {
+            let state_dir_display = state_dir.display().to_string();
+            write_fake_command(
+                gh_path,
+                &format!(
+                    "if [ -f \"{state_dir_display}/gh-create-fails\" ]; then\n  echo \"gh create failed\" >&2\n  exit 1\nfi\nif [ \"$1\" = \"repo\" ] && [ \"$2\" = \"create\" ]; then\n  \"{real_git}\" -C \"$PWD\" remote add origin git@github.com:test-owner/gh-create-failure-test.git\n  touch \"{state_dir_display}/remote-created\"\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1"
+                ),
+            );
+            write_fake_command(
+                git_path,
+                "if [ \"$1\" = \"push\" ]; then\n  exit 0\nfi\necho \"unexpected git invocation: $*\" >&2\nexit 1",
+            );
+            fs::write(state_dir.join("gh-create-fails"), "").expect("mark first gh create as failed");
+
+            let error = scaffold_project(
+                state_from_ref(&app_state),
+                "gh-create-failure-test".to_string(),
+            )
+            .expect_err("gh create failure should bubble up");
+            assert!(error.contains("Failed to create GitHub repo"));
+            assert!(
+                !repo_path.exists(),
+                "repo directory should be removed after gh repo create failure"
+            );
+            assert!(
+                !state_dir.join("remote-created").exists(),
+                "gh create failure should not leave remote state behind"
+            );
+
+            let stored = app_state
+                .storage
+                .lock()
+                .unwrap()
+                .list_projects()
+                .expect("list projects after failed scaffold");
+            assert!(
+                stored.is_empty(),
+                "failed scaffold should not persist project state"
+            );
+
+            fs::remove_file(state_dir.join("gh-create-fails")).expect("allow gh create retry");
+
+            let project = scaffold_project(
+                state_from_ref(&app_state),
+                "gh-create-failure-test".to_string(),
+            )
+            .expect("retry should succeed after rollback");
+            assert_eq!(project.name, "gh-create-failure-test");
+            assert!(repo_path.exists(), "retry should recreate repo directory");
+            assert!(
+                state_dir.join("remote-created").exists(),
+                "successful retry should create the remote"
+            );
+        });
     }
 
     // --- find_main_branch_oid tests ---


### PR DESCRIPTION
## Summary
- add a regression test for the original gh repo create failure path in scaffold_project
- keep the newer upstream rollback implementation and document the design/implementation in docs/plans
- verify retry succeeds cleanly after the failed scaffold is rolled back

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml

closes #328