### PR TITLE
fix: hide controller chat by default

### DIFF
--- a/src/lib/stores.test.ts
+++ b/src/lib/stores.test.ts
@@ -82,8 +82,8 @@ describe('stores', () => {
     expect(get(sidebarVisible)).toBe(true);
   });
 
-  it('controllerChatVisible defaults to true', () => {
-    expect(get(controllerChatVisible)).toBe(true);
+  it('controllerChatVisible defaults to false', () => {
+    expect(get(controllerChatVisible)).toBe(false);
   });
 
   describe('maintainerStatuses store', () => {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -261,7 +261,7 @@ export type HotkeyAction =
 export const hotkeyAction = writable<HotkeyAction>(null);
 export const showKeyHints = writable<boolean>(false);
 export const sidebarVisible = writable<boolean>(true);
-export const controllerChatVisible = writable<boolean>(true);
+export const controllerChatVisible = writable<boolean>(false);
 
 export const expandedProjects = writable<Set<string>>(new Set());
 


### PR DESCRIPTION
## Summary
- Change `controllerChatVisible` store default from `true` to `false`
- Controller chat is now hidden on startup; press `g` to toggle it open

## Test plan
- [x] `controllerChatVisible defaults to false` store test updated and passing
- [x] All 230 frontend tests pass
- [x] All 16 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)