### PR TITLE
fix: prevent token chart from being clipped by long commit lists

### DIFF
--- a/src/lib/SummaryPane.svelte
+++ b/src/lib/SummaryPane.svelte
@@ -154,6 +154,13 @@
 
   .progress-row {
     align-items: flex-start;
+    overflow-y: auto;
+    min-height: 0;
+    scrollbar-width: none;
+  }
+
+  .progress-row::-webkit-scrollbar {
+    display: none;
   }
 
   .label {


### PR DESCRIPTION
## Summary
- Make the commit list (`.progress-row`) scrollable within the summary pane so the token chart remains visible when there are many commits
- Previously, the 280px `max-height` with `overflow: hidden` on the summary pane would clip the token chart when the commit list grew long

## Test plan
- [x] Frontend tests pass (227/227)
- [x] Rust tests pass (16/16)
- [ ] Verify visually: focus a session with many commits and confirm the token chart is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)