### PR TITLE
fix: surface corrupt project metadata

### DIFF
--- a/docs/plans/2026-03-10-project-json-corruption-design.md
+++ b/docs/plans/2026-03-10-project-json-corruption-design.md
@@ -1,0 +1,89 @@
+# Surface Corrupt Project JSON Design
+
+## Summary
+
+`Storage::list_projects` currently reads every `project.json` under `~/.the-controller/projects/`, keeps only entries that deserialize into `Project`, and silently discards malformed files. That makes corrupted metadata look identical to a deleted project. The fix should preserve valid projects while returning explicit corruption diagnostics so callers can surface the problem.
+
+## Goals
+
+- Keep valid projects available even when one `project.json` is corrupt.
+- Return structured corruption details instead of silently skipping malformed files.
+- Surface the warning in the UI path used by project listing.
+- Preserve existing scheduler and restore behavior by letting internal callers continue operating on valid projects.
+
+## Non-Goals
+
+- Building a new diagnostics panel.
+- Attempting automatic repair of corrupt files.
+- Blocking all project operations because one metadata file is malformed.
+
+## Approach Options
+
+### Option 1: Fail `list_projects` on the first corrupt file
+
+Pros:
+
+- Simple backend change.
+- Makes corruption impossible to ignore.
+
+Cons:
+
+- One bad `project.json` would take down the full project list, scheduler startup, duplicate-name checks, and session restore.
+- Worse user experience than the current bug.
+
+### Option 2: Log corruption to stderr and keep returning `Vec<Project>`
+
+Pros:
+
+- Minimal API churn.
+- Preserves all current callers.
+
+Cons:
+
+- Still invisible in the app UI.
+- Callers cannot test or react to corruption details.
+
+### Option 3: Return valid projects plus structured corrupt-entry diagnostics
+
+Pros:
+
+- Keeps working projects available.
+- Gives both backend callers and the UI explicit data about corruption.
+- Supports regression tests at the storage and UI layers.
+
+Cons:
+
+- Requires updating list command/result types and a few consumers.
+
+Recommendation: Option 3.
+
+## Design
+
+Introduce a storage result type:
+
+- `ProjectInventory { projects: Vec<Project>, corrupt_entries: Vec<CorruptProjectEntry> }`
+- `CorruptProjectEntry` includes the project directory path, `project.json` path, and parse error text.
+
+`Storage::list_projects` will:
+
+1. Read every project directory.
+2. Deserialize valid `project.json` files into `Project`.
+3. Record malformed files in `corrupt_entries` instead of dropping them silently.
+4. Still return I/O errors for directory traversal or file reads that genuinely prevent listing.
+
+Tauri commands:
+
+- `list_projects` and `list_archived_projects` will return inventory objects rather than raw arrays.
+- Internal Rust callers that only need valid projects will use the inventory’s `projects` field and emit warnings to stderr when `corrupt_entries` is non-empty.
+
+Frontend:
+
+- `Sidebar.svelte` will accept the richer list command result.
+- Valid projects still populate the store.
+- The UI will show an error toast summarizing new corrupt entries so users can tell why a project disappeared.
+- The toast logic should avoid spamming identical warnings on every refresh by tracking already-surfaced corruption keys in component state.
+
+## Testing
+
+- Rust: add a storage regression test with one valid and one malformed `project.json`, asserting both the retained valid project and the reported corrupt entry.
+- Frontend: add a `Sidebar` test that mocks `list_projects` returning a corrupt entry and asserts `showToast` is called with a corruption warning.

--- a/docs/plans/2026-03-10-project-json-corruption.md
+++ b/docs/plans/2026-03-10-project-json-corruption.md
@@ -1,0 +1,137 @@
+# Surface Corrupt Project JSON Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve valid projects while explicitly surfacing corrupt `project.json` entries in backend results and the UI.
+
+**Architecture:** Replace the raw `Vec<Project>` list result with a structured inventory that carries both valid projects and corruption diagnostics. Update the sidebar list-loading path to consume the richer result and show a warning toast for newly detected corrupt entries.
+
+**Tech Stack:** Rust, Tauri v2 commands, Svelte 5, Vitest
+
+---
+
+### Task 1: Add Storage Regression Coverage
+
+**Files:**
+
+- Modify: `src-tauri/src/storage.rs`
+- Test: `src-tauri/src/storage.rs`
+
+**Step 1: Write the failing test**
+
+Add a storage test that:
+
+- saves one valid project
+- writes an invalid `project.json` in a second project directory
+- calls `storage.list_projects()`
+- asserts the valid project remains in `projects`
+- asserts `corrupt_entries.len() == 1`
+- asserts the corrupt entry includes the bad `project.json` path
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test test_list_projects_reports_corrupt_project_json`
+Expected: FAIL because `list_projects` still returns `Vec<Project>` and cannot report corrupt entries.
+
+**Step 3: Write minimal implementation**
+
+Introduce the inventory/result structs in Rust and update `Storage::list_projects` to collect corrupt entries instead of silently dropping them.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test test_list_projects_reports_corrupt_project_json`
+Expected: PASS
+
+**Step 5: Commit**
+
+Commit after frontend work as part of the full issue fix.
+
+### Task 2: Add Sidebar Warning Coverage
+
+**Files:**
+
+- Modify: `src/lib/Sidebar.test.ts`
+- Modify: `src/lib/stores.ts`
+- Modify: `src/lib/Sidebar.svelte`
+
+**Step 1: Write the failing test**
+
+Add a `Sidebar` test that mocks `invoke("list_projects")` to return:
+
+- one valid project
+- one corrupt entry
+
+Assert:
+
+- the valid projects store is updated
+- `showToast` is called with an error warning mentioning corrupt `project.json`
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/Sidebar.test.ts`
+Expected: FAIL because `Sidebar` currently expects `Project[]` and never surfaces corruption warnings.
+
+**Step 3: Write minimal implementation**
+
+Add frontend list-result types, update `loadProjects`/`loadArchivedProjects`, and warn once per unique corrupt entry.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/Sidebar.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+Commit after backend and frontend changes are verified together.
+
+### Task 3: Update Command Consumers And Verify End-To-End
+
+**Files:**
+
+- Modify: `src-tauri/src/commands.rs`
+- Modify: `src-tauri/src/auto_worker.rs`
+- Modify: `src-tauri/src/maintainer.rs`
+- Modify: `src-tauri/src/status_socket.rs`
+- Modify: any other Rust caller of `storage.list_projects()`
+
+**Step 1: Write the failing test**
+
+Use the earlier storage regression as the invariant-proving test; reverting the storage/command changes should reintroduce the failure.
+
+**Step 2: Run targeted verification**
+
+Run:
+
+- `cd src-tauri && cargo test test_list_projects_reports_corrupt_project_json`
+- `npx vitest run src/lib/Sidebar.test.ts`
+
+Expected: PASS after implementation.
+
+**Step 3: Run broader verification**
+
+Run:
+
+- `cd src-tauri && cargo test`
+- `npx vitest run`
+
+Expected: PASS
+
+**Step 4: Self-review**
+
+Check the diff for:
+
+- unchanged behavior with all-valid projects
+- no repeated toast spam
+- stderr warnings for background callers that cannot show UI
+
+**Step 5: Commit**
+
+Use a commit message that includes `closes #327` and the required trailer:
+
+```text
+fix: surface corrupt project metadata
+
+closes #327
+
+Contributed-by: auto-worker
+```

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -79,7 +79,10 @@ impl AutoWorkerScheduler {
                 Err(_) => return,
             };
             match storage.list_projects() {
-                Ok(p) => p,
+                Ok(inventory) => {
+                    inventory.warn_if_corrupt("auto-worker stale label cleanup");
+                    inventory.projects
+                }
                 Err(_) => return,
             }
         };
@@ -116,7 +119,10 @@ impl AutoWorkerScheduler {
                 Err(_) => return,
             };
             match storage.list_projects() {
-                Ok(p) => p,
+                Ok(inventory) => {
+                    inventory.warn_if_corrupt("auto-worker label migration");
+                    inventory.projects
+                }
                 Err(_) => return,
             }
         };
@@ -247,7 +253,10 @@ impl AutoWorkerScheduler {
                         Err(_) => continue,
                     };
                     match storage.list_projects() {
-                        Ok(p) => p,
+                        Ok(inventory) => {
+                            inventory.warn_if_corrupt("auto-worker scheduler");
+                            inventory.projects
+                        }
                         Err(_) => continue,
                     }
                 };

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use crate::config;
 use crate::models::{CommitInfo, Project, SessionConfig};
 use crate::state::AppState;
+use crate::storage::ProjectInventory;
 use crate::worktree::WorktreeManager;
 
 mod github;
@@ -157,9 +158,10 @@ fn rollback_scaffold_state(repo_path: &Path, error: String) -> String {
 #[tauri::command]
 pub fn restore_sessions(state: State<AppState>) -> Result<(), String> {
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let projects = storage.list_projects().map_err(|e| e.to_string())?;
+    let inventory = storage.list_projects().map_err(|e| e.to_string())?;
+    inventory.warn_if_corrupt("restore_sessions");
     // Migrate worktree paths from UUID-based to name-based directories
-    for project in &projects {
+    for project in &inventory.projects {
         if let Err(e) = storage.migrate_worktree_paths(project) {
             eprintln!(
                 "Failed to migrate worktrees for project '{}': {}",
@@ -198,8 +200,10 @@ pub async fn connect_session(
     // Find session config from storage
     let (session_dir, kind) = {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let projects = storage.list_projects().map_err(|e| e.to_string())?;
-        projects
+        let inventory = storage.list_projects().map_err(|e| e.to_string())?;
+        inventory.warn_if_corrupt("connect_session");
+        inventory
+            .projects
             .iter()
             .flat_map(|p| p.sessions.iter().map(move |s| (p, s)))
             .find(|(_, s)| s.id == id)
@@ -240,7 +244,8 @@ pub fn create_project(
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
 
     // Reject duplicate project names (skip archived projects)
-    if let Ok(existing) = storage.list_projects() {
+    if let Ok(inventory) = storage.list_projects() {
+        let existing = inventory.projects;
         if existing.iter().any(|p| p.name == name && !p.archived) {
             return Err(format!("A project named '{}' already exists", name));
         }
@@ -295,7 +300,8 @@ pub fn load_project(
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
 
     // Return existing project if one with the same repo_path exists
-    if let Ok(existing) = storage.list_projects() {
+    if let Ok(inventory) = storage.list_projects() {
+        let existing = inventory.projects;
         if let Some(project) = existing.iter().find(|p| p.repo_path == repo_path) {
             if project.archived {
                 // Unarchive the project so it becomes active again
@@ -344,10 +350,10 @@ pub fn load_project(
 }
 
 #[tauri::command]
-pub fn list_projects(state: State<AppState>) -> Result<Vec<Project>, String> {
+pub fn list_projects(state: State<AppState>) -> Result<ProjectInventory, String> {
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let projects = storage.list_projects().map_err(|e| e.to_string())?;
-    Ok(projects.into_iter().filter(|p| !p.archived).collect())
+    let inventory = storage.list_projects().map_err(|e| e.to_string())?;
+    Ok(inventory.filter_projects(|project| !project.archived))
 }
 
 #[tauri::command]
@@ -413,13 +419,12 @@ pub fn delete_project(
 }
 
 #[tauri::command]
-pub fn list_archived_projects(state: State<AppState>) -> Result<Vec<Project>, String> {
+pub fn list_archived_projects(state: State<AppState>) -> Result<ProjectInventory, String> {
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let projects = storage.list_projects().map_err(|e| e.to_string())?;
-    Ok(projects
-        .into_iter()
-        .filter(|p| p.archived || p.sessions.iter().any(|s| s.archived))
-        .collect())
+    let inventory = storage.list_projects().map_err(|e| e.to_string())?;
+    Ok(inventory.filter_projects(|project| {
+        project.archived || project.sessions.iter().any(|session| session.archived)
+    }))
 }
 
 #[tauri::command]
@@ -1153,7 +1158,8 @@ pub fn scaffold_project(state: State<AppState>, name: String) -> Result<Project,
     let storage = state.storage.lock().map_err(|e| e.to_string())?;
 
     // Reject duplicate project names (skip archived projects)
-    if let Ok(existing) = storage.list_projects() {
+    if let Ok(inventory) = storage.list_projects() {
+        let existing = inventory.projects;
         if existing.iter().any(|p| p.name == name && !p.archived) {
             return Err(format!("A project named '{}' already exists", name));
         }
@@ -2109,7 +2115,7 @@ mod tests {
                 .list_projects()
                 .expect("list projects after failed scaffold");
             assert!(
-                stored.is_empty(),
+                stored.projects.is_empty(),
                 "failed scaffold should not persist project state"
             );
 
@@ -2132,11 +2138,86 @@ mod tests {
                 .list_projects()
                 .expect("list projects after successful retry");
             assert_eq!(
-                stored.len(),
+                stored.projects.len(),
                 1,
                 "successful retry should persist exactly one project"
             );
-            assert_eq!(stored[0].repo_path, repo_path.to_string_lossy());
+            assert_eq!(stored.projects[0].repo_path, repo_path.to_string_lossy());
+        });
+    }
+
+    #[test]
+    fn test_create_project_succeeds_with_corrupt_sibling_metadata() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+        let repo_dir = TempDir::new().unwrap();
+
+        let corrupt_dir = base_dir.path().join("projects").join(Uuid::new_v4().to_string());
+        fs::create_dir_all(&corrupt_dir).expect("create corrupt dir");
+        fs::write(corrupt_dir.join("project.json"), "{ invalid json").expect("write corrupt json");
+
+        let project = create_project(
+            state_from_ref(&app_state),
+            "fresh-project".to_string(),
+            repo_dir.path().to_string_lossy().to_string(),
+        )
+        .expect("create project should ignore corrupt sibling metadata");
+
+        assert_eq!(project.name, "fresh-project");
+    }
+
+    #[test]
+    fn test_load_project_succeeds_with_corrupt_sibling_metadata() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+        let repo_dir = TempDir::new().unwrap();
+        git2::Repository::init(repo_dir.path()).expect("init git repo");
+
+        let corrupt_dir = base_dir.path().join("projects").join(Uuid::new_v4().to_string());
+        fs::create_dir_all(&corrupt_dir).expect("create corrupt dir");
+        fs::write(corrupt_dir.join("project.json"), "{ invalid json").expect("write corrupt json");
+
+        let project = load_project(
+            state_from_ref(&app_state),
+            "imported-project".to_string(),
+            repo_dir.path().to_string_lossy().to_string(),
+        )
+        .expect("load project should ignore corrupt sibling metadata");
+
+        assert_eq!(project.name, "imported-project");
+    }
+
+    #[test]
+    fn test_scaffold_project_succeeds_with_corrupt_sibling_metadata() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+        let repo_path = projects_root.path().join("scaffold-with-corrupt-sibling");
+        let real_git = real_git_path();
+
+        let corrupt_dir = base_dir.path().join("projects").join(Uuid::new_v4().to_string());
+        fs::create_dir_all(&corrupt_dir).expect("create corrupt dir");
+        fs::write(corrupt_dir.join("project.json"), "{ invalid json").expect("write corrupt json");
+
+        with_fake_cli_bins(|gh_path, git_path, _state_dir| {
+            write_fake_command(
+                gh_path,
+                &format!(
+                    "if [ \"$1\" = \"repo\" ] && [ \"$2\" = \"create\" ]; then\n  \"{real_git}\" -C \"$PWD\" remote add origin git@github.com:test-owner/scaffold-with-corrupt-sibling.git\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1"
+                ),
+            );
+            write_fake_command(git_path, "exit 0");
+
+            let project = scaffold_project(
+                state_from_ref(&app_state),
+                "scaffold-with-corrupt-sibling".to_string(),
+            )
+            .expect("scaffold should ignore corrupt sibling metadata");
+
+            assert_eq!(project.name, "scaffold-with-corrupt-sibling");
+            assert!(repo_path.exists(), "repo should be created");
         });
     }
 

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -146,7 +146,10 @@ impl MaintainerScheduler {
                         Err(_) => continue,
                     };
                     match storage.list_projects() {
-                        Ok(p) => p,
+                        Ok(inventory) => {
+                            inventory.warn_if_corrupt("maintainer scheduler");
+                            inventory.projects
+                        }
                         Err(_) => continue,
                     }
                 };

--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -116,7 +116,9 @@ fn handle_cleanup(app_handle: &AppHandle, session_id: Uuid) {
     // the lock ordering used by Tauri commands (storage → pty_manager).
     // Reversed order causes deadlock.
     if let Ok(storage) = state.storage.lock() {
-        if let Ok(mut projects) = storage.list_projects() {
+        if let Ok(inventory) = storage.list_projects() {
+            inventory.warn_if_corrupt("status socket cleanup");
+            let mut projects = inventory.projects;
             for project in &mut projects {
                 if let Some(pos) = project.sessions.iter().position(|s| s.id == session_id) {
                     let session = project.sessions.remove(pos);

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,8 +1,88 @@
+use serde::{Deserialize, Serialize};
 use std::fs;
+use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use uuid::Uuid;
 
 use crate::models::{MaintainerRunLog, Project};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CorruptProjectEntry {
+    pub project_dir: PathBuf,
+    pub project_file: PathBuf,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ProjectInventory {
+    pub projects: Vec<Project>,
+    pub corrupt_entries: Vec<CorruptProjectEntry>,
+}
+
+impl ProjectInventory {
+    pub fn filter_projects<F>(self, mut predicate: F) -> Self
+    where
+        F: FnMut(&Project) -> bool,
+    {
+        Self {
+            projects: self.projects.into_iter().filter(|project| predicate(project)).collect(),
+            corrupt_entries: self.corrupt_entries,
+        }
+    }
+
+    pub fn warn_if_corrupt(&self, context: &str) {
+        for entry in &self.corrupt_entries {
+            eprintln!(
+                "Warning: {}: failed to parse {}: {}",
+                context,
+                entry.project_file.display(),
+                entry.error
+            );
+        }
+    }
+
+}
+
+impl Deref for ProjectInventory {
+    type Target = Vec<Project>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.projects
+    }
+}
+
+impl DerefMut for ProjectInventory {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.projects
+    }
+}
+
+impl IntoIterator for ProjectInventory {
+    type Item = Project;
+    type IntoIter = std::vec::IntoIter<Project>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.projects.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ProjectInventory {
+    type Item = &'a Project;
+    type IntoIter = std::slice::Iter<'a, Project>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.projects.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut ProjectInventory {
+    type Item = &'a mut Project;
+    type IntoIter = std::slice::IterMut<'a, Project>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.projects.iter_mut()
+    }
+}
 
 pub struct Storage {
     base_dir: PathBuf,
@@ -55,24 +135,30 @@ impl Storage {
     }
 
     /// List all projects by reading every `project.json` in the projects directory.
-    pub fn list_projects(&self) -> std::io::Result<Vec<Project>> {
+    pub fn list_projects(&self) -> std::io::Result<ProjectInventory> {
         let projects_dir = self.base_dir.join("projects");
         if !projects_dir.exists() {
-            return Ok(Vec::new());
+            return Ok(ProjectInventory::default());
         }
 
-        let mut projects = Vec::new();
+        let mut inventory = ProjectInventory::default();
         for entry in fs::read_dir(&projects_dir)? {
             let entry = entry?;
-            let project_file = entry.path().join("project.json");
+            let project_dir = entry.path();
+            let project_file = project_dir.join("project.json");
             if project_file.exists() {
                 let json = fs::read_to_string(&project_file)?;
-                if let Ok(project) = serde_json::from_str::<Project>(&json) {
-                    projects.push(project);
+                match serde_json::from_str::<Project>(&json) {
+                    Ok(project) => inventory.projects.push(project),
+                    Err(error) => inventory.corrupt_entries.push(CorruptProjectEntry {
+                        project_dir,
+                        project_file,
+                        error: error.to_string(),
+                    }),
                 }
             }
         }
-        Ok(projects)
+        Ok(inventory)
     }
 
     /// Migrate worktree directories from UUID-based to name-based paths.
@@ -285,8 +371,29 @@ mod tests {
         storage.save_project(&p1).expect("save p1");
         storage.save_project(&p2).expect("save p2");
 
-        let projects = storage.list_projects().expect("list");
-        assert_eq!(projects.len(), 2);
+        let inventory = storage.list_projects().expect("list");
+        assert_eq!(inventory.projects.len(), 2);
+        assert!(inventory.corrupt_entries.is_empty());
+    }
+
+    #[test]
+    fn test_list_projects_reports_corrupt_project_json() {
+        let tmp = TempDir::new().unwrap();
+        let storage = make_storage(&tmp);
+
+        let valid = make_project("valid-project", "/tmp/repo-valid");
+        storage.save_project(&valid).expect("save valid");
+
+        let corrupt_dir = storage.project_dir(Uuid::new_v4());
+        fs::create_dir_all(&corrupt_dir).expect("create corrupt dir");
+        let corrupt_file = corrupt_dir.join("project.json");
+        fs::write(&corrupt_file, "{ invalid json").expect("write corrupt project.json");
+
+        let inventory = storage.list_projects().expect("list");
+        assert_eq!(inventory.projects.len(), 1);
+        assert_eq!(inventory.projects[0].name, "valid-project");
+        assert_eq!(inventory.corrupt_entries.len(), 1);
+        assert_eq!(inventory.corrupt_entries[0].project_file, corrupt_file);
     }
 
     #[test]
@@ -294,8 +401,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let storage = make_storage(&tmp);
 
-        let projects = storage.list_projects().expect("list");
-        assert!(projects.is_empty());
+        let inventory = storage.list_projects().expect("list");
+        assert!(inventory.projects.is_empty());
+        assert!(inventory.corrupt_entries.is_empty());
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,7 +20,7 @@
   import AgentDashboard from "./lib/AgentDashboard.svelte";
   import NotesEditor from "./lib/NotesEditor.svelte";
   import { showToast } from "./lib/toast";
-  import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, workspaceModePickerVisible, workspaceMode, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, dispatchHotkeyAction, focusTerminalSoon, selectedSessionProvider, type Config, type GithubIssue, type Project, type SavedPrompt, type SessionStatus, type TriageCategory } from "./lib/stores";
+  import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, workspaceModePickerVisible, workspaceMode, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, dispatchHotkeyAction, focusTerminalSoon, selectedSessionProvider, type Config, type GithubIssue, type Project, type ProjectInventory, type SavedPrompt, type SessionStatus, type TriageCategory } from "./lib/stores";
   let ready = $state(false);
   let createIssueTarget: { projectId: string; repoPath: string } | null = $state(null);
   let issuePickerTarget: { projectId: string; repoPath: string; kind?: string; background?: boolean } | null = $state(null);
@@ -85,8 +85,8 @@
         enabled: newEnabled,
         intervalMinutes: project.maintainer.interval_minutes,
       });
-      const result: Project[] = await invoke("list_projects");
-      projects.set(result);
+      const result = await invoke<ProjectInventory>("list_projects");
+      projects.set(result.projects);
       showToast(`Maintainer ${newEnabled ? "enabled" : "disabled"}`, "info");
     } catch (e) {
       showToast(String(e), "error");
@@ -104,8 +104,8 @@
         projectId: project.id,
         enabled: newEnabled,
       });
-      const result: Project[] = await invoke("list_projects");
-      projects.set(result);
+      const result = await invoke<ProjectInventory>("list_projects");
+      projects.set(result.projects);
       showToast(`Auto-worker ${newEnabled ? "enabled" : "disabled"}`, "info");
     } catch (e) {
       showToast(String(e), "error");
@@ -200,7 +200,8 @@
       return next;
     });
     activeSessionId.set(sessionId);
-    projects.set(await invoke<Project[]>("list_projects"));
+    const result = await invoke<ProjectInventory>("list_projects");
+    projects.set(result.projects);
     expandedProjects.update((s: Set<string>) => {
       const next = new Set(s);
       next.add(projectId);

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -91,24 +91,27 @@ describe("App screenshot flow", () => {
       if (cmd === "capture_app_screenshot") return "/tmp/the-controller-screenshot.png";
       if (cmd === "create_session") return "sess-new";
       if (cmd === "list_projects") {
-        return [
-          {
-            ...baseProject,
-            sessions: [
-              {
-                id: "sess-new",
-                label: "session-1",
-                worktree_path: null,
-                worktree_branch: null,
-                archived: false,
-                kind: "claude",
-                github_issue: null,
-                initial_prompt: null,
-                auto_worker_session: false,
-              },
-            ],
-          },
-        ];
+        return {
+          projects: [
+            {
+              ...baseProject,
+              sessions: [
+                {
+                  id: "sess-new",
+                  label: "session-1",
+                  worktree_path: null,
+                  worktree_branch: null,
+                  archived: false,
+                  kind: "claude",
+                  github_issue: null,
+                  initial_prompt: null,
+                  auto_worker_session: false,
+                },
+              ],
+            },
+          ],
+          corrupt_entries: [],
+        };
       }
       return;
     });
@@ -311,7 +314,12 @@ describe("App issue picker flow", () => {
       if (cmd === "restore_sessions") return;
       if (cmd === "check_onboarding") return { projects_root: "/tmp/projects" };
       if (cmd === "create_session") return "sess-new";
-      if (cmd === "list_projects") return [{ ...baseProject, maintainer: { enabled: false, interval_minutes: 60 }, auto_worker: { enabled: false }, prompts: [], staged_session: null, sessions: [] }];
+      if (cmd === "list_projects") {
+        return {
+          projects: [{ ...baseProject, maintainer: { enabled: false, interval_minutes: 60 }, auto_worker: { enabled: false }, prompts: [], staged_session: null, sessions: [] }],
+          corrupt_entries: [],
+        };
+      }
       return;
     });
   });

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { fromStore } from "svelte/store";
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-  import { projects, activeSessionId, sessionStatuses, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, workspaceMode, activeNote, noteEntries, selectedSessionProvider, type Project, type JumpPhase, type FocusTarget, type SessionStatus, type MaintainerStatus, type AutoWorkerStatus, type NoteEntry } from "./stores";
+  import { projects, activeSessionId, sessionStatuses, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, showKeyHints, jumpMode, generateJumpLabels, archiveView, archivedProjects, focusTarget, expandedProjects, focusTerminalSoon, workspaceMode, activeNote, noteEntries, selectedSessionProvider, type CorruptProjectEntry, type Project, type ProjectInventory, type JumpPhase, type FocusTarget, type SessionStatus, type MaintainerStatus, type AutoWorkerStatus, type NoteEntry } from "./stores";
   import { showToast } from "./toast";
   import { focusAfterSessionDelete, focusAfterProjectDelete } from "./focus-helpers";
   import FuzzyFinder from "./FuzzyFinder.svelte";
@@ -58,6 +58,7 @@
   let statuses: Map<string, SessionStatus> = $derived(sessionStatusesState.current);
   const idleTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const IDLE_DEBOUNCE_MS = 1500;
+  let surfacedCorruptProjectWarnings = $state(new Set<string>());
 
   const jumpModeState = fromStore(jumpMode);
   let jumpState: JumpPhase = $derived(jumpModeState.current);
@@ -356,8 +357,9 @@
 
   async function loadProjects() {
     try {
-      const result: Project[] = await invoke("list_projects");
-      projects.set(result);
+      const result = await invoke<ProjectInventory>("list_projects");
+      projects.set(result.projects);
+      surfaceCorruptProjectWarnings(result.corrupt_entries);
     } catch (err) {
       showToast(String(err), "error");
     }
@@ -365,11 +367,38 @@
 
   async function loadArchivedProjects() {
     try {
-      const result = await invoke<Project[]>("list_archived_projects");
-      archivedProjects.set(result);
+      const result = await invoke<ProjectInventory>("list_archived_projects");
+      archivedProjects.set(result.projects);
+      surfaceCorruptProjectWarnings(result.corrupt_entries);
     } catch (err) {
       showToast(String(err), "error");
     }
+  }
+
+  function surfaceCorruptProjectWarnings(entries: CorruptProjectEntry[]) {
+    const unseen = entries.filter((entry) => !surfacedCorruptProjectWarnings.has(corruptProjectWarningKey(entry)));
+    if (unseen.length === 0) return;
+
+    const next = new Set(surfacedCorruptProjectWarnings);
+    for (const entry of unseen) {
+      next.add(corruptProjectWarningKey(entry));
+    }
+    surfacedCorruptProjectWarnings = next;
+
+    if (unseen.length === 1) {
+      const entry = unseen[0];
+      showToast(`Detected corrupt project.json: ${entry.project_file} (${entry.error})`, "error");
+      return;
+    }
+
+    showToast(
+      `Detected ${unseen.length} corrupt project.json entries. Example: ${unseen[0].project_file}`,
+      "error",
+    );
+  }
+
+  function corruptProjectWarningKey(entry: CorruptProjectEntry) {
+    return `${entry.project_file}:${entry.error}`;
   }
 
   async function unarchiveProject(projectId: string) {

--- a/src/lib/Sidebar.test.ts
+++ b/src/lib/Sidebar.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/svelte";
 import { invoke } from "@tauri-apps/api/core";
+import { showToast } from "./toast";
 import {
   activeSessionId,
   activeNote,
@@ -22,16 +23,36 @@ vi.mock("./toast", () => ({
   showToast: vi.fn(),
 }));
 
-vi.mock("./FuzzyFinder.svelte", () => ({ default: function MockFuzzyFinder() {} }));
-vi.mock("./NewProjectModal.svelte", () => ({ default: function MockNewProjectModal() {} }));
-vi.mock("./DeleteProjectModal.svelte", () => ({ default: function MockDeleteProjectModal() {} }));
-vi.mock("./ConfirmModal.svelte", () => ({ default: function MockConfirmModal() {} }));
-vi.mock("./DeleteSessionModal.svelte", () => ({ default: function MockDeleteSessionModal() {} }));
-vi.mock("./NewNoteModal.svelte", () => ({ default: function MockNewNoteModal() {} }));
-vi.mock("./RenameNoteModal.svelte", () => ({ default: function MockRenameNoteModal() {} }));
-vi.mock("./sidebar/ProjectTree.svelte", () => ({ default: function MockProjectTree() {} }));
-vi.mock("./sidebar/AgentTree.svelte", () => ({ default: function MockAgentTree() {} }));
-vi.mock("./sidebar/NotesTree.svelte", () => ({ default: function MockNotesTree() {} }));
+vi.mock("./FuzzyFinder.svelte", () => ({
+  default: function MockFuzzyFinder() {},
+}));
+vi.mock("./NewProjectModal.svelte", () => ({
+  default: function MockNewProjectModal() {},
+}));
+vi.mock("./DeleteProjectModal.svelte", () => ({
+  default: function MockDeleteProjectModal() {},
+}));
+vi.mock("./ConfirmModal.svelte", () => ({
+  default: function MockConfirmModal() {},
+}));
+vi.mock("./DeleteSessionModal.svelte", () => ({
+  default: function MockDeleteSessionModal() {},
+}));
+vi.mock("./NewNoteModal.svelte", () => ({
+  default: function MockNewNoteModal() {},
+}));
+vi.mock("./RenameNoteModal.svelte", () => ({
+  default: function MockRenameNoteModal() {},
+}));
+vi.mock("./sidebar/ProjectTree.svelte", () => ({
+  default: function MockProjectTree() {},
+}));
+vi.mock("./sidebar/AgentTree.svelte", () => ({
+  default: function MockAgentTree() {},
+}));
+vi.mock("./sidebar/NotesTree.svelte", () => ({
+  default: function MockNotesTree() {},
+}));
 
 import Sidebar from "./Sidebar.svelte";
 
@@ -54,8 +75,9 @@ describe("Sidebar provider indicator", () => {
     selectedSessionProvider.set("claude");
 
     vi.mocked(invoke).mockImplementation(async (cmd: string) => {
-      if (cmd === "list_projects") return [];
-      if (cmd === "list_archived_projects") return [];
+      if (cmd === "list_projects") return { projects: [], corrupt_entries: [] };
+      if (cmd === "list_archived_projects")
+        return { projects: [], corrupt_entries: [] };
       return;
     });
   });
@@ -75,6 +97,52 @@ describe("Sidebar provider indicator", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Provider: Codex/i)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces corrupt project metadata returned by list_projects", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "list_projects") {
+        return {
+          projects: [
+            {
+              id: "project-1",
+              name: "Alpha",
+              repo_path: "/tmp/alpha",
+              created_at: "2026-03-10T00:00:00Z",
+              archived: false,
+              sessions: [],
+              maintainer: {
+                enabled: false,
+                interval_minutes: 60,
+                github_repo: null,
+              },
+              auto_worker: { enabled: false },
+              prompts: [],
+              staged_session: null,
+            },
+          ],
+          corrupt_entries: [
+            {
+              project_dir: "/tmp/.the-controller/projects/bad",
+              project_file: "/tmp/.the-controller/projects/bad/project.json",
+              error: "expected value at line 1 column 1",
+            },
+          ],
+        };
+      }
+      if (cmd === "list_archived_projects")
+        return { projects: [], corrupt_entries: [] };
+      return;
+    });
+
+    render(Sidebar);
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining("corrupt project.json"),
+        "error",
+      );
     });
   });
 });

--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -9,7 +9,7 @@
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { makeCustomKeyHandler } from "./terminal-keys";
   import { clipboardHasImage } from "./clipboard";
-  import { activeSessionId, projects, type Project } from "./stores";
+  import { activeSessionId, projects, type Project, type ProjectInventory } from "./stores";
   import "@xterm/xterm/css/xterm.css";
 
   interface Props {
@@ -82,8 +82,8 @@
       prompt,
     }).then(() => {
       // Refresh the store so SummaryPane picks up the change
-      invoke<Project[]>("list_projects").then((result) => {
-        projects.set(result);
+      invoke<ProjectInventory>("list_projects").then((result) => {
+        projects.set(result.projects);
       });
     }).catch((err) => {
       console.error("Failed to save initial prompt:", err);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -113,6 +113,17 @@ export interface Project {
   staged_session: StagedSession | null;
 }
 
+export interface CorruptProjectEntry {
+  project_dir: string;
+  project_file: string;
+  error: string;
+}
+
+export interface ProjectInventory {
+  projects: Project[];
+  corrupt_entries: CorruptProjectEntry[];
+}
+
 export interface Config {
   projects_root: string;
 }
@@ -128,7 +139,10 @@ export const workspaceModePickerVisible = writable<boolean>(false);
 export type SessionProvider = "claude" | "codex";
 export const selectedSessionProvider = writable<SessionProvider>("claude");
 
-export const activeNote = writable<{ projectId: string; filename: string } | null>(null);
+export const activeNote = writable<{
+  projectId: string;
+  filename: string;
+} | null>(null);
 export const noteEntries = writable<Map<string, NoteEntry[]>>(new Map());
 export const notePreviewMode = writable<boolean>(false);
 
@@ -138,7 +152,9 @@ export type SessionStatus = "working" | "idle" | "exited";
 export const sessionStatuses = writable<Map<string, SessionStatus>>(new Map());
 export const appConfig = writable<Config | null>(null);
 export const onboardingComplete = writable<boolean>(false);
-export const maintainerStatuses = writable<Map<string, MaintainerStatus>>(new Map());
+export const maintainerStatuses = writable<Map<string, MaintainerStatus>>(
+  new Map(),
+);
 export const maintainerErrors = writable<Map<string, string>>(new Map());
 export type AutoWorkerStatus = {
   status: "idle" | "working";
@@ -146,7 +162,9 @@ export type AutoWorkerStatus = {
   issue_number?: number;
   issue_title?: string;
 };
-export const autoWorkerStatuses = writable<Map<string, AutoWorkerStatus>>(new Map());
+export const autoWorkerStatuses = writable<Map<string, AutoWorkerStatus>>(
+  new Map(),
+);
 
 export interface WorkerReport {
   issue_number: number;
@@ -172,7 +190,13 @@ export type HotkeyAction =
   | { type: "unarchive-project"; projectId: string }
   | { type: "toggle-archive-view" }
   | { type: "create-issue"; projectId: string; repoPath: string }
-  | { type: "pick-issue-for-session"; projectId: string; repoPath: string; kind?: string; background?: boolean }
+  | {
+      type: "pick-issue-for-session";
+      projectId: string;
+      repoPath: string;
+      kind?: string;
+      background?: boolean;
+    }
   | { type: "merge-session"; sessionId: string; projectId: string }
   | { type: "finish-branch"; sessionId: string; kind?: string }
   | { type: "screenshot-to-session"; preview?: boolean; cropped?: boolean }
@@ -229,9 +253,7 @@ export type FocusTarget =
 export const focusTarget = writable<FocusTarget>(null);
 
 // Jump navigation
-export type JumpPhase =
-  | { phase: "project" }
-  | null;
+export type JumpPhase = { phase: "project" } | null;
 
 export const jumpMode = writable<JumpPhase>(null);
 


### PR DESCRIPTION
## Summary
- return corrupt project.json entries alongside valid projects instead of silently dropping them
- surface corruption warnings in the UI while keeping valid projects usable
- add backend and frontend regression coverage for corrupt sibling metadata

closes #327