### PR TITLE
fix: sanitize markdown note preview links

### DIFF
--- a/docs/plans/2026-03-10-markdown-link-sanitization-design.md
+++ b/docs/plans/2026-03-10-markdown-link-sanitization-design.md
@@ -1,0 +1,46 @@
+# Markdown Link Sanitization Design
+
+## Definition
+
+Sanitize markdown link URLs before notes preview HTML is rendered so unsafe schemes such as `javascript:` and `data:` are never emitted into anchor `href` attributes.
+
+## Constraints
+
+- Keep the change scoped to note-preview markdown rendering.
+- Preserve existing markdown behavior for allowed links and inline formatting.
+- Treat this as a behavior change and implement it with TDD.
+- Avoid introducing a broader markdown library or unrelated renderer refactors.
+
+## Approaches
+
+### 1. Allowlist schemes in the existing link replacement
+
+Parse link destinations during inline formatting, allow only `http:`, `https:`, and `mailto:`, and render disallowed destinations as plain escaped text.
+
+Pros: Minimal surface area, direct fix, easy to test.
+Cons: Requires slightly more careful string handling than the current regex replacement.
+
+### 2. Post-process rendered HTML anchors
+
+Render markdown as today, then scan the HTML for anchor tags and rewrite or remove unsafe `href` values.
+
+Pros: Leaves inline parsing untouched.
+Cons: More brittle, mixes HTML sanitization into renderer output, still requires safe attribute handling.
+
+### 3. Replace the handwritten renderer
+
+Adopt a markdown library with sanitization support.
+
+Pros: Stronger long-term markdown support.
+Cons: Too large for this issue and unnecessary for the current bug.
+
+## Chosen Design
+
+Use approach 1. Add a small URL sanitization helper in `src/lib/markdown.ts` that accepts only `http:`, `https:`, and `mailto:` absolute URLs. When a markdown link uses any other scheme or an invalid destination, render just the escaped link text instead of an anchor. Escape the `href` attribute separately so allowed URLs cannot inject attribute-breaking characters.
+
+## Validation
+
+- Add tests proving allowed `https:` and `mailto:` links still render.
+- Add tests proving `javascript:` and `data:` destinations do not produce anchors or unsafe `href` output.
+- Run the focused markdown test in a failing state first, then rerun after implementation.
+- Run the full frontend test suite before opening a PR.

--- a/docs/plans/2026-03-10-markdown-link-sanitization.md
+++ b/docs/plans/2026-03-10-markdown-link-sanitization.md
@@ -1,0 +1,69 @@
+# Markdown Link Sanitization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent unsafe markdown link URLs from reaching notes preview HTML while preserving normal note links.
+
+**Architecture:** Keep the fix inside the handwritten markdown renderer. Add a small helper that allowlists safe absolute URL schemes and use it from link rendering so unsafe destinations fall back to plain text.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest
+
+---
+
+### Task 1: Add failing coverage for unsafe link destinations
+
+**Files:**
+- Modify: `src/lib/markdown.test.ts`
+- Test: `src/lib/markdown.test.ts`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+- `mailto:` links still render as anchors.
+- `javascript:` links do not render `<a href=...>`.
+- `data:` links do not render `<a href=...>`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/markdown.test.ts`
+Expected: FAIL because unsafe links still render anchors.
+
+### Task 2: Implement minimal URL sanitization
+
+**Files:**
+- Modify: `src/lib/markdown.ts`
+- Test: `src/lib/markdown.test.ts`
+
+**Step 1: Write minimal implementation**
+
+Add:
+- A helper to escape attribute values used in `href`.
+- A helper that parses absolute URLs and allowlists `http:`, `https:`, and `mailto:`.
+- Link rendering via regex callback so each URL is sanitized before anchor HTML is emitted.
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run: `npx vitest run src/lib/markdown.test.ts`
+Expected: PASS
+
+### Task 3: Regression verification and review
+
+**Files:**
+- Modify: `docs/plans/2026-03-10-markdown-link-sanitization-design.md`
+- Modify: `docs/plans/2026-03-10-markdown-link-sanitization.md`
+
+**Step 1: Run broader verification**
+
+Run: `npx vitest run`
+Expected: PASS
+
+**Step 2: Review diff for scope and correctness**
+
+Check that:
+- Unsafe schemes never appear in rendered anchors.
+- Allowed links still preserve existing target/rel attributes.
+- No unrelated note editor behavior changed.
+
+**Step 3: Commit**
+
+Commit with a message that includes `closes #299` and the `Contributed-by: auto-worker` trailer.

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -59,6 +59,25 @@ describe("renderMarkdown", () => {
     expect(result).toContain('<a href="https://example.com" target="_blank" rel="noopener">click here</a>');
   });
 
+  it("renders mailto links", () => {
+    const result = renderMarkdown("[email me](mailto:test@example.com)");
+    expect(result).toContain('<a href="mailto:test@example.com" target="_blank" rel="noopener">email me</a>');
+  });
+
+  it("does not render javascript links", () => {
+    const result = renderMarkdown("[click me](javascript:alert-xss)");
+    expect(result).not.toContain("<a ");
+    expect(result).toContain("<p>click me</p>");
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("does not render data links", () => {
+    const result = renderMarkdown("[click me](data:text/html;base64,PHNjcmlwdD4=)");
+    expect(result).not.toContain("<a ");
+    expect(result).toContain("<p>click me</p>");
+    expect(result).not.toContain("data:text/html");
+  });
+
   it("renders unordered lists", () => {
     const md = "- item 1\n- item 2\n- item 3";
     const result = renderMarkdown(md);

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -7,6 +7,56 @@ export function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+function escapeHtmlAttribute(text: string): string {
+  return escapeHtml(text).replace(/"/g, "&quot;");
+}
+
+const ALLOWED_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+function sanitizeLinkUrl(url: string): string | null {
+  const trimmedUrl = url.trim();
+  if (trimmedUrl === "") {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    if (!ALLOWED_LINK_PROTOCOLS.has(parsedUrl.protocol)) {
+      return null;
+    }
+
+    return trimmedUrl;
+  } catch {
+    return null;
+  }
+}
+
+function renderLinks(text: string): string {
+  const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+  let result = "";
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(linkPattern)) {
+    const matchIndex = match.index ?? 0;
+    const [fullMatch, linkText, linkUrl] = match;
+
+    result += escapeHtml(text.slice(lastIndex, matchIndex));
+
+    const sanitizedUrl = sanitizeLinkUrl(linkUrl);
+    const escapedLinkText = escapeHtml(linkText);
+    if (sanitizedUrl) {
+      result += `<a href="${escapeHtmlAttribute(sanitizedUrl)}" target="_blank" rel="noopener">${escapedLinkText}</a>`;
+    } else {
+      result += escapedLinkText;
+    }
+
+    lastIndex = matchIndex + fullMatch.length;
+  }
+
+  result += escapeHtml(text.slice(lastIndex));
+  return result;
+}
+
 function processInline(line: string): string {
   // Inline code first (to prevent nested processing inside code spans)
   let result = "";
@@ -30,9 +80,7 @@ function processInline(line: string): string {
 }
 
 function processInlineFormatting(text: string): string {
-  let result = escapeHtml(text);
-  // Links: [text](url)
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+  let result = renderLinks(text);
   // Bold: **text**
   result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
   // Italic: *text* (but not inside bold markers)


### PR DESCRIPTION
## Summary\n- sanitize markdown link destinations before notes preview renders anchors\n- allow only http, https, and mailto links and fall back to plain text for unsafe schemes\n- add markdown renderer tests for allowed and blocked link URLs\n\ncloses #299