### PR TITLE
fix: invalidate issue cache after auto-worker label edits

### DIFF
--- a/docs/plans/2026-03-10-issue-cache-invalidation-design.md
+++ b/docs/plans/2026-03-10-issue-cache-invalidation-design.md
@@ -1,0 +1,79 @@
+# Issue Cache Invalidation for Auto-Worker Label Edits Design
+
+## Problem
+
+`AppState` keeps GitHub issue lists in `IssueCache` for up to 60 seconds, and the UI command layer updates that cache when users add or remove labels through Tauri commands. The auto-worker does not use those commands. It shells out to `gh issue edit` through private synchronous helpers in `src-tauri/src/auto_worker.rs`, so successful label changes leave the cached repo entry untouched until the TTL expires.
+
+The result is stale issue state in `IssuePickerModal` and the assigned issue panels after the auto-worker claims work, finishes work, or cleans stale labels.
+
+## Goal
+
+Ensure any successful auto-worker label mutation makes the next GitHub issue read for that repo refetch fresh data instead of serving stale cached issues.
+
+## Constraints
+
+- Keep the fix local to the existing cache model; do not redesign GitHub issue state management.
+- Preserve the current UI command behavior, which still performs precise in-memory cache mutations for direct user actions.
+- Cover the bug with a regression test that fails before the implementation and passes after it.
+- Avoid broad refactors of the auto-worker scheduler or GitHub command layer.
+
+## Options
+
+### 1. Invalidate the repo cache entry after successful auto-worker label edits
+
+- Add an `IssueCache` invalidation method for a repo path.
+- Thread the cache handle into the auto-worker label-edit path.
+- After a successful `gh issue edit`, remove that repo entry from the cache.
+
+Pros: minimal, correct for all auto-worker label edits, and aligns with the issue report.
+Cons: the next issue fetch pays for a full refetch instead of a targeted in-memory patch.
+
+### 2. Teach the auto-worker helpers to mirror direct cache mutations
+
+- Pass issue number and label data into `IssueCache::add_label` and `IssueCache::remove_label`.
+- Keep the cache hot without forcing a refetch.
+
+Pros: avoids an extra GitHub fetch on the next read.
+Cons: duplicates mutation logic across two code paths and is easier to get wrong when auto-worker operations become more complex.
+
+### 3. Route auto-worker label edits through the Tauri GitHub command functions
+
+- Consolidate label editing into one shared async/cache-aware path.
+
+Pros: one source of truth long term.
+Cons: disproportionately invasive for a narrow bug, because the auto-worker currently relies on synchronous helper functions in background scheduler code.
+
+## Decision
+
+Use option 1.
+
+The auto-worker only needs cache correctness, not cache precision. Invalidating the repo entry after successful label edits is the smallest change that fixes all current stale-label paths, including startup cleanup, issue pickup, issue completion, and label migration.
+
+## Design
+
+### Cache API
+
+Add `IssueCache::invalidate(&mut self, repo_path: &str)` in `src-tauri/src/state.rs`. It should remove the repo entry entirely.
+
+### Auto-worker label helper
+
+Refactor the synchronous label-edit helper flow in `src-tauri/src/auto_worker.rs` so the command execution and cache invalidation are separated cleanly:
+
+- a small helper performs the `gh issue edit`;
+- a wrapper invalidates the repo cache only when that edit succeeds.
+
+Thread `&AppState` into the auto-worker call sites that already own state, so all successful auto-worker label edits invalidate the cache.
+
+### Failure behavior
+
+If `gh issue edit` fails, return the existing error and leave the cache untouched. A failed mutation should not evict otherwise-valid cached data.
+
+## Testing
+
+Add a regression test in `src-tauri/src/auto_worker.rs` around the new wrapper helper:
+
+- seed `IssueCache` with a repo entry;
+- simulate a successful label edit via an injected closure and assert the repo entry is invalidated;
+- simulate a failed label edit and assert the cache entry remains present.
+
+This test should fail before the new invalidation path exists and pass once the helper uses `IssueCache::invalidate`.

--- a/docs/plans/2026-03-10-issue-cache-invalidation.md
+++ b/docs/plans/2026-03-10-issue-cache-invalidation.md
@@ -1,0 +1,123 @@
+# Issue Cache Invalidation for Auto-Worker Label Edits Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure auto-worker label edits cannot leave `IssueCache` stale after `gh issue edit` succeeds.
+
+**Architecture:** Keep the existing dual-path design, but add an explicit cache invalidation hook for the auto-worker's synchronous label-edit helpers. Successful auto-worker label edits evict the repo cache entry so the next issue read refetches fresh GitHub data.
+
+**Tech Stack:** Rust, Tauri v2, GitHub CLI, cargo test
+
+---
+
+### Task 1: Add the regression test for auto-worker cache invalidation
+
+**Files:**
+- Create: `docs/plans/2026-03-10-issue-cache-invalidation-design.md`
+- Create: `docs/plans/2026-03-10-issue-cache-invalidation.md`
+- Modify: `src-tauri/src/auto_worker.rs`
+- Test: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test in `src-tauri/src/auto_worker.rs` for a helper that wraps a synchronous label edit and cache invalidation. Cover two cases:
+- success removes the seeded repo entry from `IssueCache`;
+- failure keeps the seeded repo entry intact.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::successful_label_edit_invalidates_issue_cache`
+
+Expected: FAIL because the helper does not exist yet and the auto-worker label path has no cache invalidation behavior.
+
+**Step 3: Write minimal implementation**
+
+In `src-tauri/src/auto_worker.rs`:
+- extract the raw `gh issue edit` execution into a small helper;
+- add a wrapper that accepts `&AppState`, runs the edit, and invalidates the repo cache on success.
+
+In `src-tauri/src/state.rs`:
+- add `IssueCache::invalidate`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::successful_label_edit_invalidates_issue_cache`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src-tauri/src/auto_worker.rs src-tauri/src/state.rs docs/plans/2026-03-10-issue-cache-invalidation-design.md docs/plans/2026-03-10-issue-cache-invalidation.md
+git commit -m "fix: invalidate issue cache after auto-worker label edits"
+```
+
+### Task 2: Wire the invalidation through all auto-worker label edit call sites
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write the failing test**
+
+Extend the same unit test coverage or add a second focused test proving the helper only invalidates on successful edits, so callers can safely reuse it for issue pickup, cleanup, completion, and migration paths.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::failed_label_edit_keeps_issue_cache`
+
+Expected: FAIL before the helper preserves cache entries on edit failure.
+
+**Step 3: Write minimal implementation**
+
+Update the auto-worker call sites to use the new cache-aware helpers:
+- stale-label cleanup;
+- issue pickup;
+- label migration;
+- worker completion/finish handling.
+
+Thread `&AppState` where needed, keeping the change local to `auto_worker.rs`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::failed_label_edit_keeps_issue_cache`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src-tauri/src/auto_worker.rs src-tauri/src/state.rs
+git commit -m "fix: route auto-worker label edits through cache invalidation"
+```
+
+### Task 3: Verify the regression and shared backend behavior
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs` if cleanup is needed
+- Modify: `src-tauri/src/state.rs` if cleanup is needed
+
+**Step 1: Run focused backend verification**
+
+Run: `cd src-tauri && cargo test auto_worker::tests::successful_label_edit_invalidates_issue_cache auto_worker::tests::failed_label_edit_keeps_issue_cache state::tests::test_issue_cache_invalidate_removes_repo_entry`
+
+Expected: PASS.
+
+**Step 2: Run broader backend verification**
+
+Run: `cd src-tauri && cargo test`
+
+Expected: PASS, or capture any unrelated pre-existing failures explicitly.
+
+**Step 3: Self-review the diff**
+
+Check:
+- every successful auto-worker label mutation invalidates the cache;
+- failed mutations leave cache state alone;
+- direct UI GitHub commands still use their existing precise cache updates.
+
+**Step 4: Commit**
+
+```bash
+git add src-tauri/src/auto_worker.rs src-tauri/src/state.rs
+git commit -m "test: cover auto-worker issue cache invalidation"
+```

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -122,7 +122,7 @@ impl AutoWorkerScheduler {
                     .unwrap_or(false);
                 if labels.contains(&LABEL_IN_PROGRESS) && !protected {
                     eprintln!("Auto-worker: removing stale in-progress label from #{}", issue.number);
-                    let _ = remove_label_sync(&project.repo_path, issue.number, LABEL_IN_PROGRESS);
+                    let _ = remove_label_sync(state.inner(), &project.repo_path, issue.number, LABEL_IN_PROGRESS);
                 }
             }
         }
@@ -158,7 +158,7 @@ impl AutoWorkerScheduler {
                 Ok(issues) => issues,
                 Err(_) => continue,
             };
-            if let Err(e) = migrate_issues_sync(&project.repo_path, &mut issues) {
+            if let Err(e) = migrate_issues_sync(state.inner(), &project.repo_path, &mut issues) {
                 eprintln!("Auto-worker: label migration failed for {}: {}", project.name, e);
             }
         }
@@ -252,7 +252,7 @@ impl AutoWorkerScheduler {
                     if let Some(session) = active_sessions.remove(&project_id) {
                         eprintln!("Auto-worker: session completed for #{}", session.issue_number);
                         let (issue_number, issue_title) = session_issue_context(&session);
-                        mark_issue_finished(&session);
+                        mark_issue_finished(state.inner(), &session);
                         cleanup_session(&state, &session);
                         emit_status(
                             &app_handle,
@@ -303,7 +303,7 @@ impl AutoWorkerScheduler {
 
                     match spawn_auto_worker_session(&state, &app_handle, project, &eligible) {
                         Ok(session_id) => {
-                            let _ = add_label_sync(&project.repo_path, eligible.number, LABEL_IN_PROGRESS);
+                            let _ = add_label_sync(state.inner(), &project.repo_path, eligible.number, LABEL_IN_PROGRESS);
                             emit_status(&app_handle, project.id, "working", None, Some(eligible.number), Some(&eligible.title));
                             active_sessions.insert(project.id, ActiveSession {
                                 session_id,
@@ -525,9 +525,22 @@ fn fetch_issues_sync(repo_path: &str) -> Result<Vec<GithubIssue>, String> {
         .map_err(|e| format!("Failed to parse gh output: {}", e))
 }
 
-fn add_label_sync(repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
+fn finish_label_edit<F>(state: &AppState, repo_path: &str, edit: F) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    edit()?;
+
+    if let Ok(mut cache) = state.issue_cache.lock() {
+        cache.invalidate(repo_path);
+    }
+
+    Ok(())
+}
+
+fn edit_label_sync(repo_path: &str, issue_number: u64, mode: &str, label: &str) -> Result<(), String> {
     let output = Command::new("gh")
-        .args(["issue", "edit", &issue_number.to_string(), "--add-label", label])
+        .args(["issue", "edit", &issue_number.to_string(), mode, label])
         .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run gh: {}", e))?;
@@ -539,18 +552,12 @@ fn add_label_sync(repo_path: &str, issue_number: u64, label: &str) -> Result<(),
     Ok(())
 }
 
-fn remove_label_sync(repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
-    let output = Command::new("gh")
-        .args(["issue", "edit", &issue_number.to_string(), "--remove-label", label])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| format!("Failed to run gh: {}", e))?;
+fn add_label_sync(state: &AppState, repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
+    finish_label_edit(state, repo_path, || edit_label_sync(repo_path, issue_number, "--add-label", label))
+}
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("gh issue edit failed: {}", stderr));
-    }
-    Ok(())
+fn remove_label_sync(state: &AppState, repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
+    finish_label_edit(state, repo_path, || edit_label_sync(repo_path, issue_number, "--remove-label", label))
 }
 
 fn ensure_standard_labels_exist_sync(repo_path: &str) -> Result<(), String> {
@@ -637,7 +644,7 @@ fn apply_issue_migration(issue: &mut GithubIssue, migration: &LabelMigration) {
 }
 
 /// Migrate legacy labels on all issues. Returns the number of issues migrated.
-fn migrate_issues_sync(repo_path: &str, issues: &mut [GithubIssue]) -> Result<usize, String> {
+fn migrate_issues_sync(state: &AppState, repo_path: &str, issues: &mut [GithubIssue]) -> Result<usize, String> {
     ensure_standard_labels_exist_sync(repo_path)?;
 
     let mut count = 0;
@@ -648,10 +655,10 @@ fn migrate_issues_sync(repo_path: &str, issues: &mut [GithubIssue]) -> Result<us
         }
 
         for label in &migration.add {
-            add_label_sync(repo_path, issue.number, label)?;
+            add_label_sync(state, repo_path, issue.number, label)?;
         }
         for label in &migration.remove {
-            remove_label_sync(repo_path, issue.number, label)?;
+            remove_label_sync(state, repo_path, issue.number, label)?;
         }
 
         apply_issue_migration(issue, &migration);
@@ -742,7 +749,7 @@ fn kill_session(state: &AppState, session: &ActiveSession) {
     if let Ok(mut pty_manager) = state.pty_manager.lock() {
         let _ = pty_manager.close_session(session.session_id);
     }
-    mark_issue_finished(session);
+    mark_issue_finished(state, session);
     cleanup_session(state, session);
 }
 
@@ -794,10 +801,10 @@ fn close_issue_sync(repo_path: &str, issue_number: u64) -> Result<(), String> {
     Ok(())
 }
 
-fn mark_issue_finished(session: &ActiveSession) {
-    let _ = remove_label_sync(&session.repo_path, session.issue_number, LABEL_IN_PROGRESS);
+fn mark_issue_finished(state: &AppState, session: &ActiveSession) {
+    let _ = remove_label_sync(state, &session.repo_path, session.issue_number, LABEL_IN_PROGRESS);
     if has_merged_pr_sync(&session.repo_path, session.issue_number) {
-        let _ = add_label_sync(&session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
+        let _ = add_label_sync(state, &session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
         let _ = close_issue_sync(&session.repo_path, session.issue_number);
         eprintln!("Auto-worker: closed #{} (merged PR verified)", session.issue_number);
     } else {
@@ -821,7 +828,7 @@ fn cleanup_startup_worker(
 
     let session = startup_candidate_to_active_session(candidate);
     if !preserve_label {
-        mark_issue_finished(&session);
+        mark_issue_finished(state, &session);
     }
     cleanup_session(state, &session);
 }
@@ -862,6 +869,8 @@ pub fn pick_eligible_issue(issues: &[GithubIssue]) -> Option<&GithubIssue> {
 mod tests {
     use super::*;
     use crate::models::GithubLabel;
+    use crate::storage::Storage;
+    use tempfile::TempDir;
 
     fn make_issue(labels: &[&str]) -> GithubIssue {
         GithubIssue {
@@ -1009,6 +1018,41 @@ mod tests {
     #[test]
     fn json_has_results_invalid_json() {
         assert!(!json_has_results("not json"));
+    }
+
+    #[test]
+    fn successful_label_edit_invalidates_issue_cache() {
+        let tmp = TempDir::new().unwrap();
+        let state = AppState::from_storage(Storage::new(tmp.path().to_path_buf())).unwrap();
+        let repo_path = "/tmp/repo";
+
+        {
+            let mut cache = state.issue_cache.lock().unwrap();
+            cache.insert(repo_path.to_string(), vec![make_issue(&["in-progress"])]);
+        }
+
+        finish_label_edit(&state, repo_path, || Ok(())).unwrap();
+
+        let cache = state.issue_cache.lock().unwrap();
+        assert!(cache.get(repo_path).is_none());
+    }
+
+    #[test]
+    fn failed_label_edit_keeps_issue_cache() {
+        let tmp = TempDir::new().unwrap();
+        let state = AppState::from_storage(Storage::new(tmp.path().to_path_buf())).unwrap();
+        let repo_path = "/tmp/repo";
+
+        {
+            let mut cache = state.issue_cache.lock().unwrap();
+            cache.insert(repo_path.to_string(), vec![make_issue(&["in-progress"])]);
+        }
+
+        let error = finish_label_edit(&state, repo_path, || Err("boom".to_string())).unwrap_err();
+
+        assert_eq!(error, "boom");
+        let cache = state.issue_cache.lock().unwrap();
+        assert!(cache.get(repo_path).is_some());
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -43,6 +43,10 @@ impl IssueCache {
         );
     }
 
+    pub fn invalidate(&mut self, repo_path: &str) {
+        self.entries.remove(repo_path);
+    }
+
     /// Add a newly created issue to the cache for a repo (if cached).
     pub fn add_issue(&mut self, repo_path: &str, issue: GithubIssue) {
         if let Some(entry) = self.entries.get_mut(repo_path) {
@@ -230,6 +234,16 @@ mod tests {
         cache.remove_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
         assert!(entry.issues[0].labels.is_empty());
+    }
+
+    #[test]
+    fn test_issue_cache_invalidate_removes_repo_entry() {
+        let mut cache = IssueCache::new();
+        cache.insert("/repo".to_string(), vec![]);
+
+        cache.invalidate("/repo");
+
+        assert!(cache.get("/repo").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add repo-level IssueCache invalidation support
- invalidate cached issues after auto-worker add/remove label gh edits
- cover successful and failed invalidation paths with Rust regression tests

closes #252