### PR TITLE
fix: timeout merge session branch polling

### DIFF
--- a/docs/plans/2026-03-10-merge-session-branch-timeout.md
+++ b/docs/plans/2026-03-10-merge-session-branch-timeout.md
@@ -1,0 +1,91 @@
+# Merge Session Branch Timeout Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop `merge_session_branch` from polling forever when Claude never resolves merge conflicts.
+
+**Architecture:** Keep the existing merge flow, but replace the unbounded rebase-resolution wait with a bounded polling helper that returns a clear timeout error. Match the existing `stage_session_inplace` behavior rather than introducing a new cancellation system in this fix.
+
+**Tech Stack:** Rust, Tauri v2 commands, Tokio async runtime, git2-backed repository helpers
+
+---
+
+## Definition
+
+The task is to fix issue #249 by ensuring `merge_session_branch` no longer hangs indefinitely after a conflicted rebase. The command should still prompt Claude to resolve conflicts and poll for completion, but it must stop after a defined deadline and return an actionable error to the frontend.
+
+## Constraints
+
+- The issue asks for timeout or cancellation; this fix will implement timeout because it solves the hang with the smallest change and matches an existing command in the same file.
+- The command already emits `"merge-status"` progress updates and focuses the active terminal from the frontend; preserve that flow.
+- Follow TDD: the timeout behavior must be covered by a failing test first.
+- Avoid wide refactors of merge, PR creation, or frontend state unless the test proves they are necessary.
+
+## Validation
+
+- Add a test that exercises the merge rebase wait behavior with a condition that never resolves and verifies it returns a timeout error instead of waiting forever.
+- Run the new targeted Rust test and watch it fail before the implementation.
+- Run the same targeted test again after the fix and verify it passes.
+- Run a broader Rust test command for `commands::tests` to check for regressions in the command module.
+
+## Approaches Considered
+
+1. Add a timeout to the existing polling loop.
+   Recommendation: minimal change, directly fixes the bug, and matches `stage_session_inplace`.
+2. Add frontend-triggered cancellation with a `CancellationToken`.
+   More flexible, but it requires new shared state and UI plumbing that is not required to eliminate the current hang.
+3. Do both timeout and cancellation now.
+   Highest flexibility, but unnecessary scope for a simple bugfix.
+
+### Task 1: Add the failing timeout test
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+- Test: `src-tauri/src/commands.rs`
+
+**Step 1: Write the failing test**
+
+Add a test for a small async helper that waits for rebase resolution and returns `Err("Timed out waiting for merge conflict resolution.")` when the rebase condition never clears within the configured poll budget.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p the-controller --lib commands::tests::test_wait_for_merge_rebase_resolution_times_out -- --nocapture`
+
+Expected: FAIL because the helper does not exist yet or the timeout behavior is not implemented.
+
+### Task 2: Implement the minimal merge timeout
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+
+**Step 1: Write minimal implementation**
+
+Add merge-specific timeout constants and a small async helper that polls `is_rebase_in_progress` up to the configured maximum before returning a timeout error. Use that helper from `merge_session_branch` in place of the infinite `loop`.
+
+**Step 2: Run targeted test to verify it passes**
+
+Run: `cargo test -p the-controller --lib commands::tests::test_wait_for_merge_rebase_resolution_times_out -- --nocapture`
+
+Expected: PASS
+
+### Task 3: Verify broader command behavior
+
+**Files:**
+- Modify: `src-tauri/src/commands.rs`
+
+**Step 1: Run broader verification**
+
+Run: `cargo test -p the-controller --lib commands::tests -- --nocapture`
+
+Expected: PASS
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-03-10-merge-session-branch-timeout.md src-tauri/src/commands.rs
+git commit -m "fix: timeout merge session branch conflict polling
+
+closes #249
+
+Contributed-by: auto-worker"
+```

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -109,6 +109,25 @@ fn cleanup_failed_session_spawn(
     Ok(())
 }
 
+async fn wait_for_merge_rebase_resolution<F, Fut>(
+    mut is_rebase_in_progress: F,
+    max_polls: u64,
+    poll_interval: std::time::Duration,
+) -> Result<(), String>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<bool, String>>,
+{
+    for _ in 0..max_polls {
+        tokio::time::sleep(poll_interval).await;
+        if !is_rebase_in_progress().await? {
+            return Ok(());
+        }
+    }
+
+    Err("Timed out waiting for merge conflict resolution.".to_string())
+}
+
 const DEFAULT_AGENTS_MD: &str = r#"# {name}
 
 One-line project description.
@@ -1506,6 +1525,7 @@ pub fn delete_note(
 
 const MAX_MERGE_RETRIES: u32 = 5;
 const REBASE_POLL_INTERVAL_SECS: u64 = 3;
+const MAX_MERGE_REBASE_WAIT_SECS: u64 = 600; // 10 minutes
 
 #[tauri::command]
 pub async fn merge_session_branch(
@@ -1576,21 +1596,24 @@ pub async fn merge_session_branch(
                     ),
                 );
 
-                // Poll until rebase is no longer in progress
+                // Poll until rebase is no longer in progress, but stop waiting
+                // eventually so the frontend can recover if Claude never resolves it.
                 let wt_poll = worktree_path.clone();
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(REBASE_POLL_INTERVAL_SECS))
-                        .await;
-                    let wt_check = wt_poll.clone();
-                    let still_rebasing = tokio::task::spawn_blocking(move || {
-                        WorktreeManager::is_rebase_in_progress(&wt_check)
-                    })
-                    .await
-                    .map_err(|e| format!("Task failed: {}", e))?;
-                    if !still_rebasing {
-                        break;
-                    }
-                }
+                wait_for_merge_rebase_resolution(
+                    move || {
+                        let wt_check = wt_poll.clone();
+                        async move {
+                            tokio::task::spawn_blocking(move || {
+                                WorktreeManager::is_rebase_in_progress(&wt_check)
+                            })
+                            .await
+                            .map_err(|e| format!("Task failed: {}", e))
+                        }
+                    },
+                    MAX_MERGE_REBASE_WAIT_SECS / REBASE_POLL_INTERVAL_SECS,
+                    std::time::Duration::from_secs(REBASE_POLL_INTERVAL_SECS),
+                )
+                .await?;
 
                 // Loop back — will sync main and rebase again
                 continue;
@@ -1896,6 +1919,7 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::thread;
     use std::time::Duration;
@@ -1980,6 +2004,56 @@ mod tests {
         }
 
         result
+    }
+
+    #[test]
+    fn test_wait_for_merge_rebase_resolution_times_out() {
+        run_async_test(async {
+            let checks = Arc::new(AtomicUsize::new(0));
+            let checks_for_closure = Arc::clone(&checks);
+
+            let result = wait_for_merge_rebase_resolution(
+                move || {
+                    let checks_for_closure = Arc::clone(&checks_for_closure);
+                    async move {
+                        checks_for_closure.fetch_add(1, Ordering::SeqCst);
+                        Ok(true)
+                    }
+                },
+                2,
+                Duration::from_millis(1),
+            )
+            .await;
+            assert_eq!(
+                result.expect_err("wait should time out"),
+                "Timed out waiting for merge conflict resolution."
+            );
+            assert_eq!(checks.load(Ordering::SeqCst), 2);
+        });
+    }
+
+    #[test]
+    fn test_wait_for_merge_rebase_resolution_stops_once_rebase_clears() {
+        run_async_test(async {
+            let checks = Arc::new(AtomicUsize::new(0));
+            let checks_for_closure = Arc::clone(&checks);
+
+            let result = wait_for_merge_rebase_resolution(
+                move || {
+                    let checks_for_closure = Arc::clone(&checks_for_closure);
+                    async move {
+                        let attempt = checks_for_closure.fetch_add(1, Ordering::SeqCst);
+                        Ok(attempt == 0)
+                    }
+                },
+                5,
+                Duration::from_millis(1),
+            )
+            .await;
+
+            assert!(result.is_ok(), "wait should stop after rebase clears");
+            assert_eq!(checks.load(Ordering::SeqCst), 2);
+        });
     }
 
     // --- validate_project_name tests ---


### PR DESCRIPTION
## Summary
- add a bounded async helper for merge rebase conflict polling
- return a clear timeout error after 10 minutes instead of waiting forever
- cover both timeout and recovery paths with Rust tests

closes #249