### PR TITLE
fix: retain PTY child handles

### DIFF
--- a/docs/plans/2026-03-10-pty-child-handle-design.md
+++ b/docs/plans/2026-03-10-pty-child-handle-design.md
@@ -1,0 +1,39 @@
+# PTY Child Handle Retention Design
+
+## Problem
+
+`PtyManager` spawns direct PTY sessions, tmux attachment PTYs, and short-lived direct commands through `portable-pty`, but each spawn path drops the returned child handle immediately. That leaves `close_session` with no reliable way to terminate or reap the spawned process. If the child ignores `SIGHUP`, it can outlive the session and keep resources such as a worktree open.
+
+## Constraints
+
+- Keep the fix local to PTY lifecycle management in `src-tauri/src/pty_manager.rs`.
+- Preserve existing tmux behavior: closing a tmux-backed session must still kill the tmux session itself, not just the local attachment process.
+- Add an automated regression that proves the bug and the fix, rather than relying on a structural assertion.
+
+## Options Considered
+
+### 1. Keep relying on PTY teardown
+
+Rejected. Closing the PTY master depends on child signal handling and does not guarantee termination or reaping.
+
+### 2. Store the spawned child handle in `PtySession`
+
+Chosen. This gives `close_session` ownership of the child lifecycle so it can terminate and reap the process explicitly before dropping the PTY session state.
+
+### 3. Add a separate background reaper
+
+Rejected. It adds complexity and shared-state coordination for a bug that can be fixed directly where the session is owned and closed.
+
+## Design
+
+- Extend `PtySession` with a `child: Box<dyn portable_pty::Child + Send + Sync>` field.
+- Update `spawn_direct_session`, `attach_tmux_session`, and `spawn_command` to store the returned child handle in the session record.
+- In `close_session`, call `try_wait()` first. If the child is still running, call `kill()` and then `wait()` to reap it before the session is dropped.
+- Preserve the existing tmux cleanup path by still calling `TmuxManager::kill_session(session_id)` for tmux-backed sessions after the local child is handled.
+
+## Validation
+
+- Add a Unix regression test that starts `/bin/sh`, writes its PID to a file, installs `trap '' HUP`, loops forever, and then verifies `close_session` makes the process disappear.
+- Run the regression test red before the fix.
+- Run the regression test green after the fix.
+- Run the PTY manager tests and the full Rust test suite after the implementation.

--- a/docs/plans/2026-03-10-pty-child-handle.md
+++ b/docs/plans/2026-03-10-pty-child-handle.md
@@ -1,0 +1,66 @@
+# PTY Child Handle Retention Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use the-controller-executing-plans to implement this plan task-by-task.
+
+**Goal:** Retain PTY child handles so `close_session` can explicitly terminate and reap spawned processes.
+
+**Architecture:** Extend `PtySession` to own the `portable-pty` child handle, update each spawn path to keep that handle alive, and add a regression test that proves `close_session` terminates a child that ignores `SIGHUP`. The close path should reap the child before any tmux-specific cleanup runs.
+
+**Tech Stack:** Rust, portable-pty, Cargo tests
+
+---
+
+### Task 1: Reproduce the lifecycle bug with a failing regression test
+
+**Files:**
+- Modify: `src-tauri/src/pty_manager.rs`
+- Test: `src-tauri/src/pty_manager.rs`
+
+**Step 1: Write the failing test**
+
+Add a Unix-only unit test that:
+- Spawns `/bin/sh` through `spawn_command`
+- Writes the shell PID to a temp file
+- Installs `trap '' HUP`
+- Loops forever
+- Calls `close_session`
+- Asserts the PID exits within a short timeout
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test close_session_kills_direct_child_that_ignores_sighup -- --nocapture`
+Expected: FAIL because the shell process survives `close_session`
+
+**Step 3: Commit**
+
+Do not commit yet. Continue to Task 2 once the failing behavior is confirmed.
+
+### Task 2: Retain the child handle and close it explicitly
+
+**Files:**
+- Modify: `src-tauri/src/pty_manager.rs`
+- Test: `src-tauri/src/pty_manager.rs`
+
+**Step 1: Write minimal implementation**
+
+- Add `child` to `PtySession`
+- Store the child handle in all three spawn paths
+- In `close_session`, `try_wait()` first, then `kill()` and `wait()` if the child is still alive
+- Preserve existing tmux cleanup
+
+**Step 2: Run targeted tests to verify they pass**
+
+Run: `cargo test pty_manager::tests`
+Expected: PASS
+
+**Step 3: Run full verification**
+
+Run: `cargo test`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-10-pty-child-handle-design.md docs/plans/2026-03-10-pty-child-handle.md src-tauri/src/pty_manager.rs
+git commit
+```

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -1,5 +1,5 @@
 use base64::Engine;
-use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
@@ -21,6 +21,7 @@ fn build_tmux_attach_command(tmux_bin: &str, tmux_name: &str) -> CommandBuilder 
 pub struct PtySession {
     master: Box<dyn MasterPty + Send>,
     writer: Box<dyn Write + Send>,
+    child: Box<dyn Child + Send + Sync>,
     alive: Arc<Mutex<bool>>,
     tmux_session: bool,
 }
@@ -122,7 +123,7 @@ impl PtyManager {
             cmd.arg(arg);
         }
 
-        let _child = pair
+        let child = pair
             .slave
             .spawn_command(cmd)
             .map_err(|e| format!("failed to spawn {}: {}", command, e))?;
@@ -174,6 +175,7 @@ impl PtyManager {
         let session = PtySession {
             master: pair.master,
             writer,
+            child,
             alive,
             tmux_session: false,
         };
@@ -208,7 +210,7 @@ impl PtyManager {
             TmuxManager::tmux_binary().ok_or_else(|| "tmux binary not found".to_string())?;
         let cmd = build_tmux_attach_command(&tmux_bin, &tmux_name);
 
-        let _child = pair
+        let child = pair
             .slave
             .spawn_command(cmd)
             .map_err(|e| format!("failed to spawn tmux attach: {}", e))?;
@@ -260,6 +262,7 @@ impl PtyManager {
         let session = PtySession {
             master: pair.master,
             writer,
+            child,
             alive,
             tmux_session: true,
         };
@@ -293,7 +296,7 @@ impl PtyManager {
         }
         cmd.env_remove("CLAUDECODE");
 
-        let _child = pair
+        let child = pair
             .slave
             .spawn_command(cmd)
             .map_err(|e| format!("failed to spawn {}: {}", program, e))?;
@@ -345,6 +348,7 @@ impl PtyManager {
         let session = PtySession {
             master: pair.master,
             writer,
+            child,
             alive,
             tmux_session: false,
         };
@@ -429,7 +433,14 @@ impl PtyManager {
 
     /// Close a session. For tmux-backed sessions, also kills the tmux session.
     pub fn close_session(&mut self, session_id: Uuid) -> Result<(), String> {
-        let session = self.sessions.remove(&session_id);
+        let mut session = self.sessions.remove(&session_id);
+
+        if let Some(s) = session.as_mut() {
+            if !matches!(s.child.try_wait(), Ok(Some(_))) {
+                let _ = s.child.kill();
+                let _ = s.child.wait();
+            }
+        }
 
         if let Some(s) = &session {
             if s.tmux_session {
@@ -488,6 +499,47 @@ mod tests {
         while Instant::now() < deadline {
             let log = fs::read_to_string(log_path).unwrap_or_default();
             if log.contains(needle) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        false
+    }
+
+    #[cfg(unix)]
+    fn wait_for_pid_file(pid_path: &Path) -> u32 {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if let Ok(pid) = fs::read_to_string(pid_path)
+                .ok()
+                .and_then(|contents| contents.trim().parse::<u32>().ok())
+                .ok_or(())
+            {
+                return pid;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        panic!("timed out waiting for pid file at {}", pid_path.display());
+    }
+
+    #[cfg(unix)]
+    fn process_is_alive(pid: u32) -> bool {
+        std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(unix)]
+    fn wait_for_process_exit(pid: u32) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if !process_is_alive(pid) {
                 return true;
             }
             std::thread::sleep(Duration::from_millis(10));
@@ -576,6 +628,57 @@ mod tests {
         assert!(wait_for_log_entry(&log_path, "attach-session"));
 
         let _ = manager.close_session(session_id);
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_close_session_kills_direct_child_that_ignores_sighup() {
+        let temp_dir = make_temp_dir("close-session-kills-child");
+        let script_path = temp_dir.join("ignore-sighup.sh");
+        let pid_path = temp_dir.join("child.pid");
+
+        fs::write(
+            &script_path,
+            format!(
+                "echo $$ > '{}'\ntrap '' HUP\nwhile true; do sleep 1; done\n",
+                pid_path.display()
+            ),
+        )
+        .unwrap();
+
+        let mut manager = PtyManager::new();
+        let session_id = Uuid::new_v4();
+        manager
+            .spawn_command(
+                session_id,
+                "/bin/sh",
+                &[script_path.to_str().unwrap()],
+                NoopEmitter::new(),
+            )
+            .expect("spawn should succeed");
+
+        let pid = wait_for_pid_file(&pid_path);
+        assert!(
+            process_is_alive(pid),
+            "test child should be running before close_session"
+        );
+
+        manager.close_session(session_id).unwrap();
+
+        let exited = wait_for_process_exit(pid);
+        if !exited {
+            let _ = std::process::Command::new("kill")
+                .arg("-9")
+                .arg(pid.to_string())
+                .status();
+        }
+
+        assert!(
+            exited,
+            "close_session should terminate a PTY child even if it ignores SIGHUP"
+        );
+
         let _ = fs::remove_dir_all(&temp_dir);
     }
 }


### PR DESCRIPTION
## Summary
- retain the PTY child handle inside `PtySession` for all spawn paths
- explicitly kill and reap the child during `close_session` before tmux cleanup
- add a regression test for a child that ignores `SIGHUP`, plus design/plan notes

## Verification
- `cargo test close_session_kills_direct_child_that_ignores_sighup -- --nocapture`
- `cargo test pty_manager::tests`
- `cargo test`
- `npm install`
- `npx vitest run`

closes #245
