### PR TITLE
fix: use focused project for screenshot sessions

### DIFF
--- a/docs/plans/2026-03-10-screenshot-session-project-selection-design.md
+++ b/docs/plans/2026-03-10-screenshot-session-project-selection-design.md
@@ -1,0 +1,68 @@
+# Screenshot Session Project Selection Design
+
+## Summary
+
+`screenshotToNewSession` in `src/App.svelte` currently looks up a project named `"the-controller"` before creating the screenshot analysis session. That makes the feature fail in any workspace where the selected project has a different name, even though the rest of the app already tracks the active project through `focusTarget`.
+
+## Goals
+
+- Make screenshot sessions target the project implied by the current UI focus.
+- Keep the existing hotkeys and screenshot capture flow unchanged.
+- Add regression coverage that fails if screenshot session creation falls back to a hardcoded project name again.
+
+## Non-Goals
+
+- Adding a project picker modal for screenshots.
+- Changing stage-in-place behavior or other project-specific hotkeys.
+- Refactoring unrelated focus-management code.
+
+## Approach Options
+
+### Option 1: Use the currently focused project
+
+Pros:
+
+- Reuses the app's existing project-selection model.
+- Matches the issue's "currently active/selected project" guidance.
+- Minimal change with clear regression coverage.
+
+Cons:
+
+- Screenshot flow still depends on a project being focused somewhere in the UI.
+
+### Option 2: Fall back to the first available project when nothing is focused
+
+Pros:
+
+- Avoids an error toast when the user has projects loaded but no current focus.
+
+Cons:
+
+- Implicit target selection is surprising.
+- Risks sending screenshots to the wrong project silently.
+
+### Option 3: Add a target-project picker for screenshots
+
+Pros:
+
+- Explicit and flexible.
+
+Cons:
+
+- Larger UI change than this issue requires.
+- Slower flow for a hotkey-driven action.
+
+Recommendation: Option 1.
+
+## Design
+
+Resolve the screenshot target project via the existing `getTargetProject()` helper, which reads `focusTarget` and maps it back to a project in `projectsState.current`. If there is no focused project context, show a generic error toast like `Select a project before starting a screenshot session` and exit before any screenshot capture occurs.
+
+This keeps the rule simple: screenshot sessions run in whichever project the user is actively working in, whether focus is on the project row itself or one of its child targets.
+
+## Testing
+
+- Add a regression test that sets the only project name to something other than `"the-controller"`, keeps focus on that project, triggers the screenshot hotkey, and verifies `create_session` receives that project's id.
+- Run the targeted test first and confirm it fails against the current hardcoded lookup.
+- Implement the minimal `App.svelte` change.
+- Re-run the targeted test plus the `src/App.test.ts` suite to confirm the regression stays covered.

--- a/docs/plans/2026-03-10-screenshot-session-project-selection.md
+++ b/docs/plans/2026-03-10-screenshot-session-project-selection.md
@@ -1,0 +1,77 @@
+# Screenshot Session Project Selection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Make screenshot-to-session create the new session in the currently focused project instead of a hardcoded project named `"the-controller"`.
+
+**Architecture:** Reuse `App.svelte`'s existing focus-to-project helper so screenshot session targeting follows the same current-project model as the rest of the UI. Protect the behavior with an app-level regression test that proves a non-default project name still receives the screenshot session.
+
+**Tech Stack:** Svelte 5, Vitest, Testing Library
+
+---
+
+### Task 1: Add Regression Coverage For Screenshot Project Selection
+
+**Files:**
+
+- Modify: `src/App.test.ts`
+- Test: `src/App.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a test that renders `App`, seeds `projects` with a single project whose name is not `"the-controller"`, focuses that project, triggers `hotkeyAction` with `type: "screenshot-to-session"`, and asserts `invoke("create_session", ...)` receives that focused project's id.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/App.test.ts -t "uses the focused project for screenshot sessions even when the project name differs"`
+
+Expected: FAIL because `screenshotToNewSession` still searches for `"the-controller"` and exits before `create_session`.
+
+**Step 3: Write minimal implementation**
+
+Update `screenshotToNewSession` to call `getTargetProject()` and use that project's `id`. If no focused project exists, show a generic selection error and return.
+
+**Step 4: Run test to verify it passes**
+
+Run the same Vitest command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Commit after broader verification and review are complete.
+
+### Task 2: Verify The App-Level Regression
+
+**Files:**
+
+- Modify: `src/App.svelte`
+- Modify: `src/App.test.ts`
+- Modify: `docs/plans/2026-03-10-screenshot-session-project-selection-design.md`
+- Modify: `docs/plans/2026-03-10-screenshot-session-project-selection.md`
+
+**Step 1: Run broader verification**
+
+Run: `npx vitest run src/App.test.ts`
+
+Expected: PASS.
+
+**Step 2: Self-review**
+
+Check the diff for:
+
+- no remaining hardcoded `"the-controller"` lookup in screenshot flow
+- no screenshot capture when no project is selected
+- regression test that fails again if the hardcoded lookup is restored
+
+**Step 3: Commit**
+
+Use a commit message body that includes the required trailer:
+
+```text
+fix: use focused project for screenshot sessions
+
+closes #248
+
+Contributed-by: auto-worker
+```

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -236,11 +236,10 @@
   }
 
   async function screenshotToNewSession(preview: boolean, cropped: boolean) {
-    // Screenshot sessions always spawn in "the-controller" project
-    const projectId = projectsState.current.find((p) => p.name === "the-controller")?.id;
+    const project = getTargetProject();
 
-    if (!projectId) {
-      showToast("\"the-controller\" project not found", "error");
+    if (!project) {
+      showToast("Select a project before starting a screenshot session", "error");
       return;
     }
 
@@ -257,12 +256,12 @@
       // 2. Create a new session with initial prompt referencing the screenshot file.
       // Tell Claude to share the path and wait for further instructions.
       const sessionId: string = await invoke("create_session", {
-        projectId,
+        projectId: project.id,
         kind: "claude",
         initialPrompt: `I just took a screenshot of the app. The screenshot is saved at: ${screenshotPath}\nPlease read the screenshot image and share what you see, but wait for further prompts before taking any action.`,
       });
 
-      await activateNewSession(sessionId, projectId);
+      await activateNewSession(sessionId, project.id);
       focusTerminalSoon();
     } catch (e) {
       showToast(String(e), "error");

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -134,6 +134,23 @@ describe("App screenshot flow", () => {
     expect(mocks.openPath).not.toHaveBeenCalled();
   });
 
+  it("uses the focused project for screenshot sessions even when the project name differs", async () => {
+    setupMocks();
+    projects.set([{ ...baseProject, name: "client-app", repo_path: "/tmp/client-app" }]);
+    focusTarget.set({ type: "project", projectId: "proj-1" });
+
+    render(App);
+    hotkeyAction.set({ type: "screenshot-to-session" });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("create_session", expect.objectContaining({
+        projectId: "proj-1",
+        kind: "claude",
+        initialPrompt: expect.stringContaining("/tmp/the-controller-screenshot.png"),
+      }));
+    });
+  });
+
   it("Cmd+Shift+S: captures screenshot with preview", async () => {
     setupMocks();
     render(App);


### PR DESCRIPTION
## Summary
- route screenshot-to-session through the currently focused project instead of a hardcoded `the-controller` lookup
- show a generic selection error when no project is focused
- add a regression test plus design/implementation notes for the fix

## Verification
- npx vitest run src/App.test.ts -t "uses the focused project for screenshot sessions even when the project name differs"
- npx vitest run src/App.test.ts
- npx vitest run

closes #248