### PR TITLE
fix: route screenshot sessions to controller project

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -238,10 +238,13 @@
   }
 
   async function screenshotToNewSession(preview: boolean, cropped: boolean) {
-    const project = getTargetProject();
+    // IMPORTANT: Screenshot sessions are a core personalization feature — they let
+    // users debug and modify the controller from within itself. This must always
+    // target the controller project, never the focused project.
+    const project = projectsState.current.find((p) => p.name === "the-controller");
 
     if (!project) {
-      showToast("Select a project before starting a screenshot session", "error");
+      showToast("The controller project must be loaded to use screenshot sessions", "error");
       return;
     }
 

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -136,17 +136,20 @@ describe("App screenshot flow", () => {
     expect(mocks.openPath).not.toHaveBeenCalled();
   });
 
-  it("uses the focused project for screenshot sessions even when the project name differs", async () => {
+  it("always routes screenshot sessions to the controller project, ignoring focus", async () => {
+    const controllerProject = { ...baseProject, id: "proj-controller", name: "the-controller", repo_path: "/tmp/the-controller" };
+    const otherProject = { ...baseProject, id: "proj-other", name: "client-app", repo_path: "/tmp/client-app" };
     setupMocks();
-    projects.set([{ ...baseProject, name: "client-app", repo_path: "/tmp/client-app" }]);
-    focusTarget.set({ type: "project", projectId: "proj-1" });
+    projects.set([otherProject, controllerProject]);
+    // Focus is on a different project — screenshot should still go to the-controller
+    focusTarget.set({ type: "project", projectId: "proj-other" });
 
     render(App);
     hotkeyAction.set({ type: "screenshot-to-session" });
 
     await waitFor(() => {
       expect(command).toHaveBeenCalledWith("create_session", expect.objectContaining({
-        projectId: "proj-1",
+        projectId: "proj-controller",
         kind: "claude",
         initialPrompt: expect.stringContaining("/tmp/the-controller-screenshot.png"),
       }));


### PR DESCRIPTION
## Summary
- Screenshot sessions (Cmd+S/Cmd+D) were incorrectly routed to the focused project instead of always targeting the controller project
- Fixed regression: screenshots are a core personalization feature for debugging/modifying the controller from within itself
- Updated test to verify routing ignores focus and always targets the controller project

## Test plan
- [x] Existing screenshot tests updated and passing (227/227 frontend, 16/16 Rust)
- [x] New test: "always routes screenshot sessions to the controller project, ignoring focus"

🤖 Generated with [Claude Code](https://claude.com/claude-code)