### PR TITLE
fix: handle startup storage init failures

### DIFF
--- a/docs/plans/2026-03-10-app-state-storage-init-design.md
+++ b/docs/plans/2026-03-10-app-state-storage-init-design.md
@@ -1,0 +1,60 @@
+# AppState Storage Init Failure Design
+
+**Issue:** `AppState::new()` panics on startup if the default storage directory cannot be resolved or created.
+
+## Definition
+
+Startup should fail gracefully when storage initialization cannot complete. Instead of panicking in Rust before the Tauri app is usable, the app should surface a user-facing error and exit cleanly.
+
+## Constraints
+
+- Keep the change narrowly scoped to startup initialization.
+- Preserve the existing `AppState` structure for downstream command handlers.
+- Remove panic paths from both storage directory resolution and directory creation.
+- Do not start background schedulers when app state initialization fails.
+- Keep validation automated and non-brittle.
+
+## Validation
+
+- Add a regression test that forces storage initialization to fail because the configured base path is unusable.
+- Verify the new test fails before the implementation and passes after it.
+- Run the relevant Rust test suite after implementation.
+
+## Approaches Considered
+
+### 1. Minimal unwrap replacement in `AppState::new()`
+
+Convert the `unwrap()` to `expect()` or map the error to a string but keep constructor semantics otherwise.
+
+**Rejected:** this still leaves `Storage::with_default_path()` panicking and does not provide a user-facing failure mode.
+
+### 2. Return `Result` from storage and app-state constructors, handle failure in bootstrap
+
+Make `Storage::with_default_path()` and `AppState::new()` return `Result`. In `run()`, initialize state before building the app loop; if initialization fails, show a native error dialog and return without starting the application.
+
+**Chosen:** fixes the root cause, removes both panic sites, and keeps the failure handling centralized at startup.
+
+### 3. Delay state initialization until after app startup
+
+Build the Tauri app first, then initialize state in `setup()` and exit if it fails.
+
+**Rejected:** it complicates startup ordering and leaves the app briefly alive without required state.
+
+## Design
+
+1. Add a storage-path resolution helper that returns `std::io::Result<PathBuf>` instead of panicking when the home directory cannot be determined.
+2. Add an `AppState::from_storage(Storage) -> std::io::Result<Self>` constructor for testable initialization.
+3. Change `AppState::new()` to return `std::io::Result<Self>` and delegate to `from_storage`.
+4. In `run()`, attempt to build `AppState` before registering it with Tauri.
+5. If initialization fails, show a native error dialog describing the storage initialization failure and return early instead of panicking.
+
+## Error Handling
+
+- Home directory resolution failure becomes an `io::Error`.
+- Directory creation failure is propagated unchanged.
+- Startup dialog message should explain that app storage could not be initialized and include the underlying error text.
+
+## Testing
+
+- Unit test for `AppState::from_storage` returning an error when the storage base path is a file.
+- Unit test for storage default-path resolution returning an error when no home directory is available.

--- a/docs/plans/2026-03-10-app-state-storage-init.md
+++ b/docs/plans/2026-03-10-app-state-storage-init.md
@@ -1,0 +1,79 @@
+# AppState Storage Init Failure Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent startup panics when app storage cannot be initialized and replace them with graceful startup failure.
+
+**Architecture:** Move storage initialization onto fallible constructors and handle the failure once in the Tauri bootstrap. Keep `AppState`'s stored fields unchanged so the rest of the app continues to use managed state the same way.
+
+**Tech Stack:** Rust, Tauri v2, `rfd` native dialogs, Rust unit tests
+
+---
+
+### Task 1: Make storage and app-state initialization fallible
+
+**Files:**
+- Modify: `src-tauri/src/storage.rs`
+- Modify: `src-tauri/src/state.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+- assert `AppState::from_storage(...)` returns an error when the storage base path is a file
+- assert the default-path resolver returns an error when no home directory is available
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test state::tests::test_app_state_from_storage_returns_error_when_storage_dirs_cannot_be_created`
+Expected: FAIL because `AppState::from_storage` does not exist yet
+
+**Step 3: Write minimal implementation**
+
+- Add a fallible default-path helper in `Storage`
+- Add `AppState::from_storage`
+- Make `AppState::new()` return `std::io::Result<Self>`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test state::tests::test_app_state_from_storage_returns_error_when_storage_dirs_cannot_be_created`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-03-10-app-state-storage-init-design.md docs/plans/2026-03-10-app-state-storage-init.md src-tauri/src/storage.rs src-tauri/src/state.rs
+git commit -m "fix: make app state initialization fallible"
+```
+
+### Task 2: Handle startup failures in the Tauri bootstrap
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+No direct bootstrap unit test is needed beyond Task 1 because the correctness hinge is the constructor contract. Keep Task 1 as the regression coverage.
+
+**Step 2: Implement minimal bootstrap handling**
+
+- Add `rfd` as a dependency
+- Attempt `state::AppState::new()` before `.manage(...)`
+- On failure, show a native error dialog and return early
+
+**Step 3: Run focused verification**
+
+Run: `cargo test state::tests::test_app_state_from_storage_returns_error_when_storage_dirs_cannot_be_created`
+Expected: PASS
+
+**Step 4: Run broader verification**
+
+Run: `cargo test`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/src/lib.rs
+git commit -m "fix: show startup error for storage init failures"
+```

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -69,6 +69,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +129,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +166,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -779,6 +823,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -2864,6 +2917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-pty"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3119,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +3174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3236,6 +3324,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3434,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4159,6 +4277,7 @@ dependencies = [
  "once_cell",
  "portable-pty",
  "raw-window-handle",
+ "rfd",
  "serde",
  "serde_json",
  "tauri",
@@ -4622,6 +4741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,6 +4984,7 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -4917,6 +5043,8 @@ version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
 dependencies = [
+ "dlib",
+ "log",
  "pkg-config",
 ]
 
@@ -5942,6 +6070,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.14",
  "zvariant_derive",
  "zvariant_utils",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-clipboard-manager = "2.3.2"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 raw-window-handle = "0.6"
 once_cell = "1"
+rfd = "0.16.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,12 +15,32 @@ pub mod storage;
 pub mod tmux;
 pub mod worktree;
 
+fn show_startup_error(error: &std::io::Error) {
+    eprintln!("Failed to initialize app storage: {error}");
+    let _ = rfd::MessageDialog::new()
+        .set_level(rfd::MessageLevel::Error)
+        .set_title("The Controller failed to start")
+        .set_description(format!(
+            "The Controller could not initialize its storage directory.\n\n{}",
+            error
+        ))
+        .show();
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let app_state = match state::AppState::new() {
+        Ok(state) => state,
+        Err(error) => {
+            show_startup_error(&error);
+            return;
+        }
+    };
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
-        .manage(state::AppState::new())
+        .manage(app_state)
         .setup(|app| {
             skills::sync_skills();
             status_socket::start_listener(app.handle().clone());

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -34,10 +34,13 @@ impl IssueCache {
     }
 
     pub fn insert(&mut self, repo_path: String, issues: Vec<GithubIssue>) {
-        self.entries.insert(repo_path, CacheEntry {
-            issues,
-            fetched_at: Instant::now(),
-        });
+        self.entries.insert(
+            repo_path,
+            CacheEntry {
+                issues,
+                fetched_at: Instant::now(),
+            },
+        );
     }
 
     /// Add a newly created issue to the cache for a repo (if cached).
@@ -52,7 +55,9 @@ impl IssueCache {
         if let Some(entry) = self.entries.get_mut(repo_path) {
             if let Some(issue) = entry.issues.iter_mut().find(|i| i.number == issue_number) {
                 if !issue.labels.iter().any(|l| l.name == label) {
-                    issue.labels.push(GithubLabel { name: label.to_string() });
+                    issue.labels.push(GithubLabel {
+                        name: label.to_string(),
+                    });
                 }
             }
         }
@@ -75,14 +80,17 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new() -> Self {
-        let storage = Storage::with_default_path();
-        storage.ensure_dirs().unwrap();
-        Self {
+    pub fn from_storage(storage: Storage) -> std::io::Result<Self> {
+        storage.ensure_dirs()?;
+        Ok(Self {
             storage: Mutex::new(storage),
             pty_manager: Arc::new(Mutex::new(PtyManager::new())),
             issue_cache: Arc::new(Mutex::new(IssueCache::new())),
-        }
+        })
+    }
+
+    pub fn new() -> std::io::Result<Self> {
+        Self::from_storage(Storage::with_default_path()?)
     }
 }
 
@@ -90,6 +98,8 @@ impl AppState {
 mod tests {
     use super::*;
     use crate::models::{GithubIssue, GithubLabel};
+    use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn test_issue_cache_get_returns_none_on_miss() {
@@ -167,13 +177,16 @@ mod tests {
     #[test]
     fn test_issue_cache_add_label() {
         let mut cache = IssueCache::new();
-        cache.insert("/repo".to_string(), vec![GithubIssue {
-            number: 1,
-            title: "Test".to_string(),
-            url: "https://github.com/o/r/issues/1".to_string(),
-            body: None,
-            labels: vec![],
-        }]);
+        cache.insert(
+            "/repo".to_string(),
+            vec![GithubIssue {
+                number: 1,
+                title: "Test".to_string(),
+                url: "https://github.com/o/r/issues/1".to_string(),
+                body: None,
+                labels: vec![],
+            }],
+        );
         cache.add_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
         assert_eq!(entry.issues[0].labels.len(), 1);
@@ -183,13 +196,16 @@ mod tests {
     #[test]
     fn test_issue_cache_add_label_no_duplicates() {
         let mut cache = IssueCache::new();
-        cache.insert("/repo".to_string(), vec![GithubIssue {
-            number: 1,
-            title: "Test".to_string(),
-            url: "https://github.com/o/r/issues/1".to_string(),
-            body: None,
-            labels: vec![],
-        }]);
+        cache.insert(
+            "/repo".to_string(),
+            vec![GithubIssue {
+                number: 1,
+                title: "Test".to_string(),
+                url: "https://github.com/o/r/issues/1".to_string(),
+                body: None,
+                labels: vec![],
+            }],
+        );
         cache.add_label("/repo", 1, "triaged");
         cache.add_label("/repo", 1, "triaged");
         let entry = cache.get("/repo").unwrap();
@@ -199,15 +215,33 @@ mod tests {
     #[test]
     fn test_issue_cache_remove_label() {
         let mut cache = IssueCache::new();
-        cache.insert("/repo".to_string(), vec![GithubIssue {
-            number: 1,
-            title: "Test".to_string(),
-            url: "https://github.com/o/r/issues/1".to_string(),
-            body: None,
-            labels: vec![GithubLabel { name: "in-progress".to_string() }],
-        }]);
+        cache.insert(
+            "/repo".to_string(),
+            vec![GithubIssue {
+                number: 1,
+                title: "Test".to_string(),
+                url: "https://github.com/o/r/issues/1".to_string(),
+                body: None,
+                labels: vec![GithubLabel {
+                    name: "in-progress".to_string(),
+                }],
+            }],
+        );
         cache.remove_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
         assert!(entry.issues[0].labels.is_empty());
+    }
+
+    #[test]
+    fn test_app_state_from_storage_returns_error_when_storage_dirs_cannot_be_created() {
+        let tmp = TempDir::new().unwrap();
+        let file_path = tmp.path().join("blocked-base-dir");
+        fs::write(&file_path, "not a directory").unwrap();
+
+        let error = AppState::from_storage(Storage::new(file_path))
+            .err()
+            .expect("app state init should fail when storage dirs cannot be created");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::NotADirectory);
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -25,7 +26,11 @@ impl ProjectInventory {
         F: FnMut(&Project) -> bool,
     {
         Self {
-            projects: self.projects.into_iter().filter(|project| predicate(project)).collect(),
+            projects: self
+                .projects
+                .into_iter()
+                .filter(|project| predicate(project))
+                .collect(),
             corrupt_entries: self.corrupt_entries,
         }
     }
@@ -40,7 +45,6 @@ impl ProjectInventory {
             );
         }
     }
-
 }
 
 impl Deref for ProjectInventory {
@@ -94,12 +98,22 @@ impl Storage {
         Self { base_dir }
     }
 
+    pub fn default_base_dir(home_dir: Option<PathBuf>) -> io::Result<PathBuf> {
+        home_dir
+            .map(|home| home.join(".the-controller"))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "could not determine home directory",
+                )
+            })
+    }
+
     /// Create a Storage using the default `~/.the-controller/` directory.
-    pub fn with_default_path() -> Self {
-        let home = dirs::home_dir().expect("could not determine home directory");
-        Self {
-            base_dir: home.join(".the-controller"),
-        }
+    pub fn with_default_path() -> io::Result<Self> {
+        Ok(Self {
+            base_dir: Self::default_base_dir(dirs::home_dir())?,
+        })
     }
 
     /// Return the base directory path.
@@ -192,8 +206,7 @@ impl Storage {
         for session in &mut updated.sessions {
             if let Some(ref wt_path) = session.worktree_path {
                 if wt_path.starts_with(uuid_prefix) {
-                    session.worktree_path =
-                        Some(wt_path.replacen(uuid_prefix, name_prefix, 1));
+                    session.worktree_path = Some(wt_path.replacen(uuid_prefix, name_prefix, 1));
                 }
             }
         }
@@ -257,7 +270,10 @@ impl Storage {
     }
 
     /// Load the most recent maintainer run log for a project.
-    pub fn latest_maintainer_run_log(&self, project_id: Uuid) -> std::io::Result<Option<MaintainerRunLog>> {
+    pub fn latest_maintainer_run_log(
+        &self,
+        project_id: Uuid,
+    ) -> std::io::Result<Option<MaintainerRunLog>> {
         let dir = self.maintainer_run_logs_dir(project_id);
         if !dir.exists() {
             return Ok(None);
@@ -268,7 +284,11 @@ impl Storage {
     }
 
     /// Load maintainer run log history for a project, most recent first.
-    pub fn maintainer_run_log_history(&self, project_id: Uuid, limit: usize) -> std::io::Result<Vec<MaintainerRunLog>> {
+    pub fn maintainer_run_log_history(
+        &self,
+        project_id: Uuid,
+        limit: usize,
+    ) -> std::io::Result<Vec<MaintainerRunLog>> {
         let dir = self.maintainer_run_logs_dir(project_id);
         if !dir.exists() {
             return Ok(vec![]);
@@ -289,7 +309,10 @@ impl Storage {
         Ok(())
     }
 
-    fn load_run_logs_from_dir(&self, dir: &std::path::Path) -> std::io::Result<Vec<MaintainerRunLog>> {
+    fn load_run_logs_from_dir(
+        &self,
+        dir: &std::path::Path,
+    ) -> std::io::Result<Vec<MaintainerRunLog>> {
         let mut logs = Vec::new();
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
@@ -309,9 +332,7 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{
-        IssueAction, IssueSummary, MaintainerRunLog, SessionConfig,
-    };
+    use crate::models::{IssueAction, IssueSummary, MaintainerRunLog, SessionConfig};
     use tempfile::TempDir;
 
     fn make_storage(tmp: &TempDir) -> Storage {
@@ -419,7 +440,10 @@ mod tests {
         storage
             .save_agents_md(project.id, "local agents content")
             .expect("save agents.md");
-        assert_eq!(storage.get_agents_md(&project).unwrap(), "local agents content");
+        assert_eq!(
+            storage.get_agents_md(&project).unwrap(),
+            "local agents content"
+        );
     }
 
     #[test]
@@ -489,13 +513,23 @@ mod tests {
     }
 
     #[test]
+    fn test_default_base_dir_returns_error_when_home_is_unavailable() {
+        let error = Storage::default_base_dir(None)
+            .expect_err("expected missing home directory to return an error");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
     fn test_save_and_get_agents_md_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let storage = make_storage(&tmp);
         let project = make_project("test-project", "/tmp/nonexistent-repo");
         let id = project.id;
 
-        storage.save_agents_md(id, "# My Agents\nContent here").unwrap();
+        storage
+            .save_agents_md(id, "# My Agents\nContent here")
+            .unwrap();
 
         // get_agents_md falls back to config dir when repo doesn't exist
         let content = storage.get_agents_md(&project).unwrap();
@@ -582,7 +616,9 @@ mod tests {
         storage.save_maintainer_run_log(&r2).expect("save r2");
         storage.save_maintainer_run_log(&r3).expect("save r3");
 
-        let history = storage.maintainer_run_log_history(project_id, 10).expect("history");
+        let history = storage
+            .maintainer_run_log_history(project_id, 10)
+            .expect("history");
         assert_eq!(history.len(), 3);
         assert_eq!(history[0].timestamp, "2026-03-09T03:00:00Z");
         assert_eq!(history[2].timestamp, "2026-03-09T01:00:00Z");
@@ -596,10 +632,18 @@ mod tests {
 
         let r1 = make_run_log(project_id, "2026-03-09T01:00:00Z");
         storage.save_maintainer_run_log(&r1).expect("save");
-        assert!(storage.latest_maintainer_run_log(project_id).unwrap().is_some());
+        assert!(storage
+            .latest_maintainer_run_log(project_id)
+            .unwrap()
+            .is_some());
 
-        storage.clear_maintainer_run_logs(project_id).expect("clear");
-        assert!(storage.latest_maintainer_run_log(project_id).unwrap().is_none());
+        storage
+            .clear_maintainer_run_logs(project_id)
+            .expect("clear");
+        assert!(storage
+            .latest_maintainer_run_log(project_id)
+            .unwrap()
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make storage and app-state initialization fallible instead of panicking during startup
- show a native startup error dialog when the storage directory cannot be initialized
- add regression tests and design/plan docs for the startup failure path

closes #285

## Testing
- cargo test state::tests::test_app_state_from_storage_returns_error_when_storage_dirs_cannot_be_created
- cargo test storage::tests::test_default_base_dir_returns_error_when_home_is_unavailable
- cargo test