### PR TITLE
fix: map vim edit keys (o, i, a) to open note editor in notes mode

### DIFF
--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { command } from '$lib/backend';
-import { projects, activeSessionId, hotkeyAction, focusTarget, sidebarVisible, controllerChatVisible, expandedProjects, workspaceMode, workspaceModePickerVisible, selectedSessionProvider, type Project, type SessionConfig } from './stores';
+import { projects, activeSessionId, hotkeyAction, focusTarget, sidebarVisible, controllerChatVisible, expandedProjects, workspaceMode, workspaceModePickerVisible, selectedSessionProvider, activeNote, noteEntries, type Project, type SessionConfig } from './stores';
 import HotkeyManager from './HotkeyManager.svelte';
 
 function makeSession(id: string, label: string, kind = 'claude'): SessionConfig {
@@ -758,6 +758,40 @@ describe('HotkeyManager', () => {
       pressKey(' ');
       expect(get(workspaceModePickerVisible)).toBe(false);
       removeTerminalFocus(xtermEl);
+    });
+  });
+
+  // ── Notes mode keys ──
+
+  describe('notes mode keys', () => {
+    beforeEach(() => {
+      workspaceMode.set('notes');
+      noteEntries.set(new Map([['proj-1', [{ filename: 'todo.md', modified_at: '2026-01-01' }]]]));
+    });
+
+    afterEach(() => {
+      workspaceMode.set('development');
+    });
+
+    it('o on a focused note opens the note editor', () => {
+      focusTarget.set({ type: 'note', filename: 'todo.md', projectId: 'proj-1' });
+      pressKey('o');
+      expect(get(activeNote)).toEqual({ projectId: 'proj-1', filename: 'todo.md' });
+      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1' });
+    });
+
+    it('i on a focused note opens the note editor', () => {
+      focusTarget.set({ type: 'note', filename: 'todo.md', projectId: 'proj-1' });
+      pressKey('i');
+      expect(get(activeNote)).toEqual({ projectId: 'proj-1', filename: 'todo.md' });
+      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1' });
+    });
+
+    it('a on a focused note opens the note editor', () => {
+      focusTarget.set({ type: 'note', filename: 'todo.md', projectId: 'proj-1' });
+      pressKey('a');
+      expect(get(activeNote)).toEqual({ projectId: 'proj-1', filename: 'todo.md' });
+      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1' });
     });
   });
 

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -112,7 +112,9 @@ describe("command registry", () => {
     expect(map.has("p")).toBe(true);  // toggle-note-preview (notes)
     expect(map.get("p")).toBe("toggle-note-preview");
     expect(map.has("c")).toBe(false); // create-session is dev-only
-    expect(map.has("o")).toBe(false); // toggle-mode is dev-only, toggle-agent is agents-only
+    expect(map.get("o")).toBe("expand-collapse"); // open note for editing
+    expect(map.get("i")).toBe("expand-collapse"); // open note for editing
+    expect(map.get("a")).toBe("expand-collapse"); // open note for editing
   });
 
   it("buildKeyMap without mode includes all non-external commands", () => {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -106,6 +106,9 @@ export const commands: CommandDef[] = [
   { id: "delete-note", key: "d", section: "Notes", description: "Delete focused note", mode: "notes" },
   { id: "rename-note", key: "r", section: "Notes", description: "Rename focused note", mode: "notes" },
   { id: "toggle-note-preview", key: "p", section: "Notes", description: "Cycle edit / preview / split", mode: "notes" },
+  { id: "expand-collapse", key: "o", section: "Notes", description: "Open note for editing", mode: "notes", hidden: true },
+  { id: "expand-collapse", key: "i", section: "Notes", description: "Open note for editing", mode: "notes", hidden: true },
+  { id: "expand-collapse", key: "a", section: "Notes", description: "Open note for editing", mode: "notes", hidden: true },
 ];
 
 // Section order for help display


### PR DESCRIPTION
## Summary
- When focused on a note sidebar item in notes mode, vim "enter edit" keys (`o`, `i`, `a`) now open the note editor
- Previously these keys did nothing — `o` was only mapped to "toggle-mode" in development mode and "toggle-agent" in agents mode
- Maps all three keys to the existing `expand-collapse` command (same as `l`/`Enter` on a note)

## Test plan
- [x] Added tests for `o`, `i`, `a` on focused note items in notes mode
- [x] Verified all 230 tests pass
- [x] Verified no conflicts with existing key mappings in other modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)