### PR TITLE
fix: roll back failed session spawns

### DIFF
--- a/docs/plans/2026-03-10-session-spawn-rollback-design.md
+++ b/docs/plans/2026-03-10-session-spawn-rollback-design.md
@@ -1,0 +1,64 @@
+# Session Metadata Rollback On PTY Spawn Failure Design
+
+## Summary
+
+`create_session` and `unarchive_session` currently persist project/session metadata before `PtyManager::spawn_session` runs. If spawn fails, storage keeps a session that was never actually launched, which leaves archived state flipped or a brand-new session entry orphaned on disk.
+
+## Goals
+
+- Make session persistence transactional around PTY spawn for the affected command paths.
+- Preserve the current success path and lock ordering expectations.
+- Keep the fix narrow to metadata consistency; do not broaden it into unrelated worktree cleanup or session lifecycle changes.
+
+## Approach Options
+
+### Option 1: Spawn first, persist after success
+
+Build the session config, attempt spawn, then save project metadata only when spawn succeeds.
+
+Pros:
+- Avoids rollback logic.
+- Leaves storage untouched on failure.
+
+Cons:
+- Changes the current ordering guarantee that metadata exists before the live session starts.
+- Creates a new failure mode where a running session can exist without persisted metadata if the final save fails.
+
+### Option 2: Persist first, then roll back on spawn failure
+
+Save the intended project mutation, attempt the PTY spawn, and restore the prior project state if the spawn step returns an error.
+
+Pros:
+- Preserves the current success-path ordering.
+- Matches the issue remediation guidance directly.
+- Can be shared by both `create_session` and `unarchive_session`.
+
+Cons:
+- Requires explicit rollback handling and tests for the failure path.
+
+## Recommended Design
+
+Use Option 2, but implement rollback as a compensating mutation against the latest reloaded project state instead of writing an older full-project snapshot back to disk. Extract a small helper in `commands.rs` that:
+
+1. Loads the current project.
+2. Applies a caller-provided mutation.
+3. Saves the mutated project.
+4. Runs a caller-provided post-save action.
+5. If the action fails, reloads the latest project, applies a caller-provided rollback mutation for just the affected session change, and saves again.
+
+`create_session` uses the helper to append the new `SessionConfig` and remove just that session entry on failure. `unarchive_session` uses it to flip the existing session’s `archived` flag to `false` and flip it back if spawn fails. For the create path, also clean up the newly created worktree/branch when spawn fails so rollback does not leave hidden worktree state behind.
+
+## Error Handling
+
+- Return the original PTY spawn failure when the compensating rollback succeeds.
+- If rollback save fails, return an error that includes both the spawn failure and rollback failure so the user knows storage may need manual repair.
+- For `create_session`, if worktree cleanup fails after the metadata rollback, return an error that includes both the spawn failure and the cleanup failure.
+- Keep the helper scoped to one project file update so unrelated concurrent project changes are preserved.
+
+## Testing
+
+- Add a regression test for the transactional helper that saves a new session, simulates a post-save failure, and proves the session entry is removed.
+- Add a regression test for the same helper in the unarchive case, proving the archived flag is restored when the post-save action fails.
+- Add a regression test showing concurrent unrelated project changes are preserved when the rollback runs.
+- Add a focused test for the create-session cleanup path that removes the created worktree/branch.
+- Verify the tests fail without the rollback helper and pass with it.

--- a/docs/plans/2026-03-10-session-spawn-rollback.md
+++ b/docs/plans/2026-03-10-session-spawn-rollback.md
@@ -1,0 +1,101 @@
+# Session Metadata Rollback On PTY Spawn Failure Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent `create_session` and `unarchive_session` from leaving persisted session metadata behind when PTY spawn fails, without clobbering concurrent project updates.
+
+**Architecture:** Keep the existing save-before-spawn ordering, but route both command paths through a transactional helper in `commands.rs` that applies a compensating rollback mutation to the latest reloaded `Project` if the post-save action fails. For `create_session`, also clean up the worktree created for the failed session spawn. Exercise the rollback behavior with focused command tests that simulate spawn failure via an injected closure.
+
+**Tech Stack:** Rust, Tauri command state/storage helpers, existing tests in `src-tauri/src/commands.rs`
+
+---
+
+### Task 1: Add the failing regression tests
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/commands.rs`
+
+**Step 1: Write the failing tests**
+
+Add two tests around a new transactional helper:
+- One mutates a project by appending a new `SessionConfig`, then forces the post-save action to fail and asserts the saved project still has zero sessions.
+- One starts with an archived session, mutates it to unarchived, then forces the post-save action to fail and asserts the saved project still shows the session as archived.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test rollback_session_metadata --manifest-path src-tauri/Cargo.toml -- --nocapture`
+
+Expected: FAIL because the saved project still reflects the post-save mutation after the injected failure.
+
+### Task 2: Implement the minimal rollback helper
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+
+**Step 1: Write minimal implementation**
+
+- Add a helper that loads a project, applies a mutation, saves, runs a post-save closure, and on failure reloads the latest project state and applies a compensating rollback mutation.
+- Preserve concurrent unrelated project changes by rolling back only the affected session mutation.
+- Preserve the original action error unless rollback also fails.
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run: `cargo test rollback_session_metadata --manifest-path src-tauri/Cargo.toml -- --nocapture`
+
+Expected: PASS.
+
+### Task 3: Wire the commands to the helper
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+
+**Step 1: Replace duplicated save-before-spawn logic**
+
+- Update `create_session` to persist the new `SessionConfig` via the helper and run `spawn_session` as the post-save action.
+- Update `unarchive_session` to toggle `archived` via the helper and run `spawn_session` as the post-save action.
+- Remove the newly created worktree/branch when `create_session` spawn fails.
+- Keep lock ordering safe by ensuring storage is not held while the PTY manager lock is acquired.
+
+**Step 2: Run focused command tests**
+
+Run: `cargo test commands::tests:: --manifest-path src-tauri/Cargo.toml rollback_session_metadata`
+
+Expected: PASS.
+
+### Task 4: Cover the concurrency and cleanup edge cases
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/commands.rs`
+
+**Step 1: Add regression coverage**
+
+- Add a test proving unrelated concurrent project edits survive the rollback path.
+- Add a focused test proving failed create-session cleanup removes the created worktree and branch reference.
+
+**Step 2: Run focused command tests**
+
+Run: `cargo test commands::tests:: --manifest-path src-tauri/Cargo.toml`
+
+Expected: PASS.
+
+### Task 5: Verify, review, and ship
+
+**Files:**
+- Modify: `docs/plans/2026-03-10-session-spawn-rollback-design.md`
+- Modify: `docs/plans/2026-03-10-session-spawn-rollback.md`
+
+**Step 1: Run fresh verification**
+
+Run the targeted regression tests plus the relevant command suite and confirm the output is passing before commit/PR.
+
+**Step 2: Self-review diff**
+
+Run: `git diff -- src-tauri/src/commands.rs docs/plans/2026-03-10-session-spawn-rollback-design.md docs/plans/2026-03-10-session-spawn-rollback.md`
+
+**Step 3: Commit**
+
+Use a commit message body that includes `closes #298` and ends with:
+
+`Contributed-by: auto-worker`

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -53,6 +53,62 @@ pub(crate) fn next_session_label(sessions: &[SessionConfig]) -> String {
     format!("session-{}-{}", max_num + 1, short_id)
 }
 
+fn update_project_with_rollback<T, C, M, R, A>(
+    state: &AppState,
+    project_id: Uuid,
+    mutate: M,
+    rollback: R,
+    action: A,
+) -> Result<T, String>
+where
+    M: FnOnce(&mut Project) -> Result<C, String>,
+    R: FnOnce(&mut Project) -> Result<(), String>,
+    A: FnOnce(C) -> Result<T, String>,
+{
+    let action_context = {
+        let storage = state.storage.lock().map_err(|e| e.to_string())?;
+        let mut project = storage
+            .load_project(project_id)
+            .map_err(|e| e.to_string())?;
+        let action_context = mutate(&mut project)?;
+        storage.save_project(&project).map_err(|e| e.to_string())?;
+        action_context
+    };
+
+    match action(action_context) {
+        Ok(result) => Ok(result),
+        Err(action_err) => {
+            let rollback = (|| -> Result<(), String> {
+                let storage = state.storage.lock().map_err(|e| e.to_string())?;
+                let mut project = storage
+                    .load_project(project_id)
+                    .map_err(|e| e.to_string())?;
+                rollback(&mut project)?;
+                storage.save_project(&project).map_err(|e| e.to_string())
+            })();
+
+            match rollback {
+                Ok(()) => Err(action_err),
+                Err(rollback_err) => Err(format!(
+                    "{} (rollback failed: {})",
+                    action_err, rollback_err
+                )),
+            }
+        }
+    }
+}
+
+fn cleanup_failed_session_spawn(
+    repo_path: &str,
+    worktree_path: Option<&str>,
+    worktree_branch: Option<&str>,
+) -> Result<(), String> {
+    if let Some((path, branch)) = worktree_path.zip(worktree_branch) {
+        WorktreeManager::remove_worktree(path, repo_path, branch)?;
+    }
+    Ok(())
+}
+
 const DEFAULT_AGENTS_MD: &str = r#"# {name}
 
 One-line project description.
@@ -663,42 +719,58 @@ pub fn create_session(
             )
         })
     });
+    let rollback_worktree = wt_path.clone().zip(wt_branch.clone());
 
-    // Save session config
-    {
-        let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let mut project = storage
-            .load_project(project_uuid)
-            .map_err(|e| e.to_string())?;
+    let session_config = SessionConfig {
+        id: session_id,
+        label: label.clone(),
+        worktree_path: wt_path,
+        worktree_branch: wt_branch,
+        archived: false,
+        kind: kind.clone(),
+        github_issue,
+        initial_prompt: initial_prompt.clone(),
+        done_commits: vec![],
+        auto_worker_session: false,
+    };
 
-        let session_config = SessionConfig {
-            id: session_id,
-            label: label.clone(),
-            worktree_path: wt_path,
-            worktree_branch: wt_branch,
-            archived: false,
-            kind: kind.clone(),
-            github_issue,
-            initial_prompt: initial_prompt.clone(),
-            done_commits: vec![],
-            auto_worker_session: false,
-        };
-        project.sessions.push(session_config);
-        storage.save_project(&project).map_err(|e| e.to_string())?;
-    }
-
-    // Spawn the PTY session in the worktree (or repo) directory
-    let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
-    pty_manager.spawn_session(
-        session_id,
-        &session_dir,
-        &kind,
-        app_handle,
-        false,
-        initial_prompt.as_deref(),
-        24,
-        80,
-    )?;
+    update_project_with_rollback(
+        &state,
+        project_uuid,
+        |project| {
+            project.sessions.push(session_config);
+            Ok(())
+        },
+        |project| {
+            project.sessions.retain(|session| session.id != session_id);
+            Ok(())
+        },
+        |()| {
+            let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
+            pty_manager.spawn_session(
+                session_id,
+                &session_dir,
+                &kind,
+                app_handle,
+                false,
+                initial_prompt.as_deref(),
+                24,
+                80,
+            )
+        },
+    )
+    .map_err(|spawn_err| {
+        if let Some((ref worktree_path, ref worktree_branch)) = rollback_worktree {
+            if let Err(cleanup_err) = cleanup_failed_session_spawn(
+                &repo_path,
+                Some(worktree_path.as_str()),
+                Some(worktree_branch.as_str()),
+            ) {
+                return format!("{} (worktree cleanup failed: {})", spawn_err, cleanup_err);
+            }
+        }
+        spawn_err
+    })?;
 
     Ok(session_id.to_string())
 }
@@ -1096,41 +1168,41 @@ pub fn unarchive_session(
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let session_uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
-    let storage = state.storage.lock().map_err(|e| e.to_string())?;
-    let mut project = storage
-        .load_project(project_uuid)
-        .map_err(|e| e.to_string())?;
+    update_project_with_rollback(
+        &state,
+        project_uuid,
+        |project| {
+            let repo_path = project.repo_path.clone();
+            let session = project
+                .sessions
+                .iter_mut()
+                .find(|s| s.id == session_uuid && s.archived)
+                .ok_or_else(|| "Archived session not found".to_string())?;
 
-    let session = project
-        .sessions
-        .iter_mut()
-        .find(|s| s.id == session_uuid && s.archived)
-        .ok_or_else(|| "Archived session not found".to_string())?;
-
-    // Use existing worktree path, or fall back to repo path
-    let session_dir = session
-        .worktree_path
-        .clone()
-        .unwrap_or_else(|| project.repo_path.clone());
-    let kind = session.kind.clone();
-
-    session.archived = false;
-    storage.save_project(&project).map_err(|e| e.to_string())?;
-
-    // Need to drop storage lock before acquiring pty_manager lock
-    drop(storage);
-
-    // Spawn the PTY session in the existing worktree directory
-    let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
-    pty_manager.spawn_session(
-        session_uuid,
-        &session_dir,
-        &kind,
-        app_handle,
-        true,
-        None,
-        24,
-        80,
+            let session_dir = session.worktree_path.clone().unwrap_or(repo_path);
+            let kind = session.kind.clone();
+            session.archived = false;
+            Ok((session_dir, kind))
+        },
+        |project| {
+            if let Some(session) = project.sessions.iter_mut().find(|s| s.id == session_uuid) {
+                session.archived = true;
+            }
+            Ok(())
+        },
+        |(session_dir, kind)| {
+            let mut pty_manager = state.pty_manager.lock().map_err(|e| e.to_string())?;
+            pty_manager.spawn_session(
+                session_uuid,
+                &session_dir,
+                &kind,
+                app_handle,
+                true,
+                None,
+                24,
+                80,
+            )
+        },
     )?;
 
     Ok(())
@@ -1809,7 +1881,7 @@ fn find_main_branch_oid(repo: &git2::Repository) -> Option<git2::Oid> {
 mod tests {
     use super::*;
     use crate::config::{save_config, Config};
-    use crate::models::SessionConfig;
+    use crate::models::{SavedPrompt, SessionConfig};
     use crate::pty_manager::PtyManager;
     use crate::state::{AppState, IssueCache};
     use crate::storage::Storage;
@@ -2276,7 +2348,10 @@ mod tests {
                 1,
                 "only the competing project should remain after rollback"
             );
-            assert_eq!(stored.projects[0].repo_path, imported_repo.path().to_string_lossy());
+            assert_eq!(
+                stored.projects[0].repo_path,
+                imported_repo.path().to_string_lossy()
+            );
         });
     }
 
@@ -2435,6 +2510,247 @@ mod tests {
             );
             assert_eq!(stored.projects[0].repo_path, repo_path.to_string_lossy());
         });
+    }
+
+    #[test]
+    fn test_rollback_session_metadata_for_create_session_path() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let repo_dir = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+
+        let project = create_project(
+            state_from_ref(&app_state),
+            "rollback-session-create".to_string(),
+            repo_dir.path().to_string_lossy().to_string(),
+        )
+        .expect("create project");
+
+        let session_id = Uuid::new_v4();
+        let error = update_project_with_rollback(
+            &app_state,
+            project.id,
+            |project| {
+                project.sessions.push(SessionConfig {
+                    id: session_id,
+                    label: "session-1".to_string(),
+                    worktree_path: Some("/tmp/worktree".to_string()),
+                    worktree_branch: Some("session-1".to_string()),
+                    archived: false,
+                    kind: "claude".to_string(),
+                    github_issue: None,
+                    initial_prompt: None,
+                    done_commits: vec![],
+                    auto_worker_session: false,
+                });
+                Ok(())
+            },
+            |project| {
+                project.sessions.retain(|session| session.id != session_id);
+                Ok(())
+            },
+            |()| Err::<(), String>("spawn failed".to_string()),
+        )
+        .expect_err("post-save failure should bubble up");
+
+        assert_eq!(error, "spawn failed");
+
+        let stored = app_state
+            .storage
+            .lock()
+            .unwrap()
+            .load_project(project.id)
+            .expect("load project after rollback");
+        assert!(
+            stored.sessions.is_empty(),
+            "failed create-session path should remove persisted session metadata"
+        );
+    }
+
+    #[test]
+    fn test_rollback_session_metadata_for_unarchive_session_path() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let repo_dir = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+
+        let project = create_project(
+            state_from_ref(&app_state),
+            "rollback-session-unarchive".to_string(),
+            repo_dir.path().to_string_lossy().to_string(),
+        )
+        .expect("create project");
+
+        let session_id = Uuid::new_v4();
+        {
+            let storage = app_state.storage.lock().unwrap();
+            let mut stored = storage.load_project(project.id).expect("load project");
+            stored.sessions.push(SessionConfig {
+                id: session_id,
+                label: "session-1".to_string(),
+                worktree_path: Some("/tmp/worktree".to_string()),
+                worktree_branch: Some("session-1".to_string()),
+                archived: true,
+                kind: "claude".to_string(),
+                github_issue: None,
+                initial_prompt: None,
+                done_commits: vec![],
+                auto_worker_session: false,
+            });
+            storage
+                .save_project(&stored)
+                .expect("save archived session");
+        }
+
+        let error = update_project_with_rollback(
+            &app_state,
+            project.id,
+            |project| {
+                let session = project
+                    .sessions
+                    .iter_mut()
+                    .find(|session| session.id == session_id)
+                    .expect("find archived session");
+                session.archived = false;
+                Ok(())
+            },
+            |project| {
+                if let Some(session) = project
+                    .sessions
+                    .iter_mut()
+                    .find(|session| session.id == session_id)
+                {
+                    session.archived = true;
+                }
+                Ok(())
+            },
+            |()| Err::<(), String>("spawn failed".to_string()),
+        )
+        .expect_err("post-save failure should bubble up");
+
+        assert_eq!(error, "spawn failed");
+
+        let stored = app_state
+            .storage
+            .lock()
+            .unwrap()
+            .load_project(project.id)
+            .expect("load project after rollback");
+        assert_eq!(stored.sessions.len(), 1);
+        assert!(
+            stored.sessions[0].archived,
+            "failed unarchive path should restore archived session metadata"
+        );
+    }
+
+    #[test]
+    fn test_rollback_session_metadata_preserves_concurrent_project_updates() {
+        let base_dir = TempDir::new().unwrap();
+        let projects_root = TempDir::new().unwrap();
+        let repo_dir = TempDir::new().unwrap();
+        let app_state = make_test_state(base_dir.path(), projects_root.path());
+
+        let project = create_project(
+            state_from_ref(&app_state),
+            "rollback-session-concurrency".to_string(),
+            repo_dir.path().to_string_lossy().to_string(),
+        )
+        .expect("create project");
+
+        let session_id = Uuid::new_v4();
+        let prompt_id = Uuid::new_v4();
+        let error = update_project_with_rollback(
+            &app_state,
+            project.id,
+            |project| {
+                project.sessions.push(SessionConfig {
+                    id: session_id,
+                    label: "session-1".to_string(),
+                    worktree_path: Some("/tmp/worktree".to_string()),
+                    worktree_branch: Some("session-1".to_string()),
+                    archived: false,
+                    kind: "claude".to_string(),
+                    github_issue: None,
+                    initial_prompt: None,
+                    done_commits: vec![],
+                    auto_worker_session: false,
+                });
+                Ok(())
+            },
+            |project| {
+                project.sessions.retain(|session| session.id != session_id);
+                Ok(())
+            },
+            |()| {
+                let storage = app_state.storage.lock().unwrap();
+                let mut latest = storage
+                    .load_project(project.id)
+                    .expect("load latest project");
+                latest.prompts.push(SavedPrompt {
+                    id: prompt_id,
+                    name: "Concurrent prompt".to_string(),
+                    text: "Preserve me".to_string(),
+                    created_at: "2026-03-10T00:00:00Z".to_string(),
+                    source_session_label: "session-elsewhere".to_string(),
+                });
+                storage
+                    .save_project(&latest)
+                    .expect("save concurrent update");
+                Err::<(), String>("spawn failed".to_string())
+            },
+        )
+        .expect_err("post-save failure should bubble up");
+
+        assert_eq!(error, "spawn failed");
+
+        let stored = app_state
+            .storage
+            .lock()
+            .unwrap()
+            .load_project(project.id)
+            .expect("load project after rollback");
+        assert!(
+            stored.sessions.is_empty(),
+            "rollback should still remove the failed session metadata"
+        );
+        assert_eq!(stored.prompts.len(), 1);
+        assert_eq!(stored.prompts[0].id, prompt_id);
+    }
+
+    #[test]
+    fn test_cleanup_failed_session_spawn_removes_created_worktree() {
+        let repo_dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(repo_dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        let worktree_root = TempDir::new().unwrap();
+        let branch = "session-cleanup";
+        let worktree_path = WorktreeManager::create_worktree(
+            &repo_dir.path().to_string_lossy(),
+            branch,
+            &worktree_root.path().join(branch),
+        )
+        .expect("create worktree");
+
+        cleanup_failed_session_spawn(
+            &repo_dir.path().to_string_lossy(),
+            Some(worktree_path.to_str().unwrap()),
+            Some(branch),
+        )
+        .expect("cleanup created worktree");
+
+        assert!(
+            !worktree_path.exists(),
+            "failed session spawn cleanup should remove the worktree directory"
+        );
+        assert!(
+            repo.find_branch(branch, git2::BranchType::Local).is_err(),
+            "failed session spawn cleanup should remove the branch reference"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make `create_session` and `unarchive_session` roll back only the failed session metadata when PTY spawn fails
- preserve concurrent project updates during rollback and clean up newly created worktrees if `create_session` spawn fails
- add regression coverage for create, unarchive, concurrent-update, and worktree-cleanup failure paths

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npx vitest run`

closes #298
