### PR TITLE
fix: recover partial worktree path migration

### DIFF
--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -182,12 +182,8 @@ impl Storage {
     /// No-op if the UUID directory doesn't exist (already migrated or no worktrees).
     pub fn migrate_worktree_paths(&self, project: &Project) -> std::io::Result<()> {
         let uuid_dir = self.base_dir.join("worktrees").join(project.id.to_string());
-        if !uuid_dir.exists() {
-            return Ok(());
-        }
-
         let name_dir = self.base_dir.join("worktrees").join(&project.name);
-        if name_dir.exists() {
+        if uuid_dir.exists() && name_dir.exists() {
             eprintln!(
                 "Warning: cannot migrate worktrees for project '{}': target dir already exists",
                 project.name
@@ -195,22 +191,29 @@ impl Storage {
             return Ok(());
         }
 
-        // Rename the directory
-        fs::rename(&uuid_dir, &name_dir)?;
+        if uuid_dir.exists() {
+            fs::rename(&uuid_dir, &name_dir)?;
+        } else if !name_dir.exists() {
+            return Ok(());
+        }
 
-        // Update stored worktree paths
         let uuid_prefix = uuid_dir.to_str().unwrap_or_default();
         let name_prefix = name_dir.to_str().unwrap_or_default();
 
         let mut updated = project.clone();
+        let mut changed = false;
         for session in &mut updated.sessions {
             if let Some(ref wt_path) = session.worktree_path {
                 if wt_path.starts_with(uuid_prefix) {
                     session.worktree_path = Some(wt_path.replacen(uuid_prefix, name_prefix, 1));
+                    changed = true;
                 }
             }
         }
-        self.save_project(&updated)?;
+
+        if changed {
+            self.save_project(&updated)?;
+        }
 
         Ok(())
     }

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -432,6 +432,70 @@ fn test_migrate_worktree_paths_noop_when_no_uuid_dir() {
     );
 }
 
+/// If startup crashes after renaming `worktrees/{uuid}/` to `worktrees/{name}/`
+/// but before saving the updated project config, the next startup should still
+/// repair stale UUID-based `worktree_path` values. Re-running the migration
+/// must remain safe once the config has been repaired.
+#[test]
+fn test_migrate_worktree_paths_repairs_stale_paths_after_partial_migration() {
+    let tmp = TempDir::new().unwrap();
+    let storage = make_storage(&tmp);
+
+    let project_id = Uuid::new_v4();
+    let name_wt_dir = tmp.path().join("worktrees").join("recovered-project");
+    let name_session = name_wt_dir.join("session-1");
+    fs::create_dir_all(&name_session).expect("create name worktree dir");
+
+    let stale_uuid_session = tmp
+        .path()
+        .join("worktrees")
+        .join(project_id.to_string())
+        .join("session-1");
+
+    let project = Project {
+        id: project_id,
+        name: "recovered-project".to_string(),
+        repo_path: "/tmp/fake-repo".to_string(),
+        created_at: "2026-03-01T00:00:00Z".to_string(),
+        archived: false,
+        maintainer: MaintainerConfig::default(),
+        auto_worker: AutoWorkerConfig::default(),
+        prompts: vec![],
+        sessions: vec![SessionConfig {
+            id: Uuid::new_v4(),
+            label: "session-1".to_string(),
+            worktree_path: Some(stale_uuid_session.to_str().unwrap().to_string()),
+            worktree_branch: Some("session-1".to_string()),
+            archived: false,
+            kind: "claude".to_string(),
+            github_issue: None,
+            initial_prompt: None,
+            done_commits: vec![],
+            auto_worker_session: false,
+        }],
+        staged_session: None,
+    };
+    storage.save_project(&project).expect("save project");
+
+    storage.migrate_worktree_paths(&project).expect("first migrate");
+    let repaired = storage.load_project(project_id).expect("load repaired project");
+    assert_eq!(
+        repaired.sessions[0].worktree_path.as_deref(),
+        Some(name_session.to_str().unwrap()),
+        "migration should repair stale UUID-based paths when the directory was already renamed"
+    );
+
+    storage
+        .migrate_worktree_paths(&repaired)
+        .expect("second migrate should stay idempotent");
+    let rerun = storage.load_project(project_id).expect("load after second migrate");
+    assert_eq!(
+        rerun.sessions[0].worktree_path.as_deref(),
+        Some(name_session.to_str().unwrap()),
+        "running the migration again should keep the repaired path stable"
+    );
+}
+
 /// When both `worktrees/{uuid}/` and `worktrees/{name}/` exist,
 /// migration should skip the rename to avoid clobbering the name dir.
 /// The stored `worktree_path` must remain unchanged (still UUID-based).


### PR DESCRIPTION
## Summary
- repair stale UUID-based session worktree paths when the name-based worktree directory already exists from a partial migration
- add a regression test that covers the partial-migration recovery path and repeat-startup idempotency
- preserve the existing warning/no-op when both UUID and name directories exist

## Verification
- cargo test --manifest-path src-tauri/Cargo.toml --test integration test_migrate_worktree_paths_repairs_stale_paths_after_partial_migration -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml --test integration
- cargo test --manifest-path src-tauri/Cargo.toml

closes #280