### PR TITLE
fix: narrow scaffold_project storage lock scope

### DIFF
--- a/docs/plans/2026-03-10-scaffold-lock-scope-design.md
+++ b/docs/plans/2026-03-10-scaffold-lock-scope-design.md
@@ -52,7 +52,7 @@ Split `scaffold_project` into three phases:
 
 1. Acquire `state.storage` briefly to load the config, list projects, and reject duplicates or pre-existing directories.
 2. Run the scaffold side effects in `tokio::task::spawn_blocking`, including repo creation, template writes, git commit, GitHub publish, and rollback on failure. This phase returns the constructed `Project` without touching storage.
-3. Reacquire `state.storage` after the blocking task completes and persist the finished `Project`.
+3. Reacquire `state.storage` after the blocking task completes, re-check duplicate-name uniqueness while holding the mutex, and persist the finished `Project` only if the name is still available. If another command claimed the name while scaffolding was in flight, roll back the scaffolded local and remote repo instead of saving duplicate metadata.
 
 This keeps the global storage mutex unavailable only for short metadata reads and the final save, while all filesystem and external process work happens without the lock and off the UI thread.
 
@@ -67,4 +67,5 @@ This keeps the global storage mutex unavailable only for short metadata reads an
 - Add a command-level regression test that starts `scaffold_project` on a separate thread with a fake `gh repo create` script that blocks on a sentinel file.
 - While that fake `gh` command is sleeping, attempt to acquire `app_state.storage.lock()` from the test thread and assert it succeeds immediately.
 - Release the sentinel so scaffolding completes, then assert the project is saved successfully.
+- Add a concurrency regression test that blocks `scaffold_project`, claims the same name through `create_project`, then verifies `scaffold_project` rolls its local and remote state back instead of saving a duplicate project name.
 - Run the existing scaffold rollback tests to ensure the refactor did not change failure cleanup behavior.

--- a/docs/plans/2026-03-10-scaffold-lock-scope-implementation.md
+++ b/docs/plans/2026-03-10-scaffold-lock-scope-implementation.md
@@ -28,7 +28,7 @@ Add a command test that:
 
 **Step 2: Run test to verify it fails**
 
-Run: `cargo test test_scaffold_project_does_not_hold_storage_lock_during_external_publish --manifest-path src-tauri/Cargo.toml -- --exact`
+Run: `cargo test 'commands::tests::test_scaffold_project_does_not_hold_storage_lock_during_external_publish' --manifest-path src-tauri/Cargo.toml -- --exact`
 
 Expected: FAIL because the current implementation still holds the storage mutex for the full scaffold.
 
@@ -42,11 +42,12 @@ Expected: FAIL because the current implementation still holds the storage mutex 
 - Change `scaffold_project` to `pub async fn`.
 - Under an initial short-lived storage lock, load config and reject duplicates.
 - Move the existing scaffold body into `spawn_blocking`.
-- Reacquire storage only for `save_project`.
+- Reacquire storage only for the final duplicate-name recheck and `save_project`.
+- If the name was claimed while scaffolding was in flight, roll back the scaffolded repo/remote before returning the duplicate-name error.
 
 **Step 2: Run the new regression to verify it passes**
 
-Run: `cargo test test_scaffold_project_does_not_hold_storage_lock_during_external_publish --manifest-path src-tauri/Cargo.toml -- --exact`
+Run: `cargo test 'commands::tests::test_scaffold_project_does_not_hold_storage_lock_during_external_publish' --manifest-path src-tauri/Cargo.toml -- --exact`
 
 Expected: PASS.
 
@@ -60,6 +61,8 @@ Expected: PASS.
 Run: `cargo test test_scaffold_project_rolls_back_directory_when_github_creation_fails --manifest-path src-tauri/Cargo.toml -- --exact`
 
 Run: `cargo test test_scaffold_project_rolls_back_remote_and_local_state_when_initial_push_fails --manifest-path src-tauri/Cargo.toml -- --exact`
+
+Run: `cargo test 'commands::tests::test_scaffold_project_rolls_back_if_name_is_claimed_before_final_save' --manifest-path src-tauri/Cargo.toml -- --exact`
 
 Expected: PASS.
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1283,12 +1283,21 @@ pub async fn scaffold_project(state: State<'_, AppState>, name: String) -> Resul
         .await
         .map_err(|e| format!("Task failed: {}", e))??;
 
-    state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .save_project(&project)
-        .map_err(|e| e.to_string())?;
+    let storage = state.storage.lock().map_err(|e| e.to_string())?;
+    if let Ok(inventory) = storage.list_projects() {
+        let existing = inventory.projects;
+        if existing
+            .iter()
+            .any(|p| p.name == project.name && !p.archived)
+        {
+            drop(storage);
+            return Err(rollback_scaffold_state(
+                Path::new(&project.repo_path),
+                format!("A project named '{}' already exists", project.name),
+            ));
+        }
+    }
+    storage.save_project(&project).map_err(|e| e.to_string())?;
 
     Ok(project)
 }
@@ -2186,6 +2195,88 @@ mod tests {
                 storage_lock_available,
                 "storage lock should stay available while external publish is blocked"
             );
+        });
+    }
+
+    #[test]
+    fn test_scaffold_project_rolls_back_if_name_is_claimed_before_final_save() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let app_state = Arc::new(make_test_state(base_dir.path(), projects_root.path()));
+        let repo_path = projects_root.path().join("lock-race-test");
+        let imported_repo = TempDir::new().unwrap();
+        let real_git = real_git_path();
+
+        with_fake_cli_bins(|gh_path, git_path, state_dir| {
+            let state_dir_display = state_dir.display().to_string();
+            write_fake_command(
+                gh_path,
+                &format!(
+                    "if [ \"$1\" = \"repo\" ] && [ \"$2\" = \"create\" ]; then\n  touch \"{state_dir_display}/gh-create-started\"\n  while [ -f \"{state_dir_display}/gh-create-block\" ]; do\n    sleep 0.05\n  done\n  \"{real_git}\" -C \"$PWD\" remote add origin git@github.com:test-owner/lock-race-test.git\n  touch \"{state_dir_display}/remote-created\"\n  exit 0\nfi\nif [ \"$1\" = \"repo\" ] && [ \"$2\" = \"delete\" ]; then\n  rm -f \"{state_dir_display}/remote-created\"\n  touch \"{state_dir_display}/remote-deleted\"\n  exit 0\nfi\necho \"unexpected gh invocation: $*\" >&2\nexit 1"
+                ),
+            );
+            write_fake_command(git_path, "if [ \"$1\" = \"push\" ]; then\n  exit 0\nfi\necho \"unexpected git invocation: $*\" >&2\nexit 1");
+            fs::write(state_dir.join("gh-create-block"), "").expect("block gh create");
+
+            let app_state_for_thread = Arc::clone(&app_state);
+            let handle = thread::spawn(move || {
+                run_async_test(scaffold_project(
+                    state_from_ref(app_state_for_thread.as_ref()),
+                    "lock-race-test".to_string(),
+                ))
+            });
+
+            for _ in 0..100 {
+                if state_dir.join("gh-create-started").exists() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                state_dir.join("gh-create-started").exists(),
+                "scaffold should reach gh repo create"
+            );
+
+            let imported = create_project(
+                state_from_ref(app_state.as_ref()),
+                "lock-race-test".to_string(),
+                imported_repo.path().to_string_lossy().to_string(),
+            )
+            .expect("concurrent create_project should claim the name");
+            assert_eq!(imported.name, "lock-race-test");
+
+            fs::remove_file(state_dir.join("gh-create-block")).expect("unblock gh create");
+
+            let error = handle
+                .join()
+                .expect("scaffold thread should not panic")
+                .expect_err("scaffold should fail once the name is claimed");
+
+            assert!(
+                error.contains("A project named 'lock-race-test' already exists"),
+                "expected duplicate-name failure, got: {error}"
+            );
+            assert!(
+                !repo_path.exists(),
+                "scaffold repo should be rolled back if final save loses the name race"
+            );
+            assert!(
+                state_dir.join("remote-deleted").exists(),
+                "remote repo should be deleted when the final save loses the name race"
+            );
+
+            let stored = app_state
+                .storage
+                .lock()
+                .unwrap()
+                .list_projects()
+                .expect("list projects after duplicate-name race");
+            assert_eq!(
+                stored.projects.len(),
+                1,
+                "only the competing project should remain after rollback"
+            );
+            assert_eq!(stored.projects[0].repo_path, imported_repo.path().to_string_lossy());
         });
     }
 


### PR DESCRIPTION
## Summary
- move scaffold_project's slow filesystem and GitHub publish flow off the main thread and out from under the global storage mutex
- keep duplicate-name enforcement atomic by re-checking under the final storage lock and rolling scaffolded state back if another command claims the name
- add regressions for stalled external publish lock availability and the duplicate-name race before final save

## Testing
- cargo test commands::tests:: --manifest-path src-tauri/Cargo.toml
- cargo test test_scaffold --manifest-path src-tauri/Cargo.toml

closes #307