### PR TITLE
fix: use selected provider for screenshot sessions

### DIFF
--- a/docs/plans/2026-03-10-screenshot-provider-design.md
+++ b/docs/plans/2026-03-10-screenshot-provider-design.md
@@ -1,0 +1,68 @@
+# Screenshot Session Provider Design
+
+## Summary
+
+`screenshotToNewSession` in `src/App.svelte` currently hardcodes `kind: "claude"` when it creates a new session from a screenshot. That bypasses the selected foreground provider state introduced for other session-entry paths, so screenshot flows do not follow the current provider toggle.
+
+## Goals
+
+- Make every screenshot shortcut create the new session with the current foreground provider.
+- Keep screenshot capture, preview, and focused-project behavior unchanged.
+- Add regression coverage that fails if screenshot session creation is hardcoded to Claude again.
+
+## Non-Goals
+
+- Changing screenshot capture or preview behavior.
+- Changing background issue execution, which should remain Codex-only.
+- Refactoring unrelated session creation code.
+
+## Approach Options
+
+### Option 1: Reuse the current foreground provider state
+
+Pros:
+
+- Matches normal foreground session creation behavior.
+- Minimal change with clear regression coverage.
+- Keeps provider selection centralized in the existing store.
+
+Cons:
+
+- Screenshot sessions continue to depend on app-level provider state.
+
+### Option 2: Keep screenshots pinned to Claude
+
+Pros:
+
+- No implementation work.
+
+Cons:
+
+- Conflicts with the current provider toggle model.
+- Surprises users because screenshot sessions behave differently from other foreground sessions.
+
+### Option 3: Add a separate screenshot provider setting
+
+Pros:
+
+- Explicit per-feature control.
+
+Cons:
+
+- Adds state and UI complexity without a clear need.
+- Creates another provider rule to learn.
+
+Recommendation: Option 1.
+
+## Design
+
+Update `screenshotToNewSession` to use `currentSessionProvider` for the `create_session.kind` field instead of a hardcoded `"claude"`. This makes all screenshot entry points (`Cmd+S`, `Cmd+Shift+S`, `Cmd+D`, `Cmd+Shift+D`) follow the same foreground provider state as the `c` session flow.
+
+The project lookup, capture command, preview behavior, and initial prompt remain unchanged.
+
+## Testing
+
+- Add an app-level regression test that sets `selectedSessionProvider` to `"codex"`, triggers screenshot-to-session, and verifies `create_session` receives `kind: "codex"`.
+- Run that targeted test first and confirm it fails against the hardcoded implementation.
+- Implement the minimal `App.svelte` change.
+- Re-run the targeted test and then the `src/App.test.ts` suite to confirm the screenshot variants still work.

--- a/docs/plans/2026-03-10-screenshot-provider.md
+++ b/docs/plans/2026-03-10-screenshot-provider.md
@@ -1,0 +1,67 @@
+# Screenshot Session Provider Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Make screenshot-created sessions use the current foreground provider instead of always creating Claude sessions.
+
+**Architecture:** Reuse the existing `selectedSessionProvider` state already threaded through normal foreground session creation. Constrain the change to `App.svelte` and protect it with an app-level regression test in `src/App.test.ts`.
+
+**Tech Stack:** Svelte 5, Svelte stores, Vitest, Testing Library
+
+---
+
+### Task 1: Add Regression Coverage For Screenshot Provider Selection
+
+**Files:**
+- Modify: `src/App.test.ts`
+- Test: `src/App.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a test that renders `App`, sets `selectedSessionProvider` to `"codex"`, triggers `hotkeyAction` with `type: "screenshot-to-session"`, and asserts `invoke("create_session", ...)` receives `kind: "codex"`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/App.test.ts -t "uses the selected provider for screenshot sessions"`
+
+Expected: FAIL because `screenshotToNewSession` still hardcodes `kind: "claude"`.
+
+**Step 3: Write minimal implementation**
+
+Update `screenshotToNewSession` to use `currentSessionProvider` when it calls `create_session`.
+
+**Step 4: Run test to verify it passes**
+
+Run the same Vitest command.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+Commit after broader verification is complete.
+
+### Task 2: Verify Screenshot Flow Regressions
+
+**Files:**
+- Modify: `src/App.svelte`
+- Modify: `src/App.test.ts`
+- Modify: `docs/plans/2026-03-10-screenshot-provider-design.md`
+- Modify: `docs/plans/2026-03-10-screenshot-provider.md`
+
+**Step 1: Run broader verification**
+
+Run: `npx vitest run src/App.test.ts`
+
+Expected: PASS.
+
+**Step 2: Self-review**
+
+Check the diff for:
+
+- screenshot sessions using `currentSessionProvider`
+- unchanged screenshot preview and capture behavior
+- regression coverage that fails again if `kind: "claude"` is restored
+
+**Step 3: Commit**
+
+Use a concise fix commit message after verification.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -257,7 +257,7 @@
       // Tell Claude to share the path and wait for further instructions.
       const sessionId: string = await invoke("create_session", {
         projectId: project.id,
-        kind: "claude",
+        kind: currentSessionProvider,
         initialPrompt: `I just took a screenshot of the app. The screenshot is saved at: ${screenshotPath}\nPlease read the screenshot image and share what you see, but wait for further prompts before taking any action.`,
       });
 

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -151,6 +151,22 @@ describe("App screenshot flow", () => {
     });
   });
 
+  it("uses the selected provider for screenshot sessions", async () => {
+    setupMocks();
+    selectedSessionProvider.set("codex");
+
+    render(App);
+    hotkeyAction.set({ type: "screenshot-to-session" });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("create_session", expect.objectContaining({
+        projectId: "proj-1",
+        kind: "codex",
+        initialPrompt: expect.stringContaining("/tmp/the-controller-screenshot.png"),
+      }));
+    });
+  });
+
   it("Cmd+Shift+S: captures screenshot with preview", async () => {
     setupMocks();
     render(App);


### PR DESCRIPTION
## Summary
- make screenshot-created sessions use the current foreground provider
- add an app-level regression test for screenshot session provider selection
- document the design and implementation plan for the fix

## Testing
- npx vitest run
- cargo test