### PR TITLE
fix(notes): exit editor on escape in normal mode

### DIFF
--- a/docs/plans/2026-03-10-notes-escape-normal-mode-design.md
+++ b/docs/plans/2026-03-10-notes-escape-normal-mode-design.md
@@ -1,0 +1,26 @@
+# Notes Escape Normal Mode Design
+
+## Definition
+
+Refine notes-editor Vim integration so `Escape` behaves like a true "back out" key: when the editor is already in Vim normal mode, a single `Escape` should leave the editor and return focus to the selected note row in the sidebar.
+
+## Constraints
+
+- Preserve standard Vim behavior for insert and visual mode transitions.
+- Keep notes editing inside the current CodeMirror + `@replit/codemirror-vim` implementation.
+- Do not route editor keystrokes back through the global hotkey manager while the editor is focused.
+- Remove the timing-based double-escape requirement from notes mode.
+- Prove the behavior with regression tests before implementation changes.
+
+## Chosen Design
+
+Track the editor's current Vim mode inside the CodeMirror wrapper by subscribing to the plugin's `vim-mode-change` signal. Pass that mode to `NotesEditor` alongside `Escape` key events. `NotesEditor` should move focus back to the selected note only when it receives `Escape` while the editor reports Vim normal mode. In insert, replace, or visual modes, `Escape` should remain editor-local so Vim can handle its normal mode transition.
+
+This keeps the app aligned with user intent: the first `Escape` exits edit submodes, and once the editor is already at the top-level Vim state, the next `Escape` exits back to sidebar navigation.
+
+## Validation
+
+- Add a failing notes-editor test proving `Escape` in normal mode moves focus to the selected note row immediately.
+- Add a failing notes-editor test proving `Escape` in insert mode does not move focus out of the editor.
+- Run the focused notes-editor tests red, implement the smallest change, then rerun green.
+- Run the full notes-editor test file after implementation.

--- a/docs/plans/2026-03-10-notes-escape-normal-mode.md
+++ b/docs/plans/2026-03-10-notes-escape-normal-mode.md
@@ -1,0 +1,69 @@
+# Notes Escape Normal Mode Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Make a single `Escape` leave the notes editor only when Vim is already in normal mode.
+
+**Architecture:** Extend the CodeMirror Vim wrapper to surface mode changes to `NotesEditor`, then replace the notes editor's timing-based double-escape logic with a mode-aware focus transition. Cover the change with focused regression tests in `NotesEditor.test.ts`.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest, Testing Library, CodeMirror 6, `@replit/codemirror-vim`
+
+---
+
+### Task 1: Lock in the new escape behavior with failing tests
+
+**Files:**
+- Modify: `src/lib/NotesEditor.test.ts`
+
+**Step 1: Write the failing test**
+
+Replace the old double-escape regression with:
+- a test proving one `Escape` in normal mode moves focus to `{ type: "note", ... }`
+- a test proving after entering insert mode, one `Escape` keeps focus on `{ type: "notes-editor", ... }`
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/NotesEditor.test.ts`
+Expected: FAIL because the current implementation still requires a second `Escape` and does not know the Vim mode.
+
+### Task 2: Surface Vim mode from the editor wrapper
+
+**Files:**
+- Modify: `src/lib/CodeMirrorNoteEditor.svelte`
+
+**Step 1: Write minimal implementation**
+
+- Add an `onModeChange` callback prop.
+- Use `getCM(view)` from `@replit/codemirror-vim` to subscribe to `vim-mode-change`.
+- Track the latest Vim mode and include it when invoking the escape callback.
+
+**Step 2: Run targeted tests**
+
+Run: `npx vitest run src/lib/NotesEditor.test.ts`
+Expected: still FAIL until `NotesEditor` consumes the mode.
+
+### Task 3: Replace double-escape timing with mode-aware focus exit
+
+**Files:**
+- Modify: `src/lib/NotesEditor.svelte`
+
+**Step 1: Write minimal implementation**
+
+- Remove the timing state used for double-escape detection.
+- Track the latest Vim mode reported by `CodeMirrorNoteEditor`.
+- On `Escape`, move focus back to the selected note only when the mode is `normal`.
+
+**Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/NotesEditor.test.ts`
+Expected: PASS
+
+### Task 4: Final verification
+
+**Files:**
+- No code changes expected
+
+**Step 1: Run verification**
+
+Run: `npx vitest run src/lib/NotesEditor.test.ts`
+Expected: PASS with no failures in the file.

--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -2,19 +2,23 @@
   import { EditorState } from "@codemirror/state";
   import { EditorView, drawSelection } from "@codemirror/view";
   import { markdown } from "@codemirror/lang-markdown";
-  import { vim } from "@replit/codemirror-vim";
+  import { getCM, vim } from "@replit/codemirror-vim";
+
+  export type VimMode = "normal" | "insert" | "visual" | "replace";
 
   interface Props {
     value: string;
     focused?: boolean;
     onChange?: (value: string) => void;
-    onEscape?: () => void;
+    onEscape?: (mode: VimMode | string) => void;
+    onModeChange?: (mode: VimMode | string) => void;
   }
 
-  let { value, focused = false, onChange, onEscape }: Props = $props();
+  let { value, focused = false, onChange, onEscape, onModeChange }: Props = $props();
 
   let hostEl: HTMLDivElement | undefined;
   let view: EditorView | null = null;
+  let currentMode: VimMode | string = "normal";
 
   function buildState(doc: string) {
     return EditorState.create({
@@ -27,7 +31,7 @@
         EditorView.domEventHandlers({
           keydown: (event) => {
             if (event.key === "Escape") {
-              onEscape?.();
+              onEscape?.(currentMode);
             }
             return false;
           },
@@ -49,7 +53,19 @@
       parent: hostEl,
     });
 
+    currentMode = "normal";
+    onModeChange?.(currentMode);
+
+    const cm = getCM(view);
+    const handleModeChange = (event: { mode?: string }) => {
+      currentMode = event.mode ?? "normal";
+      onModeChange?.(currentMode);
+    };
+
+    cm?.on("vim-mode-change", handleModeChange);
+
     return () => {
+      cm?.off("vim-mode-change", handleModeChange);
       view?.destroy();
       view = null;
     };

--- a/src/lib/NotesEditor.svelte
+++ b/src/lib/NotesEditor.svelte
@@ -3,14 +3,14 @@
   import { untrack } from "svelte";
   import { command } from "$lib/backend";
   import { activeNote, noteViewMode, projects, focusTarget, hotkeyAction, type NoteViewMode, type Project, type FocusTarget } from "./stores";
-  import CodeMirrorNoteEditor from "./CodeMirrorNoteEditor.svelte";
+  import CodeMirrorNoteEditor, { type VimMode } from "./CodeMirrorNoteEditor.svelte";
   import { renderMarkdown } from "./markdown";
 
   let content = $state("");
   let savedContent = $state("");
   let loading = $state(true);
   let saveTimer: ReturnType<typeof setTimeout> | null = $state(null);
-  let lastEditorEscapeAt = $state(0);
+  let editorMode = $state<VimMode | string>("normal");
 
   const activeNoteState = fromStore(activeNote);
   let currentNote = $derived(activeNoteState.current);
@@ -139,18 +139,14 @@
     scheduleSave();
   }
 
-  function handleEditorEscape() {
-    const now = Date.now();
-    if (now - lastEditorEscapeAt < 300) {
-      lastEditorEscapeAt = 0;
-      void saveNow();
-      if (currentNote) {
-        focusTarget.set({ type: "note", filename: currentNote.filename, projectId: currentNote.projectId });
-      }
-      return;
-    }
+  function handleEditorEscape(mode: VimMode | string) {
+    editorMode = mode;
+    if (editorMode !== "normal") return;
 
-    lastEditorEscapeAt = now;
+    void saveNow();
+    if (currentNote) {
+      focusTarget.set({ type: "note", filename: currentNote.filename, projectId: currentNote.projectId });
+    }
   }
 
   function setViewMode(mode: NoteViewMode) {
@@ -204,6 +200,9 @@
           value={content}
           focused={editorFocused}
           onChange={handleEditorChange}
+          onModeChange={(mode) => {
+            editorMode = mode;
+          }}
           onEscape={handleEditorEscape}
         />
       {/if}

--- a/src/lib/NotesEditor.test.ts
+++ b/src/lib/NotesEditor.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { command } from "$lib/backend";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 import NotesEditor from "./NotesEditor.svelte";
@@ -112,7 +113,7 @@ describe("NotesEditor", () => {
     expect(await screen.findByTestId("note-code-editor")).toBeInTheDocument();
   });
 
-  it("keeps focus in the editor on a single escape and returns to the note on double escape", async () => {
+  it("returns to the note on a single escape when vim is already in normal mode", async () => {
     vi.mocked(command).mockImplementation((commandName: string) => {
       if (commandName === "read_note") {
         return Promise.resolve("# Heading\n\nBody copy");
@@ -128,14 +129,76 @@ describe("NotesEditor", () => {
     focusTarget.set({ type: "notes-editor", projectId: "project-1" });
 
     render(NotesEditor);
+    const user = userEvent.setup();
 
     const editor = await screen.findByTestId("note-code-editor");
     const textbox = within(editor).getByRole("textbox");
+    textbox.focus();
 
-    await fireEvent.keyDown(textbox, { key: "Escape" });
+    await user.keyboard("{Escape}");
+
+    expect(get(focusTarget)).toEqual({ type: "note", filename: "a.md", projectId: "project-1" });
+  });
+
+  it("keeps escape in the editor when leaving insert mode, then exits on the next normal-mode escape", async () => {
+    vi.mocked(command).mockImplementation((commandName: string) => {
+      if (commandName === "read_note") {
+        return Promise.resolve("# Heading\n\nBody copy");
+      }
+
+      if (commandName === "write_note") {
+        return Promise.resolve(undefined);
+      }
+
+      return Promise.resolve(undefined);
+    });
+
+    focusTarget.set({ type: "notes-editor", projectId: "project-1" });
+
+    render(NotesEditor);
+    const user = userEvent.setup();
+
+    const editor = await screen.findByTestId("note-code-editor");
+    const textbox = within(editor).getByRole("textbox");
+    textbox.focus();
+
+    await user.keyboard("i");
+    await user.keyboard("{Escape}");
     expect(get(focusTarget)).toEqual({ type: "notes-editor", projectId: "project-1" });
 
-    await fireEvent.keyDown(textbox, { key: "Escape" });
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    await user.keyboard("{Escape}");
+    expect(get(focusTarget)).toEqual({ type: "note", filename: "a.md", projectId: "project-1" });
+  });
+
+  it("keeps escape in the editor when leaving visual mode, then exits on the next normal-mode escape", async () => {
+    vi.mocked(command).mockImplementation((commandName: string) => {
+      if (commandName === "read_note") {
+        return Promise.resolve("# Heading\n\nBody copy");
+      }
+
+      if (commandName === "write_note") {
+        return Promise.resolve(undefined);
+      }
+
+      return Promise.resolve(undefined);
+    });
+
+    focusTarget.set({ type: "notes-editor", projectId: "project-1" });
+
+    render(NotesEditor);
+    const user = userEvent.setup();
+
+    const editor = await screen.findByTestId("note-code-editor");
+    const textbox = within(editor).getByRole("textbox");
+    textbox.focus();
+
+    await user.keyboard("v");
+    await user.keyboard("{Escape}");
+    expect(get(focusTarget)).toEqual({ type: "notes-editor", projectId: "project-1" });
+
+    await user.keyboard("{Escape}");
     expect(get(focusTarget)).toEqual({ type: "note", filename: "a.md", projectId: "project-1" });
   });
 

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -5,3 +5,13 @@ vi.mock('$lib/backend', () => ({
   command: vi.fn().mockResolvedValue(undefined),
   listen: vi.fn(() => () => {}),
 }));
+
+if (!Range.prototype.getClientRects) {
+  Range.prototype.getClientRects = function getClientRects() {
+    return {
+      length: 0,
+      item: () => null,
+      [Symbol.iterator]: function* emptyIterator() {},
+    } as DOMRectList;
+  };
+}


### PR DESCRIPTION
## Summary
- exit the notes editor on a single Escape when Vim is already in normal mode
- keep Escape local while leaving insert and visual modes
- add regression coverage for normal, insert, and visual mode Escape behavior

## Testing
- npx vitest run