### PR TITLE
feat: default session provider to codex

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -137,7 +137,7 @@ export type WorkspaceMode = "development" | "agents" | "notes";
 export const workspaceMode = writable<WorkspaceMode>("development");
 export const workspaceModePickerVisible = writable<boolean>(false);
 export type SessionProvider = "claude" | "codex";
-export const selectedSessionProvider = writable<SessionProvider>("claude");
+export const selectedSessionProvider = writable<SessionProvider>("codex");
 
 export const activeNote = writable<{
   projectId: string;


### PR DESCRIPTION
## Summary
- Changes the default session provider from Claude Code to Codex when pressing `c` to create a new session
- Toggle still available via `⌘t`

## Test plan
- [x] All 219 frontend tests pass
- [x] All 18 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)