### PR TITLE
fix: focus controller chat on g key and rename header

### DIFF
--- a/src/lib/GlobalChat.svelte
+++ b/src/lib/GlobalChat.svelte
@@ -140,15 +140,7 @@
 
 <aside class="global-chat" data-testid="global-chat">
   <header class="chat-header" data-testid="controller-chat-focus">
-    {#if session.focus.project_name}
-      <span class="focus-project">{session.focus.project_name}</span>
-      {#if session.focus.note_filename}
-        <span class="focus-separator">/</span>
-        <span class="focus-note">{session.focus.note_filename}</span>
-      {/if}
-    {:else}
-      <span class="focus-empty">No focus</span>
-    {/if}
+    controller-chat
   </header>
 
   <div class="transcript" data-testid="controller-chat-transcript">
@@ -203,21 +195,6 @@
     align-items: center;
     gap: 4px;
     min-height: 20px;
-  }
-
-  .focus-project {
-    color: #cdd6f4;
-  }
-
-  .focus-separator {
-    color: #6c7086;
-  }
-
-  .focus-note {
-    color: #bac2de;
-  }
-
-  .focus-empty {
     color: #6c7086;
   }
 

--- a/src/lib/GlobalChat.test.ts
+++ b/src/lib/GlobalChat.test.ts
@@ -70,7 +70,7 @@ describe("GlobalChat", () => {
 
     expect(await screen.findByText("controller.create_note(issue-123.md)")).toBeInTheDocument();
     expect(screen.getByText("Created the note and opened it.")).toBeInTheDocument();
-    expect(screen.getByTestId("controller-chat-focus")).toHaveTextContent("Project Alpha / issue-123.md");
+    expect(screen.getByTestId("controller-chat-focus")).toHaveTextContent("controller-chat");
   });
 
   it("submits a user message through send_controller_chat_message", async () => {

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import { fromStore, get } from "svelte/store";
   import { command } from "$lib/backend";
   import {
@@ -316,6 +316,10 @@
         return true;
       case "toggle-controller-chat":
         controllerChatVisible.update(v => !v);
+        tick().then(() => {
+          const input = document.querySelector('[data-testid="controller-chat-input"]') as HTMLElement;
+          input?.focus();
+        });
         return true;
       case "create-issue":
         dispatchCreateIssue();


### PR DESCRIPTION
## Summary
- Pressing `g` now focuses the controller chat textarea after toggling it visible (uses Svelte `tick()` to wait for DOM update)
- Changed the controller chat header from dynamic project/note display to static "controller-chat"
- Cleaned up unused CSS classes for removed header elements

## Test plan
- [x] All 230 frontend tests pass
- [ ] Press `g` to open controller chat — textarea should receive focus
- [ ] Header should display "controller-chat"

🤖 Generated with [Claude Code](https://claude.com/claude-code)