### PR TITLE
fix: standardize complexity labels and drop migration

### DIFF
--- a/docs/plans/2026-03-10-auto-worker-label-migration-cleanup-design.md
+++ b/docs/plans/2026-03-10-auto-worker-label-migration-cleanup-design.md
@@ -1,0 +1,26 @@
+# Auto-worker Label Migration Cleanup Design
+
+**Problem**
+
+The auto-worker still carries runtime migration logic for legacy GitHub labels even though the repo is now standardized on canonical labels. That keeps extra startup work, extra code paths, and tests for behavior we no longer want to support.
+
+**Decision**
+
+Adopt strict canonical labels for auto-worker scheduling:
+
+- `priority:high|low`
+- `complexity:low|high`
+
+Legacy labels such as `priority: high`, `complexity: low`, and `complexity:simple` are no longer supported by the scheduler.
+
+**Design**
+
+- Remove startup background migration from `src-tauri/src/auto_worker.rs`
+- Remove migration helpers and legacy-label constants/types from the same file
+- Keep eligibility checks strict and canonical-only
+- Replace migration-oriented tests with canonical behavior tests plus one explicit regression test that legacy labels are not eligible
+
+**Validation**
+
+- `cargo test auto_worker::tests --manifest-path src-tauri/Cargo.toml`
+- `rg 'migrate_labels_background|migrate_issues_sync|LabelMigration|priority: high|complexity: low|complexity:simple' src-tauri/src/auto_worker.rs`

--- a/docs/plans/2026-03-10-auto-worker-label-migration-cleanup.md
+++ b/docs/plans/2026-03-10-auto-worker-label-migration-cleanup.md
@@ -1,0 +1,71 @@
+# Auto-worker Label Migration Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove legacy auto-worker label migration and support only canonical GitHub labels.
+
+**Architecture:** Keep the scheduler simple: it fetches issues and filters only on canonical labels. No startup relabeling, no compatibility rewriting, and no tests that imply legacy labels still work.
+
+**Tech Stack:** Rust, cargo test
+
+---
+
+### Task 1: Lock in strict canonical behavior with tests
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Write the failing test**
+
+Add a test asserting an issue with legacy labels like `priority: high` and `complexity: low` is not eligible.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test legacy_labels_are_not_eligible --manifest-path src-tauri/Cargo.toml`
+Expected: FAIL because migration compatibility still exists in the file.
+
+**Step 3: Remove migration-focused tests**
+
+Delete tests that validate migration plans or migrated labels, since that behavior is being removed.
+
+**Step 4: Run focused test suite**
+
+Run: `cargo test auto_worker::tests --manifest-path src-tauri/Cargo.toml`
+Expected: FAIL until production migration code is removed.
+
+### Task 2: Remove legacy migration code from auto_worker
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Remove startup migration execution**
+
+Delete the background migration thread from `AutoWorkerScheduler::start`.
+
+**Step 2: Remove migration helpers and constants**
+
+Delete legacy-label constants, `LabelMigration`, migration helpers, and any now-unused label bootstrap that only existed for migration.
+
+**Step 3: Keep canonical eligibility only**
+
+Leave `is_eligible` using only canonical labels.
+
+**Step 4: Run tests**
+
+Run: `cargo test auto_worker::tests --manifest-path src-tauri/Cargo.toml`
+Expected: PASS.
+
+### Task 3: Verify cleanup scope
+
+**Files:**
+- Modify: `src-tauri/src/auto_worker.rs`
+
+**Step 1: Search for removed concepts**
+
+Run: `rg 'migrate_labels_background|migrate_issues_sync|LabelMigration|priority: high|complexity: low|complexity:simple' src-tauri/src/auto_worker.rs`
+Expected: no matches.
+
+**Step 2: Final verification**
+
+Run: `cargo test auto_worker::tests --manifest-path src-tauri/Cargo.toml`
+Expected: PASS.

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -25,29 +25,11 @@ const POLL_INTERVAL_SECS: u64 = 30;
 const SESSION_TIMEOUT_SECS: u64 = 30 * 60; // 30 minutes
 const MAX_NUDGES: u32 = 3;
 const NUDGE_COOLDOWN_SECS: u64 = 60;
-const LABEL_PRIORITY_HIGH_OLD: &str = "priority: high";
-const LABEL_PRIORITY_LOW_OLD: &str = "priority: low";
 const LABEL_PRIORITY_HIGH: &str = "priority:high";
-const LABEL_PRIORITY_LOW: &str = "priority:low";
-const LABEL_COMPLEXITY_LOW_OLD: &str = "complexity: low";
-const LABEL_COMPLEXITY_HIGH_OLD: &str = "complexity: high";
-const LABEL_COMPLEXITY_SIMPLE: &str = "complexity:simple";
-const LABEL_COMPLEXITY_HIGH: &str = "complexity:high";
+const LABEL_COMPLEXITY_LOW: &str = "complexity:low";
 const LABEL_IN_PROGRESS: &str = "in-progress";
 const LABEL_ASSIGNED_TO_AUTO_WORKER: &str = "assigned-to-auto-worker";
 const LABEL_FINISHED_BY_WORKER: &str = "finished-by-worker";
-
-#[derive(Debug, Default, PartialEq, Eq)]
-struct LabelMigration {
-    add: Vec<String>,
-    remove: Vec<String>,
-}
-
-impl LabelMigration {
-    fn is_empty(&self) -> bool {
-        self.add.is_empty() && self.remove.is_empty()
-    }
-}
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct WorkerLabelPlan {
@@ -183,53 +165,9 @@ impl AutoWorkerScheduler {
         }
     }
 
-    /// Migrate legacy issue labels in the background.
-    /// Runs once on startup without blocking the poll loop.
-    fn migrate_labels_background(app_handle: &AppHandle) {
-        let state = match app_handle.try_state::<AppState>() {
-            Some(s) => s,
-            None => return,
-        };
-
-        let projects = {
-            let storage = match state.storage.lock() {
-                Ok(s) => s,
-                Err(_) => return,
-            };
-            match storage.list_projects() {
-                Ok(inventory) => {
-                    inventory.warn_if_corrupt("auto-worker label migration");
-                    inventory.projects
-                }
-                Err(_) => return,
-            }
-        };
-
-        for project in &projects {
-            if !project.auto_worker.enabled || project.archived {
-                continue;
-            }
-            let mut issues = match fetch_issues_sync(&project.repo_path) {
-                Ok(issues) => issues,
-                Err(_) => continue,
-            };
-            if let Err(e) = migrate_issues_sync(state.inner(), &project.repo_path, &mut issues) {
-                eprintln!("Auto-worker: label migration failed for {}: {}", project.name, e);
-            }
-        }
-    }
-
     pub fn start(app_handle: AppHandle) {
         std::thread::spawn(move || {
             let mut active_sessions = Self::restore_startup_state(&app_handle);
-
-            // Migrate legacy labels in a background thread so the poll loop
-            // can start immediately. Migration is slow (~2-5s per issue via
-            // gh API) and was previously blocking the scheduler for minutes.
-            let migration_handle = app_handle.clone();
-            std::thread::spawn(move || {
-                Self::migrate_labels_background(&migration_handle);
-            });
 
             loop {
                 std::thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
@@ -656,114 +594,6 @@ fn issue_is_closed_sync(repo_path: &str, issue_number: u64) -> Result<bool, Stri
     Ok(raw["state"].as_str() == Some("CLOSED"))
 }
 
-fn ensure_standard_labels_exist_sync(repo_path: &str) -> Result<(), String> {
-    let labels = [
-        (LABEL_PRIORITY_LOW, "Low priority", "a6e3a1"),
-        (LABEL_PRIORITY_HIGH, "High priority", "f38ba8"),
-        (LABEL_COMPLEXITY_SIMPLE, "Simple fix", "89b4fa"),
-        (LABEL_COMPLEXITY_HIGH, "Significant effort", "f9e2af"),
-    ];
-
-    for (label, description, color) in labels {
-        let output = Command::new("gh")
-            .args([
-                "label",
-                "create",
-                label,
-                "--description",
-                description,
-                "--color",
-                color,
-                "--force",
-            ])
-            .current_dir(repo_path)
-            .output()
-            .map_err(|e| format!("Failed to run gh: {}", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("gh label create failed: {}", stderr));
-        }
-    }
-
-    Ok(())
-}
-
-fn dedup_and_sort(values: &mut Vec<String>) {
-    values.sort();
-    values.dedup();
-}
-
-fn migration_for_issue(issue: &GithubIssue) -> LabelMigration {
-    let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
-    let has = |label: &str| labels.contains(&label);
-
-    let mut migration = LabelMigration::default();
-
-    if has(LABEL_PRIORITY_HIGH_OLD) {
-        migration.remove.push(LABEL_PRIORITY_HIGH_OLD.to_string());
-        if !has(LABEL_PRIORITY_HIGH) {
-            migration.add.push(LABEL_PRIORITY_HIGH.to_string());
-        }
-    }
-    if has(LABEL_PRIORITY_LOW_OLD) {
-        migration.remove.push(LABEL_PRIORITY_LOW_OLD.to_string());
-        if !has(LABEL_PRIORITY_LOW) {
-            migration.add.push(LABEL_PRIORITY_LOW.to_string());
-        }
-    }
-    if has(LABEL_COMPLEXITY_LOW_OLD) {
-        migration.remove.push(LABEL_COMPLEXITY_LOW_OLD.to_string());
-        if !has(LABEL_COMPLEXITY_SIMPLE) {
-            migration.add.push(LABEL_COMPLEXITY_SIMPLE.to_string());
-        }
-    }
-    if has(LABEL_COMPLEXITY_HIGH_OLD) {
-        migration.remove.push(LABEL_COMPLEXITY_HIGH_OLD.to_string());
-        if !has(LABEL_COMPLEXITY_HIGH) {
-            migration.add.push(LABEL_COMPLEXITY_HIGH.to_string());
-        }
-    }
-    dedup_and_sort(&mut migration.add);
-    dedup_and_sort(&mut migration.remove);
-    migration
-}
-
-fn apply_issue_migration(issue: &mut GithubIssue, migration: &LabelMigration) {
-    issue.labels
-        .retain(|label| !migration.remove.iter().any(|remove| remove == &label.name));
-    for label in &migration.add {
-        if !issue.labels.iter().any(|existing| existing.name == *label) {
-            issue.labels.push(crate::models::GithubLabel { name: label.clone() });
-        }
-    }
-}
-
-/// Migrate legacy labels on all issues. Returns the number of issues migrated.
-fn migrate_issues_sync(state: &AppState, repo_path: &str, issues: &mut [GithubIssue]) -> Result<usize, String> {
-    ensure_standard_labels_exist_sync(repo_path)?;
-
-    let mut count = 0;
-    for issue in issues {
-        let migration = migration_for_issue(issue);
-        if migration.is_empty() {
-            continue;
-        }
-
-        for label in &migration.add {
-            add_label_sync(state, repo_path, issue.number, label)?;
-        }
-        for label in &migration.remove {
-            remove_label_sync(state, repo_path, issue.number, label)?;
-        }
-
-        apply_issue_migration(issue, &migration);
-        count += 1;
-    }
-
-    Ok(count)
-}
-
 fn spawn_auto_worker_session(
     state: &AppState,
     project: &crate::models::Project,
@@ -965,7 +795,7 @@ fn cleanup_session(state: &AppState, session: &ActiveSession) {
 pub fn is_eligible(issue: &GithubIssue) -> bool {
     let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
     labels.contains(&LABEL_PRIORITY_HIGH)
-        && labels.contains(&LABEL_COMPLEXITY_SIMPLE)
+        && labels.contains(&LABEL_COMPLEXITY_LOW)
         && !labels.contains(&LABEL_IN_PROGRESS)
         && !labels.contains(&LABEL_FINISHED_BY_WORKER)
         && !labels.contains(&LABEL_ASSIGNED_TO_AUTO_WORKER)
@@ -995,19 +825,19 @@ mod tests {
 
     #[test]
     fn eligible_issue_has_all_required_labels() {
-        let issue = make_issue(&["priority:high", "complexity:simple", "triaged"]);
+        let issue = make_issue(&["priority:high", "complexity:low", "triaged"]);
         assert!(is_eligible(&issue));
     }
 
     #[test]
     fn standardized_issue_is_eligible() {
-        let issue = make_issue(&["priority:high", "complexity:simple"]);
+        let issue = make_issue(&["priority:high", "complexity:low"]);
         assert!(is_eligible(&issue));
     }
 
     #[test]
     fn missing_priority_high_not_eligible() {
-        let issue = make_issue(&["complexity:simple", "triaged"]);
+        let issue = make_issue(&["complexity:low", "triaged"]);
         assert!(!is_eligible(&issue));
     }
 
@@ -1018,20 +848,26 @@ mod tests {
     }
 
     #[test]
+    fn legacy_labels_are_not_eligible() {
+        let issue = make_issue(&["priority: high", "complexity: low", "triaged"]);
+        assert!(!is_eligible(&issue));
+    }
+
+    #[test]
     fn triaged_not_required_for_eligibility() {
-        let issue = make_issue(&["priority:high", "complexity:simple"]);
+        let issue = make_issue(&["priority:high", "complexity:low"]);
         assert!(is_eligible(&issue));
     }
 
     #[test]
     fn in_progress_not_eligible() {
-        let issue = make_issue(&["priority:high", "complexity:simple", "triaged", "in-progress"]);
+        let issue = make_issue(&["priority:high", "complexity:low", "triaged", "in-progress"]);
         assert!(!is_eligible(&issue));
     }
 
     #[test]
     fn finished_by_worker_not_eligible() {
-        let issue = make_issue(&["priority:high", "complexity:simple", "triaged", "finished-by-worker"]);
+        let issue = make_issue(&["priority:high", "complexity:low", "triaged", "finished-by-worker"]);
         assert!(!is_eligible(&issue));
     }
 
@@ -1039,7 +875,7 @@ mod tests {
     fn pick_eligible_returns_first_match() {
         let issues = vec![
             make_issue(&["priority:low"]),
-            make_issue(&["priority:high", "complexity:simple"]),
+            make_issue(&["priority:high", "complexity:low"]),
         ];
         let picked = pick_eligible_issue(&issues);
         assert!(picked.is_some());
@@ -1049,49 +885,9 @@ mod tests {
     fn pick_eligible_returns_none_when_no_match() {
         let issues = vec![
             make_issue(&["priority:low"]),
-            make_issue(&["in-progress", "priority:high", "complexity:simple"]),
+            make_issue(&["in-progress", "priority:high", "complexity:low"]),
         ];
         assert!(pick_eligible_issue(&issues).is_none());
-    }
-
-    #[test]
-    fn migration_plan_rewrites_legacy_labels() {
-        let issue = make_issue(&["priority: high", "complexity: low"]);
-        let migration = migration_for_issue(&issue);
-        assert_eq!(
-            migration,
-            LabelMigration {
-                add: vec!["complexity:simple".to_string(), "priority:high".to_string()],
-                remove: vec!["complexity: low".to_string(), "priority: high".to_string()],
-            }
-        );
-    }
-
-    #[test]
-    fn migration_plan_does_not_add_triaged_for_maintainer_issues() {
-        let issue = make_issue(&["filed-by-maintainer", "priority:high", "complexity:simple"]);
-        let migration = migration_for_issue(&issue);
-        assert_eq!(
-            migration,
-            LabelMigration {
-                add: vec![],
-                remove: vec![],
-            }
-        );
-    }
-
-    #[test]
-    fn apply_issue_migration_updates_issue_labels() {
-        let mut issue = make_issue(&["filed-by-maintainer", "priority: high", "complexity: low"]);
-        let migration = migration_for_issue(&issue);
-        apply_issue_migration(&mut issue, &migration);
-
-        let labels: Vec<&str> = issue.labels.iter().map(|label| label.name.as_str()).collect();
-        assert!(labels.contains(&"filed-by-maintainer"));
-        assert!(labels.contains(&"priority:high"));
-        assert!(labels.contains(&"complexity:simple"));
-        assert!(!labels.contains(&"priority: high"));
-        assert!(!labels.contains(&"complexity: low"));
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -146,7 +146,7 @@
       command("add_github_label", {
         repoPath,
         issueNumber: issue.number,
-        label: complexity === "high" ? "complexity:high" : "complexity:simple",
+        label: complexity === "high" ? "complexity:high" : "complexity:low",
         description: complexity === "high" ? "Multi-step task, needs capable agents" : "Quick task, suitable for simple agents",
         color: complexity === "high" ? "FAB387" : "89DCEB",
       }).catch((e: unknown) => showToast(`Failed to add complexity label: ${e}`, "error"));

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -40,7 +40,9 @@ vi.mock("./lib/Toast.svelte", () => ({ default: function MockToast() {} }));
 vi.mock("./lib/HotkeyManager.svelte", () => ({ default: function MockHotkeyManager() {} }));
 vi.mock("./lib/HotkeyHelp.svelte", () => ({ default: function MockHotkeyHelp() {} }));
 
-vi.mock("./lib/CreateIssueModal.svelte", () => ({ default: function MockCreateIssueModal() {} }));
+vi.mock("./lib/CreateIssueModal.svelte", async () => ({
+  default: (await import("./test/CreateIssueModalMock.svelte")).default,
+}));
 vi.mock("./lib/IssuePickerModal.svelte", async () => ({
   default: (await import("./test/IssuePickerModalMock.svelte")).default,
 }));
@@ -376,6 +378,71 @@ describe("App issue picker flow", () => {
         githubIssue: expect.objectContaining({ number: 42 }),
         kind: "codex",
         background: true,
+      }));
+    });
+  });
+});
+
+describe("App issue creation flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error compile-time constants injected in app builds
+    globalThis.__BUILD_COMMIT__ = "test-commit";
+    // @ts-expect-error compile-time constants injected in app builds
+    globalThis.__BUILD_BRANCH__ = "test-branch";
+    // @ts-expect-error compile-time constants injected in app builds
+    globalThis.__DEV_PORT__ = "1420";
+
+    projects.set([{ ...baseProject, maintainer: { enabled: false, interval_minutes: 60 }, auto_worker: { enabled: false }, prompts: [], staged_session: null }]);
+    activeSessionId.set(null);
+    focusTarget.set({ type: "project", projectId: "proj-1" });
+    hotkeyAction.set(null);
+    showKeyHints.set(false);
+    sidebarVisible.set(true);
+    selectedSessionProvider.set("claude");
+    onboardingComplete.set(true);
+    appConfig.set({ projects_root: "/tmp/projects" });
+    sessionStatuses.set(new Map());
+    expandedProjects.set(new Set());
+
+    vi.mocked(command).mockImplementation(async (cmd: string) => {
+      if (cmd === "restore_sessions") return;
+      if (cmd === "check_onboarding") return { projects_root: "/tmp/projects" };
+      if (cmd === "generate_issue_body") return "Generated body";
+      if (cmd === "create_github_issue") {
+        return {
+          number: 77,
+          title: "Mock issue",
+          url: "https://example.com/issues/77",
+          body: "Generated body",
+          labels: [],
+        };
+      }
+      if (cmd === "list_projects") {
+        return {
+          projects: [{ ...baseProject, maintainer: { enabled: false, interval_minutes: 60 }, auto_worker: { enabled: false }, prompts: [], staged_session: null, sessions: [] }],
+          corrupt_entries: [],
+        };
+      }
+      return;
+    });
+  });
+
+  it("creates low-complexity issues with the canonical complexity:low label", async () => {
+    render(App);
+
+    hotkeyAction.set({
+      type: "create-issue",
+      projectId: "proj-1",
+      repoPath: "/tmp/the-controller",
+    });
+
+    await fireEvent.click(await screen.findByTestId("mock-create-issue-submit"));
+
+    await waitFor(() => {
+      expect(command).toHaveBeenCalledWith("add_github_label", expect.objectContaining({
+        issueNumber: 77,
+        label: "complexity:low",
       }));
     });
   });

--- a/src/lib/AgentDashboard.svelte
+++ b/src/lib/AgentDashboard.svelte
@@ -451,7 +451,7 @@
           <span class="policy-label">Required</span>
           <div class="policy-labels">
             <span class="policy-tag required">priority:high</span>
-            <span class="policy-tag required">complexity:simple</span>
+            <span class="policy-tag required">complexity:low</span>
           </div>
         </div>
         <div class="policy-row">

--- a/src/lib/AgentDashboard.test.ts
+++ b/src/lib/AgentDashboard.test.ts
@@ -75,6 +75,7 @@ describe("AgentDashboard auto-worker pane", () => {
     });
 
     expect(screen.getByText("assigned-to-auto-worker")).toBeInTheDocument();
+    expect(screen.getByText("complexity:low")).toBeInTheDocument();
     expect(screen.queryByText("finished-by-worker")).not.toBeInTheDocument();
   });
 

--- a/src/lib/TriagePanel.svelte
+++ b/src/lib/TriagePanel.svelte
@@ -129,7 +129,7 @@
       command("add_github_label", {
         repoPath: path,
         issueNumber: issue.number,
-        label: complexity === "low" ? "complexity:simple" : "complexity:high",
+        label: complexity === "low" ? "complexity:low" : "complexity:high",
         description: complexity === "low" ? "Quick task, suitable for simple agents" : "Multi-step task, needs capable agents",
         color: complexity === "low" ? "89DCEB" : "FAB387",
       }).catch((e: unknown) => showToast(`Failed to label #${issue.number}: ${e}`, "error"));

--- a/src/lib/TriagePanel.test.ts
+++ b/src/lib/TriagePanel.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { command } from "$lib/backend";
+import TriagePanel from "./TriagePanel.svelte";
+import { focusTarget, projects, type Project } from "./stores";
+
+const baseProject: Project = {
+  id: "project-1",
+  name: "Controller",
+  repo_path: "/tmp/controller",
+  created_at: "2026-03-10T00:00:00Z",
+  archived: false,
+  sessions: [],
+  maintainer: {
+    enabled: false,
+    interval_minutes: 60,
+    github_repo: null,
+  },
+  auto_worker: { enabled: false },
+  prompts: [],
+  staged_session: null,
+};
+
+describe("TriagePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    projects.set([baseProject]);
+    focusTarget.set({ type: "project", projectId: "project-1" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes the canonical complexity:low label for low-complexity triage", async () => {
+    vi.mocked(command).mockImplementation(async (cmd: string) => {
+      if (cmd === "list_github_issues") {
+        return [
+          {
+            number: 42,
+            title: "Normalize complexity labels",
+            url: "https://example.com/issues/42",
+            body: "Body",
+            labels: [],
+          },
+        ];
+      }
+
+      return undefined;
+    });
+
+    render(TriagePanel, {
+      props: {
+        category: "untriaged",
+        onClose: vi.fn(),
+      },
+    });
+
+    await screen.findByText("Normalize complexity labels");
+
+    await fireEvent.click(screen.getByText("Low priority"));
+    await fireEvent.click(await screen.findByText("Low complexity"));
+    await vi.advanceTimersByTimeAsync(300);
+
+    await waitFor(() => {
+      expect(command).toHaveBeenCalledWith("add_github_label", expect.objectContaining({
+        issueNumber: 42,
+        label: "complexity:low",
+      }));
+    });
+  });
+});

--- a/src/test/CreateIssueModalMock.svelte
+++ b/src/test/CreateIssueModalMock.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  type Priority = "high" | "low";
+  type Complexity = "high" | "low";
+
+  let {
+    onSubmit,
+    onClose,
+  }: {
+    onSubmit: (title: string, priority: Priority, complexity: Complexity) => void;
+    onClose: () => void;
+  } = $props();
+</script>
+
+<button
+  type="button"
+  data-testid="mock-create-issue-submit"
+  onclick={() => onSubmit("Mock issue", "low", "low")}
+>
+  Submit issue
+</button>
+<button type="button" data-testid="mock-create-issue-close" onclick={onClose}>Close issue modal</button>


### PR DESCRIPTION
## Summary
- standardize frontend issue flows on `complexity:low`
- remove auto-worker legacy label migration and keep canonical labels only
- add regression coverage for canonical labels and strict legacy rejection

## Verification
- npx vitest run
- cargo test --manifest-path src-tauri/Cargo.toml