### PR TITLE
fix: make auto-worker completion visible and restart-safe

### DIFF
--- a/docs/plans/2026-03-10-auto-worker-assignment-label-design.md
+++ b/docs/plans/2026-03-10-auto-worker-assignment-label-design.md
@@ -1,0 +1,57 @@
+# Auto-Worker Assignment Label Design
+
+## Definition
+
+Add a persistent `assigned-to-auto-worker` GitHub label so worker-owned issues carry durable provenance without overloading the generic `in-progress` label. The dashboard should treat a worker issue as completed when it has `assigned-to-auto-worker` and the issue is closed.
+
+## Constraints
+
+- Keep `in-progress` as the generic "currently being worked on in a session" label.
+- Add `assigned-to-auto-worker` when the auto-worker claims an issue.
+- Remove `in-progress` whenever worker ownership ends.
+- Keep `assigned-to-auto-worker` only if the issue ended up closed.
+- Remove `assigned-to-auto-worker` if the worker stops and the issue is still open.
+- Eliminate dependence on `finished-by-worker` for normal reporting.
+- Use TDD for behavior changes in both backend label handling and frontend report loading.
+- Historical worker issues should be backfilled with a one-off migration rather than complex runtime inference from git history.
+
+## Approaches
+
+### 1. Add `assigned-to-auto-worker` and derive completion from issue state
+
+Keep `in-progress` for active ownership, add `assigned-to-auto-worker` for worker provenance, and consider closed worker-labeled issues completed.
+
+Pros: Smallest long-term state model, avoids fragile terminal cleanup bookkeeping, matches the user's preferred semantics.
+Cons: A closed worker-owned issue is treated as completed even if closure happened by a path other than a merged worker PR.
+
+### 2. Keep `finished-by-worker` and add `assigned-to-auto-worker`
+
+Preserve the current finished label, but also add a provenance label when work starts.
+
+Pros: Most explicit state, distinguishes ownership from successful completion.
+Cons: Still relies on cleanup paths correctly maintaining a second terminal label, which is exactly what failed here.
+
+### 3. Infer worker provenance from git history and report comments
+
+Avoid new labels and reconstruct worker history from commit trailers, report comments, and PR linkage.
+
+Pros: Minimal label footprint.
+Cons: Runtime inference is brittle, expensive, and harder to explain than explicit issue metadata.
+
+## Chosen Design
+
+Use approach 1.
+
+When the scheduler claims an eligible issue, it should add both `in-progress` and `assigned-to-auto-worker`. When the worker exits or is cleaned up during restart recovery, it should always remove `in-progress`. If the issue is closed at that time, keep `assigned-to-auto-worker`. If the issue is still open, remove `assigned-to-auto-worker` because the worker did not complete it.
+
+The dashboard should stop querying `finished-by-worker` and instead query closed issues labeled `assigned-to-auto-worker`. The auto-worker pane must continue to show these completed issues as its report list. Opening an item should show the latest `<!-- auto-worker-report -->` comment when present. If a historical or migrated issue has no worker report comment, it should still appear in the pane with a fallback body such as `No worker report was posted for this issue.` Worker report comments remain useful detail when present, but they are no longer the sole index for completed work. For historical issues, run a one-off migration that adds `assigned-to-auto-worker` to issues already containing the `<!-- auto-worker-report -->` marker, then optionally remove any stale `finished-by-worker` labels.
+
+## Validation
+
+- Add backend tests proving issue claim adds `assigned-to-auto-worker`.
+- Add backend tests proving successful worker cleanup removes `in-progress` and retains `assigned-to-auto-worker` when the issue is closed.
+- Add backend tests proving unsuccessful worker cleanup removes both `in-progress` and `assigned-to-auto-worker` when the issue remains open.
+- Add command-level tests proving worker report queries load closed issues with `assigned-to-auto-worker`.
+- Add command-level tests proving issues without worker report comments still appear in the auto-worker pane with fallback detail text.
+- Run targeted Rust and frontend tests in a failing state first, then rerun after implementation.
+- Run a one-off migration against the repository and verify previously missing worker issues appear in the dashboard.

--- a/docs/plans/2026-03-10-auto-worker-assignment-label.md
+++ b/docs/plans/2026-03-10-auto-worker-assignment-label.md
@@ -1,0 +1,179 @@
+# Auto-Worker Assignment Label Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Make auto-worker issue provenance explicit with `assigned-to-auto-worker` and derive completed worker history from closed issues instead of the fragile `finished-by-worker` label.
+
+**Architecture:** Update the auto-worker scheduler so issue claim and cleanup maintain two labels with distinct semantics: `in-progress` for transient ownership and `assigned-to-auto-worker` for persistent worker provenance. Update the GitHub command that feeds the dashboard to query closed worker-labeled issues, and run a one-off migration to backfill historical worker-owned issues from existing worker report comments.
+
+**Tech Stack:** Rust, Tauri v2, TypeScript, Svelte 5, Vitest, GitHub CLI
+
+---
+
+### Task 1: Add failing backend coverage for worker label semantics
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+- Test: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write the failing test**
+
+Add focused unit tests for helper logic that encodes:
+- claiming an issue adds `assigned-to-auto-worker`
+- successful completion keeps `assigned-to-auto-worker`
+- unsuccessful completion removes `assigned-to-auto-worker`
+
+Factor pure label-transition helpers if needed so the logic is testable without shelling out to GitHub.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test auto_worker -- --nocapture`
+Expected: FAIL because current worker cleanup logic has no `assigned-to-auto-worker` behavior.
+
+### Task 2: Implement minimal backend label transition logic
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+- Test: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write minimal implementation**
+
+Update the scheduler to:
+- define `LABEL_ASSIGNED_TO_AUTO_WORKER`
+- add it alongside `in-progress` when a worker claims an issue
+- remove `in-progress` on all worker cleanup paths
+- keep or remove `assigned-to-auto-worker` based on whether the issue is closed
+- stop using `finished-by-worker` for eligibility and completion bookkeeping where no longer needed
+
+Use the smallest refactor that makes cleanup decisions explicit and shared across normal exit, kill, and restart recovery.
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run: `cd src-tauri && cargo test auto_worker -- --nocapture`
+Expected: PASS
+
+### Task 3: Add failing coverage for completed worker issue queries
+
+**Files:**
+- Modify: `src-tauri/src/commands/github.rs`
+- Test: `src-tauri/src/commands/github.rs`
+
+**Step 1: Write the failing test**
+
+Extract a pure parser/helper for worker issue query results and add tests asserting:
+- closed issues with `assigned-to-auto-worker` are returned
+- open issues with `assigned-to-auto-worker` are excluded from completed history
+- worker report comments are still selected when present
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test commands::github -- --nocapture`
+Expected: FAIL because the current query/parser is keyed to `finished-by-worker`.
+
+### Task 4: Implement the new completed-worker query
+
+**Files:**
+- Modify: `src-tauri/src/commands/github.rs`
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/commands/github.rs`
+
+**Step 1: Write minimal implementation**
+
+Change `get_worker_reports` to:
+- query issues labeled `assigned-to-auto-worker`
+- request issue state along with comments and timestamps
+- filter to closed issues before returning results
+- keep returning the latest `<!-- auto-worker-report -->` comment body when present
+- return a fallback body for closed worker issues with no report comment so they still show in the auto-worker pane
+
+Preserve the existing `WorkerReport` API shape unless the frontend needs a small extension.
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run: `cd src-tauri && cargo test commands::github -- --nocapture`
+Expected: PASS
+
+### Task 5: Update the dashboard wording and behavior
+
+**Files:**
+- Modify: `src/lib/AgentDashboard.svelte`
+- Modify: `src/lib/stores.ts`
+- Test: `src/lib/AgentDashboard.test.ts` or the closest existing dashboard/frontend test file if present
+
+**Step 1: Write the failing test**
+
+Add or extend frontend coverage so the auto-worker dashboard treats the returned items as completed work and does not depend on `finished-by-worker` terminology.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/AgentDashboard.test.ts`
+Expected: FAIL because the current wording/query assumptions still reflect the old finished-label model.
+
+**Step 3: Write minimal implementation**
+
+Update any user-facing copy that still implies the old terminal label model if needed, while keeping the dashboard interaction model unchanged. Ensure the auto-worker pane still renders the completed issue list and detail view even when some items use fallback report text.
+
+**Step 4: Run targeted tests to verify they pass**
+
+Run: `npx vitest run src/lib/AgentDashboard.test.ts`
+Expected: PASS
+
+### Task 6: Add a one-off migration for historical worker issues
+
+**Files:**
+- Create: `scripts/backfill-auto-worker-assignment-labels.sh`
+- Modify: `docs/plans/2026-03-10-auto-worker-assignment-label-design.md`
+- Modify: `docs/plans/2026-03-10-auto-worker-assignment-label.md`
+
+**Step 1: Write the migration script**
+
+Create a small script that:
+- lists repo issues with comments
+- finds issues containing `<!-- auto-worker-report -->`
+- adds `assigned-to-auto-worker` to those issues
+- optionally removes `finished-by-worker` if present
+
+Keep it idempotent and repository-parameterized.
+
+**Step 2: Dry-run or inspect the candidate set**
+
+Run: `bash scripts/backfill-auto-worker-assignment-labels.sh kwannoel/the-controller --dry-run`
+Expected: Prints the historical worker-owned issues that will be labeled.
+
+**Step 3: Run the migration**
+
+Run: `bash scripts/backfill-auto-worker-assignment-labels.sh kwannoel/the-controller`
+Expected: Historical issues receive `assigned-to-auto-worker` without changing unrelated issues.
+
+### Task 7: Full verification and review
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+- Modify: `src-tauri/src/commands/github.rs`
+- Modify: `src/lib/AgentDashboard.svelte`
+- Create: `scripts/backfill-auto-worker-assignment-labels.sh`
+
+**Step 1: Run backend verification**
+
+Run: `cd src-tauri && cargo test`
+Expected: PASS
+
+**Step 2: Run frontend verification**
+
+Run: `npx vitest run`
+Expected: PASS
+
+**Step 3: Review the GitHub issue state**
+
+Verify in GitHub that:
+- active worker issues carry both `in-progress` and `assigned-to-auto-worker`
+- completed worker issues are closed and retain `assigned-to-auto-worker`
+- abandoned or failed worker issues are open and do not retain `assigned-to-auto-worker`
+- completed worker issues remain visible in the auto-worker pane, with real report comments when available and fallback text otherwise
+
+**Step 4: Commit**
+
+```bash
+git add src-tauri/src/auto_worker.rs src-tauri/src/commands/github.rs src-tauri/src/commands.rs src/lib/AgentDashboard.svelte src/lib/stores.ts scripts/backfill-auto-worker-assignment-labels.sh docs/plans/2026-03-10-auto-worker-assignment-label-design.md docs/plans/2026-03-10-auto-worker-assignment-label.md
+git commit -m "fix: add persistent auto-worker assignment label"
+```

--- a/scripts/backfill-auto-worker-assignment-labels.sh
+++ b/scripts/backfill-auto-worker-assignment-labels.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <owner/repo> [--dry-run]" >&2
+  exit 1
+fi
+
+REPO="$1"
+DRY_RUN="${2:-}"
+ASSIGNED_LABEL="assigned-to-auto-worker"
+FINISHED_LABEL="finished-by-worker"
+REPORT_MARKER="<!-- auto-worker-report -->"
+
+if [[ "$DRY_RUN" != "" && "$DRY_RUN" != "--dry-run" ]]; then
+  echo "Unknown option: $DRY_RUN" >&2
+  exit 1
+fi
+
+gh label create "$ASSIGNED_LABEL" \
+  --repo "$REPO" \
+  --description "Issue has been handled by the auto-worker" \
+  --color "94E2D5" \
+  --force >/dev/null
+
+ISSUES_JSON="$(gh issue list \
+  --repo "$REPO" \
+  --state all \
+  --limit 200 \
+  --json number,title,labels,comments)"
+
+ISSUE_ROWS="$(
+  printf '%s' "$ISSUES_JSON" | node -e '
+const fs = require("fs");
+const marker = process.argv[1];
+const assigned = process.argv[2];
+const finished = process.argv[3];
+const issues = JSON.parse(fs.readFileSync(0, "utf8"));
+for (const issue of issues) {
+  const hasReport = (issue.comments || []).some((comment) =>
+    typeof comment.body === "string" && comment.body.includes(marker)
+  );
+  if (!hasReport) continue;
+  const labels = new Set((issue.labels || []).map((label) => label.name));
+  const needsAssigned = !labels.has(assigned);
+  const hasFinished = labels.has(finished);
+  console.log([issue.number, issue.title, needsAssigned ? "1" : "0", hasFinished ? "1" : "0"].join("\t"));
+}
+' "$REPORT_MARKER" "$ASSIGNED_LABEL" "$FINISHED_LABEL"
+)"
+
+if [[ -z "$ISSUE_ROWS" ]]; then
+  echo "No worker-report issues found in $REPO"
+  exit 0
+fi
+
+while IFS= read -r row; do
+  IFS=$'\t' read -r issue_number issue_title needs_assigned has_finished <<<"$row"
+  echo "#$issue_number $issue_title"
+
+  if [[ "$needs_assigned" == "0" && "$has_finished" == "0" ]]; then
+    echo "  no changes"
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "--dry-run" ]]; then
+    [[ "$needs_assigned" == "1" ]] && echo "  would add $ASSIGNED_LABEL"
+    [[ "$has_finished" == "1" ]] && echo "  would remove $FINISHED_LABEL"
+    continue
+  fi
+
+  if [[ "$needs_assigned" == "1" ]]; then
+    gh issue edit "$issue_number" --repo "$REPO" --add-label "$ASSIGNED_LABEL" >/dev/null
+    echo "  added $ASSIGNED_LABEL"
+  fi
+
+  if [[ "$has_finished" == "1" ]]; then
+    gh issue edit "$issue_number" --repo "$REPO" --remove-label "$FINISHED_LABEL" >/dev/null
+    echo "  removed $FINISHED_LABEL"
+  fi
+done <<<"$ISSUE_ROWS"

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -34,6 +34,7 @@ const LABEL_COMPLEXITY_HIGH_OLD: &str = "complexity: high";
 const LABEL_COMPLEXITY_SIMPLE: &str = "complexity:simple";
 const LABEL_COMPLEXITY_HIGH: &str = "complexity:high";
 const LABEL_IN_PROGRESS: &str = "in-progress";
+const LABEL_ASSIGNED_TO_AUTO_WORKER: &str = "assigned-to-auto-worker";
 const LABEL_FINISHED_BY_WORKER: &str = "finished-by-worker";
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -45,6 +46,60 @@ struct LabelMigration {
 impl LabelMigration {
     fn is_empty(&self) -> bool {
         self.add.is_empty() && self.remove.is_empty()
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct WorkerLabelPlan {
+    add: Vec<&'static str>,
+    remove: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LabelDefinition {
+    description: &'static str,
+    color: &'static str,
+}
+
+fn worker_claim_label_plan() -> WorkerLabelPlan {
+    WorkerLabelPlan {
+        add: vec![LABEL_IN_PROGRESS, LABEL_ASSIGNED_TO_AUTO_WORKER],
+        remove: vec![],
+    }
+}
+
+fn worker_cleanup_label_plan(issue_closed: Option<bool>) -> WorkerLabelPlan {
+    let mut remove = vec![LABEL_IN_PROGRESS];
+    if issue_closed == Some(false) {
+        remove.push(LABEL_ASSIGNED_TO_AUTO_WORKER);
+    }
+    WorkerLabelPlan { add: vec![], remove }
+}
+
+fn label_definition(label: &str) -> Option<LabelDefinition> {
+    match label {
+        LABEL_IN_PROGRESS => Some(LabelDefinition {
+            description: "Issue is being worked on in a session",
+            color: "F9E2AF",
+        }),
+        LABEL_ASSIGNED_TO_AUTO_WORKER => Some(LabelDefinition {
+            description: "Issue has been handled by the auto-worker",
+            color: "94E2D5",
+        }),
+        LABEL_FINISHED_BY_WORKER => Some(LabelDefinition {
+            description: "Issue was completed by the auto-worker",
+            color: "A6E3A1",
+        }),
+        _ => None,
+    }
+}
+
+fn apply_worker_label_plan_sync(state: &AppState, repo_path: &str, issue_number: u64, plan: &WorkerLabelPlan) {
+    for label in &plan.add {
+        let _ = add_label_sync(state, repo_path, issue_number, label);
+    }
+    for label in &plan.remove {
+        let _ = remove_label_sync(state, repo_path, issue_number, label);
     }
 }
 
@@ -303,7 +358,12 @@ impl AutoWorkerScheduler {
 
                     match spawn_auto_worker_session(&state, &app_handle, project, &eligible) {
                         Ok(session_id) => {
-                            let _ = add_label_sync(state.inner(), &project.repo_path, eligible.number, LABEL_IN_PROGRESS);
+                            apply_worker_label_plan_sync(
+                                state.inner(),
+                                &project.repo_path,
+                                eligible.number,
+                                &worker_claim_label_plan(),
+                            );
                             emit_status(&app_handle, project.id, "working", None, Some(eligible.number), Some(&eligible.title));
                             active_sessions.insert(project.id, ActiveSession {
                                 session_id,
@@ -539,6 +599,24 @@ where
 }
 
 fn edit_label_sync(repo_path: &str, issue_number: u64, mode: &str, label: &str) -> Result<(), String> {
+    if mode == "--add-label" {
+        if let Some(definition) = label_definition(label) {
+            let _ = Command::new("gh")
+                .args([
+                    "label",
+                    "create",
+                    label,
+                    "--description",
+                    definition.description,
+                    "--color",
+                    definition.color,
+                    "--force",
+                ])
+                .current_dir(repo_path)
+                .output();
+        }
+    }
+
     let output = Command::new("gh")
         .args(["issue", "edit", &issue_number.to_string(), mode, label])
         .current_dir(repo_path)
@@ -558,6 +636,24 @@ fn add_label_sync(state: &AppState, repo_path: &str, issue_number: u64, label: &
 
 fn remove_label_sync(state: &AppState, repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
     finish_label_edit(state, repo_path, || edit_label_sync(repo_path, issue_number, "--remove-label", label))
+}
+
+fn issue_is_closed_sync(repo_path: &str, issue_number: u64) -> Result<bool, String> {
+    let output = Command::new("gh")
+        .args(["issue", "view", &issue_number.to_string(), "--json", "state"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh issue view failed: {}", stderr));
+    }
+
+    let raw: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))?;
+
+    Ok(raw["state"].as_str() == Some("CLOSED"))
 }
 
 fn ensure_standard_labels_exist_sync(repo_path: &str) -> Result<(), String> {
@@ -802,16 +898,31 @@ fn close_issue_sync(repo_path: &str, issue_number: u64) -> Result<(), String> {
 }
 
 fn mark_issue_finished(state: &AppState, session: &ActiveSession) {
-    let _ = remove_label_sync(state, &session.repo_path, session.issue_number, LABEL_IN_PROGRESS);
-    if has_merged_pr_sync(&session.repo_path, session.issue_number) {
+    let mut issue_closed = issue_is_closed_sync(&session.repo_path, session.issue_number).ok();
+
+    if issue_closed != Some(true) && has_merged_pr_sync(&session.repo_path, session.issue_number) {
+        if close_issue_sync(&session.repo_path, session.issue_number).is_ok() {
+            issue_closed = Some(true);
+        }
+    }
+
+    apply_worker_label_plan_sync(
+        state,
+        &session.repo_path,
+        session.issue_number,
+        &worker_cleanup_label_plan(issue_closed),
+    );
+
+    if issue_closed == Some(true) {
         let _ = add_label_sync(state, &session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
-        let _ = close_issue_sync(&session.repo_path, session.issue_number);
-        eprintln!("Auto-worker: closed #{} (merged PR verified)", session.issue_number);
+        eprintln!("Auto-worker: finalized #{} as completed", session.issue_number);
+    } else if issue_closed == Some(false) {
+        let _ = remove_label_sync(state, &session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
+        eprintln!("Auto-worker: #{} exited while still open", session.issue_number);
     } else {
-        eprintln!("Auto-worker: #{} exited without merged PR, not closing", session.issue_number);
+        eprintln!("Auto-worker: #{} cleanup could not confirm issue state", session.issue_number);
     }
 }
-
 fn cleanup_startup_worker(
     state: &AppState,
     candidate: &StartupWorkerCandidate,
@@ -858,6 +969,7 @@ pub fn is_eligible(issue: &GithubIssue) -> bool {
         && labels.contains(&LABEL_COMPLEXITY_SIMPLE)
         && !labels.contains(&LABEL_IN_PROGRESS)
         && !labels.contains(&LABEL_FINISHED_BY_WORKER)
+        && !labels.contains(&LABEL_ASSIGNED_TO_AUTO_WORKER)
 }
 
 /// Pick the first eligible issue from a list.
@@ -1053,6 +1165,49 @@ mod tests {
         assert_eq!(error, "boom");
         let cache = state.issue_cache.lock().unwrap();
         assert!(cache.get(repo_path).is_some());
+    }
+
+    #[test]
+    fn worker_claim_label_plan_adds_assigned_to_auto_worker() {
+        let plan = worker_claim_label_plan();
+
+        assert!(plan.add.contains(&LABEL_IN_PROGRESS));
+        assert!(plan.add.contains(&LABEL_ASSIGNED_TO_AUTO_WORKER));
+    }
+
+    #[test]
+    fn worker_cleanup_label_plan_keeps_assignment_when_issue_closed() {
+        let plan = worker_cleanup_label_plan(Some(true));
+
+        assert!(plan.remove.contains(&LABEL_IN_PROGRESS));
+        assert!(!plan.remove.contains(&LABEL_ASSIGNED_TO_AUTO_WORKER));
+    }
+
+    #[test]
+    fn worker_cleanup_label_plan_removes_assignment_when_issue_still_open() {
+        let plan = worker_cleanup_label_plan(Some(false));
+
+        assert!(plan.remove.contains(&LABEL_IN_PROGRESS));
+        assert!(plan.remove.contains(&LABEL_ASSIGNED_TO_AUTO_WORKER));
+    }
+
+    #[test]
+    fn worker_cleanup_label_plan_preserves_assignment_when_issue_state_unknown() {
+        let plan = worker_cleanup_label_plan(None);
+
+        assert!(plan.remove.contains(&LABEL_IN_PROGRESS));
+        assert!(!plan.remove.contains(&LABEL_ASSIGNED_TO_AUTO_WORKER));
+    }
+
+    #[test]
+    fn label_definition_includes_assigned_to_auto_worker() {
+        assert_eq!(
+            label_definition(LABEL_ASSIGNED_TO_AUTO_WORKER),
+            Some(LabelDefinition {
+                description: "Issue has been handled by the auto-worker",
+                color: "94E2D5",
+            })
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -11,6 +11,9 @@ pub struct WorkerReport {
     pub updated_at: String,
 }
 
+const WORKER_REPORT_FALLBACK_BODY: &str = "No worker report was posted for this issue.";
+const LABEL_ASSIGNED_TO_AUTO_WORKER: &str = "assigned-to-auto-worker";
+
 /// Parse a GitHub remote URL into an "owner/repo" string.
 /// Handles SSH (git@github.com:owner/repo.git), HTTPS, and HTTP URLs.
 fn parse_github_nwo(url: &str) -> Result<String, String> {
@@ -429,9 +432,9 @@ pub(crate) async fn get_worker_reports(repo_path: String) -> Result<Vec<WorkerRe
         .args([
             "issue", "list",
             "--repo", &nwo,
-            "--label", "finished-by-worker",
+            "--label", LABEL_ASSIGNED_TO_AUTO_WORKER,
             "--state", "all",
-            "--json", "number,title,comments,updatedAt",
+            "--json", "number,title,state,comments,updatedAt",
             "--limit", "50",
         ])
         .output()
@@ -446,9 +449,17 @@ pub(crate) async fn get_worker_reports(repo_path: String) -> Result<Vec<WorkerRe
     let raw: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)
         .map_err(|e| format!("Failed to parse gh output: {}", e))?;
 
-    let reports: Vec<WorkerReport> = raw
-        .into_iter()
+    let reports = parse_worker_reports(raw);
+
+    Ok(reports)
+}
+
+fn parse_worker_reports(raw: Vec<serde_json::Value>) -> Vec<WorkerReport> {
+    raw.into_iter()
         .filter_map(|issue| {
+            if issue["state"].as_str() != Some("CLOSED") {
+                return None;
+            }
             let number = issue["number"].as_u64()?;
             let title = issue["title"].as_str()?.to_string();
             let updated_at = issue["updatedAt"].as_str().unwrap_or("").to_string();
@@ -460,7 +471,7 @@ pub(crate) async fn get_worker_reports(repo_path: String) -> Result<Vec<WorkerRe
                         text.contains("<!-- auto-worker-report -->").then_some(text)
                     })
                 })
-                .unwrap_or("")
+                .unwrap_or(WORKER_REPORT_FALLBACK_BODY)
                 .to_string();
             Some(WorkerReport {
                 issue_number: number,
@@ -469,9 +480,7 @@ pub(crate) async fn get_worker_reports(repo_path: String) -> Result<Vec<WorkerRe
                 updated_at,
             })
         })
-        .collect();
-
-    Ok(reports)
+        .collect()
 }
 
 #[cfg(test)]
@@ -570,5 +579,41 @@ mod tests {
     #[test]
     fn test_parse_github_issue_url_empty() {
         assert!(parse_github_issue_url("").is_err());
+    }
+
+    #[test]
+    fn parse_worker_reports_excludes_open_issues() {
+        let reports = parse_worker_reports(vec![
+            serde_json::json!({
+                "number": 42,
+                "title": "Closed worker issue",
+                "state": "CLOSED",
+                "updatedAt": "2026-03-10T00:00:00Z",
+                "comments": [],
+            }),
+            serde_json::json!({
+                "number": 43,
+                "title": "Open worker issue",
+                "state": "OPEN",
+                "updatedAt": "2026-03-10T00:00:00Z",
+                "comments": [],
+            }),
+        ]);
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].issue_number, 42);
+    }
+
+    #[test]
+    fn parse_worker_reports_uses_fallback_body_when_report_comment_missing() {
+        let reports = parse_worker_reports(vec![serde_json::json!({
+            "number": 42,
+            "title": "Closed worker issue",
+            "state": "CLOSED",
+            "updatedAt": "2026-03-10T00:00:00Z",
+            "comments": [],
+        })]);
+
+        assert_eq!(reports[0].comment_body, WORKER_REPORT_FALLBACK_BODY);
     }
 }

--- a/src-tauri/src/session_args.rs
+++ b/src-tauri/src/session_args.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-const BACKGROUND_WORKFLOW_SUFFIX: &str = "\n\nYou are an autonomous background worker. Complete the following workflow end-to-end without waiting for user input:\n1. **Design** — Analyze the issue and plan the approach\n2. **Implement** — Write the code changes\n3. **Review** — Self-review the changes for correctness and quality\n4. **Push PR** — Create and push a pull request\n5. **Merge** — Merge the PR once checks pass\n6. **Report** — If step 5 succeeded, post a report comment on the GitHub issue (use the issue number from above) via `gh issue comment <issue_number> --body \"...\"`. Start the comment body with the marker `<!-- auto-worker-report -->` on its own line, then summarize what was changed, include the PR URL, and confirm the merge succeeded. Skip this step if the merge did not succeed.\n7. **Sync local master** — After merging, sync master in the main repo (where master is always checked out) by running: `git -C \"$(git worktree list | head -1 | awk '{print $1}')\" pull`\n\nCOMMIT TAGGING: Every commit you create MUST include the trailer `Contributed-by: auto-worker` at the end of the commit message body. This is how we identify worker contributions. Example:\n```\nfix: resolve parsing edge case\n\nHandles the null input scenario.\n\nContributed-by: auto-worker\n```\n\nCRITICAL: Never ask questions. Never wait for confirmation or user input. If you are uncertain about anything, make your best judgment and proceed. You must complete the entire workflow autonomously.";
+const BACKGROUND_WORKFLOW_SUFFIX: &str = "\n\nYou are an autonomous background worker. Complete the following workflow end-to-end without waiting for user input:\n1. **Design** — Analyze the issue and plan the approach\n2. **Implement** — Write the code changes\n3. **Review** — Self-review the changes for correctness and quality\n4. **Push PR** — Create and push a pull request\n5. **Merge** — Merge the PR once checks pass\n6. **Report** — If step 5 succeeded, post a report comment on the GitHub issue (use the issue number from above) via `gh issue comment <issue_number> --body \"...\"`. Start the comment body with the marker `<!-- auto-worker-report -->` on its own line, then summarize what was changed, include the PR URL, and confirm the merge succeeded. Skip this step if the merge did not succeed.\n7. **Finalize issue state** — Before syncing local master, update the GitHub issue to reflect the final worker outcome. Remove `in-progress`. If the issue is now closed, keep or add `assigned-to-auto-worker`. If the issue is still open, remove `assigned-to-auto-worker` so the issue can be retried cleanly.\n8. **Sync local master** — After the GitHub issue state is finalized, sync master in the main repo (where master is always checked out) by running: `git -C \"$(git worktree list | head -1 | awk '{print $1}')\" pull`\n\nCOMMIT TAGGING: Every commit you create MUST include the trailer `Contributed-by: auto-worker` at the end of the commit message body. This is how we identify worker contributions. Example:\n```\nfix: resolve parsing edge case\n\nHandles the null input scenario.\n\nContributed-by: auto-worker\n```\n\nCRITICAL: Never ask questions. Never wait for confirmation or user input. If you are uncertain about anything, make your best judgment and proceed. You must complete the entire workflow autonomously.";
 
 /// Build the initial prompt injected into a session from a GitHub issue.
 /// When `background` is true, appends the autonomous workflow instructions.
@@ -158,9 +158,19 @@ mod tests {
         assert!(prompt.contains("Report"));
         assert!(prompt.contains("gh issue comment"));
         assert!(prompt.contains("auto-worker-report"));
+        assert!(prompt.contains("Finalize issue state"));
         assert!(prompt.contains("Sync local master"));
         assert!(prompt.contains("Never ask questions"));
         assert!(prompt.contains("Contributed-by: auto-worker"));
+    }
+
+    #[test]
+    fn build_issue_prompt_finalizes_issue_before_syncing_local_master() {
+        let prompt = build_issue_prompt(42, "Fix the bug", "https://github.com/foo/bar/issues/42", true);
+        let finalize_index = prompt.find("Finalize issue state").unwrap();
+        let sync_index = prompt.find("Sync local master").unwrap();
+
+        assert!(finalize_index < sync_index);
     }
 
     #[test]

--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -458,7 +458,7 @@
           <span class="policy-label">Excluded</span>
           <div class="policy-labels">
             <span class="policy-tag excluded">in-progress</span>
-            <span class="policy-tag excluded">finished-by-worker</span>
+            <span class="policy-tag excluded">assigned-to-auto-worker</span>
           </div>
         </div>
       </div>

--- a/src/lib/AgentDashboard.test.ts
+++ b/src/lib/AgentDashboard.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import AgentDashboard from "./AgentDashboard.svelte";
+import {
+  autoWorkerStatuses,
+  focusTarget,
+  hotkeyAction,
+  maintainerErrors,
+  maintainerStatuses,
+  projects,
+  type Project,
+  type WorkerReport,
+} from "./stores";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("./toast", () => ({
+  showToast: vi.fn(),
+}));
+
+function makeProject(): Project {
+  return {
+    id: "project-1",
+    name: "Controller",
+    repo_path: "/tmp/controller",
+    created_at: "2026-03-10T00:00:00Z",
+    archived: false,
+    sessions: [],
+    maintainer: {
+      enabled: false,
+      interval_minutes: 60,
+      github_repo: null,
+    },
+    auto_worker: { enabled: true },
+    prompts: [],
+    staged_session: null,
+  };
+}
+
+describe("AgentDashboard auto-worker pane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projects.set([makeProject()]);
+    focusTarget.set({ type: "agent", agentKind: "auto-worker", projectId: "project-1" });
+    autoWorkerStatuses.set(new Map([["project-1", { status: "idle" }]]));
+    maintainerStatuses.set(new Map());
+    maintainerErrors.set(new Map());
+    hotkeyAction.set(null);
+    vi.mocked(openUrl).mockResolvedValue();
+  });
+
+  it("shows completed worker issues and the assigned-to-auto-worker policy tag", async () => {
+    const reports: WorkerReport[] = [
+      {
+        issue_number: 299,
+        title: "Sanitize markdown link URLs",
+        comment_body: "No worker report was posted for this issue.",
+        updated_at: "2026-03-10T07:04:46Z",
+      },
+    ];
+
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_worker_reports") return reports;
+      return [];
+    });
+
+    render(AgentDashboard);
+
+    await waitFor(() => {
+      expect(screen.getByText("#299 Sanitize markdown link URLs")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("assigned-to-auto-worker")).toBeInTheDocument();
+    expect(screen.queryByText("finished-by-worker")).not.toBeInTheDocument();
+  });
+
+  it("shows fallback report text when a completed issue has no worker report comment", async () => {
+    const reports: WorkerReport[] = [
+      {
+        issue_number: 299,
+        title: "Sanitize markdown link URLs",
+        comment_body: "No worker report was posted for this issue.",
+        updated_at: "2026-03-10T07:04:46Z",
+      },
+    ];
+
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_worker_reports") return reports;
+      return [];
+    });
+
+    render(AgentDashboard);
+
+    const report = await screen.findByText("#299 Sanitize markdown link URLs");
+    await fireEvent.click(report);
+
+    await waitFor(() => {
+      expect(screen.getByText("No worker report was posted for this issue.")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add persistent `assigned-to-auto-worker` provenance and make completed worker items visible in the auto-worker pane
- backfill historical worker issues via an ad hoc script and keep fallback text for issues without a report comment
- update the background worker workflow so issue finalization happens before syncing local master

## Verification
- cd src-tauri && cargo test
- npx vitest run