### PR TITLE
fix: pass vim entry keys through to notes editor

### DIFF
--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -2,19 +2,20 @@
   import { EditorState } from "@codemirror/state";
   import { EditorView, drawSelection } from "@codemirror/view";
   import { markdown } from "@codemirror/lang-markdown";
-  import { getCM, vim } from "@replit/codemirror-vim";
+  import { Vim, getCM, vim } from "@replit/codemirror-vim";
 
   export type VimMode = "normal" | "insert" | "visual" | "replace";
 
   interface Props {
     value: string;
     focused?: boolean;
+    entryKey?: string;
     onChange?: (value: string) => void;
     onEscape?: (mode: VimMode | string) => void;
     onModeChange?: (mode: VimMode | string) => void;
   }
 
-  let { value, focused = false, onChange, onEscape, onModeChange }: Props = $props();
+  let { value, focused = false, entryKey, onChange, onEscape, onModeChange }: Props = $props();
 
   let hostEl: HTMLDivElement | undefined;
   let view: EditorView | null = null;
@@ -82,9 +83,17 @@
     });
   });
 
+  let lastEntryKey: string | undefined;
   $effect(() => {
     if (view && focused) {
       view.focus();
+      if (entryKey && entryKey !== lastEntryKey) {
+        lastEntryKey = entryKey;
+        const cm = getCM(view);
+        if (cm) Vim.handleKey(cm, entryKey, "mapping");
+      }
+    } else {
+      lastEntryKey = undefined;
     }
   });
 </script>

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -349,7 +349,8 @@
           focusTarget.set({ type: "agent-panel", agentKind: currentFocus.agentKind, projectId: currentFocus.projectId });
         } else if (currentFocus?.type === "note") {
           activeNote.set({ projectId: currentFocus.projectId, filename: currentFocus.filename });
-          focusTarget.set({ type: "notes-editor", projectId: currentFocus.projectId });
+          const vimKeys = ["o", "i", "a"];
+          focusTarget.set({ type: "notes-editor", projectId: currentFocus.projectId, entryKey: vimKeys.includes(key) ? key : undefined });
         }
         return true;
       case "toggle-mode":
@@ -481,8 +482,9 @@
     // Allow dialog-local keyboard handlers to own key events.
     if (isDialogOpen()) return;
 
-    // Don't intercept keys when typing in input fields
+    // Don't intercept keys when typing in input fields or the notes code editor
     if (isEditableElementFocused()) return;
+    if (currentFocus?.type === "notes-editor") return;
 
     // Escape: check for double-tap (forward to terminal), else walk up focus hierarchy
     if (e.key === "Escape") {
@@ -494,17 +496,6 @@
         dispatchAction({ type: "focus-terminal" });
         e.stopPropagation();
         e.preventDefault();
-      } else if (currentFocus?.type === "notes-editor") {
-        // Get current active note to return focus to
-        const currentNote = get(activeNote);
-        if (currentNote) {
-          focusTarget.set({ type: "note", filename: currentNote.filename, projectId: currentNote.projectId });
-        } else {
-          focusTarget.set({ type: "project", projectId: currentFocus.projectId });
-        }
-        e.stopPropagation();
-        e.preventDefault();
-        pushKeystroke("Esc");
       } else if (currentFocus?.type === "note") {
         focusTarget.set({ type: "project", projectId: currentFocus.projectId });
         e.stopPropagation();

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -773,25 +773,25 @@ describe('HotkeyManager', () => {
       workspaceMode.set('development');
     });
 
-    it('o on a focused note opens the note editor', () => {
+    it('o on a focused note opens the note editor with entryKey', () => {
       focusTarget.set({ type: 'note', filename: 'todo.md', projectId: 'proj-1' });
       pressKey('o');
       expect(get(activeNote)).toEqual({ projectId: 'proj-1', filename: 'todo.md' });
-      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1' });
+      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1', entryKey: 'o' });
     });
 
-    it('i on a focused note opens the note editor', () => {
+    it('i on a focused note opens the note editor with entryKey', () => {
       focusTarget.set({ type: 'note', filename: 'todo.md', projectId: 'proj-1' });
       pressKey('i');
       expect(get(activeNote)).toEqual({ projectId: 'proj-1', filename: 'todo.md' });
-      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1' });
+      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1', entryKey: 'i' });
     });
 
-    it('a on a focused note opens the note editor', () => {
+    it('a on a focused note opens the note editor with entryKey', () => {
       focusTarget.set({ type: 'note', filename: 'todo.md', projectId: 'proj-1' });
       pressKey('a');
       expect(get(activeNote)).toEqual({ projectId: 'proj-1', filename: 'todo.md' });
-      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1' });
+      expect(get(focusTarget)).toEqual({ type: 'notes-editor', projectId: 'proj-1', entryKey: 'a' });
     });
   });
 

--- a/src/lib/NotesEditor.svelte
+++ b/src/lib/NotesEditor.svelte
@@ -27,6 +27,7 @@
   let currentFocus: FocusTarget = $derived(focusTargetState.current);
 
   let editorFocused = $derived(currentFocus?.type === "notes-editor");
+  let editorEntryKey = $derived(currentFocus?.type === "notes-editor" ? currentFocus.entryKey : undefined);
 
   let projectName = $derived(
     currentNote
@@ -199,6 +200,7 @@
         <CodeMirrorNoteEditor
           value={content}
           focused={editorFocused}
+          entryKey={editorEntryKey}
           onChange={handleEditorChange}
           onModeChange={(mode) => {
             editorMode = mode;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -284,6 +284,6 @@ export type FocusTarget =
   | { type: "agent"; agentKind: AgentKind; projectId: string }
   | { type: "agent-panel"; agentKind: AgentKind; projectId: string }
   | { type: "note"; filename: string; projectId: string }
-  | { type: "notes-editor"; projectId: string }
+  | { type: "notes-editor"; projectId: string; entryKey?: string }
   | null;
 export const focusTarget = writable<FocusTarget>(null);


### PR DESCRIPTION
## Summary
- When opening the notes editor with `o`/`i`/`a` from the sidebar, the vim command now executes in CodeMirror (e.g. `o` inserts a new line below and enters insert mode)
- The HotkeyManager no longer intercepts any keys while the notes editor is focused, fixing Enter being swallowed by the global `expand-collapse` binding
- Removed redundant `notes-editor` Escape handling from HotkeyManager — already handled correctly by CodeMirror's `onEscape` callback

## Test plan
- [x] All 230 existing tests pass
- [x] Updated HotkeyManager tests to verify `entryKey` is passed for `o`/`i`/`a`
- [ ] Manual: press `o` on a note in sidebar → editor opens with new line + insert mode
- [ ] Manual: press `i` on a note → editor opens in insert mode at cursor
- [ ] Manual: press Enter in insert mode → newline is inserted (not swallowed)
- [ ] Manual: press Escape in insert mode → returns to normal mode (stays in editor)
- [ ] Manual: press Escape in normal mode → exits editor, focuses sidebar note

🤖 Generated with [Claude Code](https://claude.com/claude-code)