### PR TITLE
fix: prevent CodeMirror view destruction on keystroke in vim insert mode

### DIFF
--- a/e2e/specs/notes-vim-o.spec.ts
+++ b/e2e/specs/notes-vim-o.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+
+test("o key creates new line and enters insert mode", async ({ page }) => {
+  // Reset note content
+  await page.request.post("http://localhost:3001/api/write_note", {
+    data: { projectName: "fa-agent-v3", filename: "test-note.md", content: "# Test Note" },
+  });
+
+  await page.goto("/");
+  await expect(page.locator(".sidebar")).toBeVisible({ timeout: 10_000 });
+
+  // Navigate to notes mode and open editor
+  await page.keyboard.press("Space");
+  await page.waitForTimeout(300);
+  await page.keyboard.press("n");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("j");
+  await page.waitForTimeout(200);
+  await page.keyboard.press("l");
+  await page.waitForTimeout(300);
+  await page.keyboard.press("j");
+  await page.waitForTimeout(200);
+  await page.keyboard.press("Enter");
+  await page.waitForTimeout(1000);
+
+  const editor = page.locator('[data-testid="note-code-editor"]');
+  await expect(editor).toBeVisible({ timeout: 3_000 });
+  await expect(editor.locator(".cm-focused")).toBeVisible({ timeout: 2_000 });
+
+  const getContent = () => page.evaluate(() => {
+    const lines = document.querySelectorAll('[data-testid="note-code-editor"] .cm-line');
+    return Array.from(lines).map(l => l.textContent).join('\n');
+  });
+
+  // Press o — should create new line below and enter insert mode
+  await page.keyboard.press("o");
+  await page.waitForTimeout(300);
+
+  // Type text on the new line
+  await page.keyboard.type("hello from o");
+  await page.waitForTimeout(300);
+
+  const content = await getContent();
+  console.log("Content after o + typing:", JSON.stringify(content));
+
+  // Verify: line 1 is original content, line 2 has the typed text
+  expect(content).toContain("# Test Note");
+  expect(content).toContain("hello from o");
+
+  // Escape back to normal mode, press o again
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(200);
+  await page.keyboard.press("o");
+  await page.waitForTimeout(300);
+  await page.keyboard.type("second line");
+  await page.waitForTimeout(300);
+
+  const finalContent = await getContent();
+  console.log("Final content:", JSON.stringify(finalContent));
+
+  expect(finalContent).toContain("hello from o");
+  expect(finalContent).toContain("second line");
+});
+
+test("o entry key from sidebar opens editor in insert mode with new line", async ({ page }) => {
+  // Reset note content
+  await page.request.post("http://localhost:3001/api/write_note", {
+    data: { projectName: "fa-agent-v3", filename: "test-note.md", content: "# Test Note" },
+  });
+
+  await page.goto("/");
+  await expect(page.locator(".sidebar")).toBeVisible({ timeout: 10_000 });
+
+  // Navigate to notes mode
+  await page.keyboard.press("Space");
+  await page.waitForTimeout(300);
+  await page.keyboard.press("n");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("j");
+  await page.waitForTimeout(200);
+  await page.keyboard.press("l");
+  await page.waitForTimeout(300);
+  await page.keyboard.press("j");
+  await page.waitForTimeout(200);
+
+  // Press o on the focused note (entry key) — should open editor with vim o
+  await page.keyboard.press("o");
+  await page.waitForTimeout(1000);
+
+  const editor = page.locator('[data-testid="note-code-editor"]');
+  await expect(editor).toBeVisible({ timeout: 3_000 });
+
+  // Type text — if o entry key worked, we should be in insert mode on a new line
+  await page.keyboard.type("via entry key");
+  await page.waitForTimeout(300);
+
+  const content = await page.evaluate(() => {
+    const lines = document.querySelectorAll('[data-testid="note-code-editor"] .cm-line');
+    return Array.from(lines).map(l => l.textContent).join('\n');
+  });
+  console.log("Content after entry-key o:", JSON.stringify(content));
+
+  expect(content).toContain("# Test Note");
+  expect(content).toContain("via entry key");
+});

--- a/skills/the-controller-debugging-ui-with-playwright/SKILL.md
+++ b/skills/the-controller-debugging-ui-with-playwright/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: the-controller-debugging-ui-with-playwright
+description: Use when a UI behavior doesn't work as expected (key not responding, focus lost, mode not changing) and code reading alone isn't enough — runs Playwright in browser mode to reproduce, isolate, and pinpoint the root cause
+---
+
+# Debugging UI/UX Issues with Playwright
+
+## When to Use
+
+A user reports a UI behavior that doesn't work as expected — a key doesn't respond, focus is lost, a mode doesn't change, a visual state is wrong — and reading the code doesn't make it obvious why.
+
+**Don't skip to fixes.** Use the `the-controller-systematic-debugging` skill's iron law: no fixes without root cause investigation first. This skill is the browser-specific investigation technique.
+
+## Setup Checklist
+
+Before writing any test, verify all three servers:
+
+```bash
+# 1. Backend (port 3001)
+lsof -i :3001 -P | grep LISTEN
+# If not running:
+cd src-tauri && cargo run --bin server --features server
+
+# 2. Frontend dev server (port 1420)
+lsof -i :1420 -P | grep LISTEN
+# CRITICAL: verify it's serving the right directory
+ps -p $(lsof -t -i :1420) -o command=
+# If it says /Users/noel/projects/the-controller — that's the main repo
+# Code changes MUST go to that directory, not a worktree
+
+# 3. Playwright dependencies
+npm install  # worktrees need their own node_modules
+```
+
+**Silent failure trap**: The axum server has a `fallback_handler` that returns `null` for any unregistered API route. If a feature silently does nothing in browser mode, check if the API endpoint exists in `src-tauri/src/bin/server.rs`.
+
+## The Four Phases
+
+### Phase 1: Reproduce
+
+Write a Playwright test that does exactly what the user did. No cleverness — just automate the steps.
+
+```typescript
+test("reproduce: o key should enter insert mode", async ({ page }) => {
+  await page.goto("/");
+  // Navigate to the right state
+  await page.keyboard.press("Space");
+  await page.waitForTimeout(300);
+  await page.keyboard.press("n");
+  // ... exact steps the user took ...
+
+  // Screenshot at each step
+  await page.screenshot({ path: "e2e/results/step-01.png" });
+
+  // Assert the expected outcome
+  expect(content).toContain("typed text");
+});
+```
+
+Run with `npx playwright test <file> --project=e2e --headed`.
+
+If the test passes, the bug isn't what you think. If it fails, you have a reproducible case.
+
+### Phase 2: Isolate
+
+Break the problem into smaller pieces to narrow the scope:
+
+- **Specificity**: If `o` doesn't work, does `i` work? Does `a` work? Does ANY command of that type work?
+- **Granularity**: If typing doesn't work, does one character work? Two? Use individual `page.keyboard.press()` calls with `waitForTimeout()` between them.
+- **Mechanism**: Does `page.keyboard.type()` work? Does `page.keyboard.insertText()` work? Does `page.evaluate()` to directly call APIs work?
+
+Check content after EACH individual action:
+
+```typescript
+await page.keyboard.press("o");
+await page.waitForTimeout(300);
+content = await getContent();
+console.log("After o:", JSON.stringify(content));
+
+await page.keyboard.press("h");
+await page.waitForTimeout(200);
+content = await getContent();
+console.log("After o + h:", JSON.stringify(content));
+```
+
+### Phase 3: Instrument
+
+Once you know the symptom (e.g., "second character isn't typed"), add diagnostics:
+
+#### Focus tracking (most common root cause)
+
+```typescript
+// Install global focus monitor
+await page.evaluate(() => {
+  document.addEventListener("focusin", (e) => {
+    console.log("[FOCUS] focusin:", (e.target as HTMLElement)?.tagName,
+      (e.target as HTMLElement)?.className?.substring(0, 60));
+  });
+  document.addEventListener("focusout", (e) => {
+    console.log("[FOCUS] focusout:", (e.target as HTMLElement)?.tagName,
+      (e.target as HTMLElement)?.className?.substring(0, 60));
+  });
+  // Blur listener with stack trace — this is the money shot
+  const target = document.querySelector('.cm-content');
+  target?.addEventListener("blur", () => {
+    console.log("[FOCUS] BLUR!", new Error().stack);
+  });
+});
+
+// Check activeElement after each action
+const checkFocus = async (label: string) => {
+  const info = await page.evaluate(() => ({
+    activeTag: document.activeElement?.tagName,
+    activeClass: document.activeElement?.className?.substring(0, 60),
+  }));
+  console.log(`[FOCUS ${label}]`, JSON.stringify(info));
+};
+```
+
+#### Console log capture
+
+```typescript
+page.on("console", (msg) => {
+  if (msg.text().includes("MY-DEBUG")) consoleLogs.push(msg.text());
+});
+```
+
+**Remember**: add `console.log` to the file the dev server is serving, not the worktree copy.
+
+### Phase 4: Pinpoint
+
+Follow the stack trace from Phase 3 to the root cause.
+
+**The stack trace from a blur event handler is the single most useful piece of evidence.** It tells you exactly which code path stole focus or destroyed the element.
+
+Example from the `o`-key bug:
+```
+cm-content BLUR!
+  at _EditorView.destroy (chunk-FJ5OGNHB.js:8197:23)
+  at CodeMirrorNoteEditor.svelte:74:10
+  at execute_effect_teardown (chunk-HXN5OQ4Q.js:3225:17)
+```
+
+This immediately revealed: Svelte's `$effect` cleanup was destroying the CodeMirror view. The effect was re-running because it tracked `value` (a reactive prop), which changed on every keystroke.
+
+## Known Gotchas
+
+### Svelte 5 `$effect` + imperative libraries (CodeMirror, xterm.js)
+
+`$effect` tracks ALL reactive values read in its body. If a view-creation effect reads a prop like `value` via `buildState(value)`, every content change will:
+
+1. Re-run the effect
+2. Execute cleanup (destroying the view)
+3. Recreate the view from scratch
+4. Lose all internal state (vim mode, cursor position, focus)
+
+**Fix**: Use `untrack()` for values that should only be read once:
+
+```typescript
+import { untrack } from "svelte";
+
+$effect(() => {
+  if (!hostEl || view) return;
+  const initialValue = untrack(() => value);
+  view = new EditorView({ state: buildState(initialValue), parent: hostEl });
+  // ...
+});
+```
+
+This pattern applies to ANY imperative library mounted in a Svelte 5 `$effect`. The value sync should be a separate effect.
+
+### Notes storage path
+
+`~/.the-controller/notes/{project_name}/`, not `~/.the-controller/projects/{id}/`.

--- a/src-tauri/src/bin/server.rs
+++ b/src-tauri/src/bin/server.rs
@@ -14,6 +14,7 @@ use the_controller_lib::{
     controller_chat::{self, ControllerFocusUpdate},
     config,
     emitter::WsBroadcastEmitter,
+    notes,
     state::AppState,
 };
 use tokio::sync::broadcast;
@@ -49,6 +50,12 @@ async fn main() {
         .route("/api/get_controller_chat_session", post(get_controller_chat_session))
         .route("/api/update_controller_chat_focus", post(update_controller_chat_focus))
         .route("/api/send_controller_chat_message", post(send_controller_chat_message))
+        .route("/api/list_notes", post(api_list_notes))
+        .route("/api/read_note", post(api_read_note))
+        .route("/api/write_note", post(api_write_note))
+        .route("/api/create_note", post(api_create_note))
+        .route("/api/delete_note", post(api_delete_note))
+        .route("/api/rename_note", post(api_rename_note))
         .route("/ws", get(ws_upgrade))
         .fallback(post(fallback_handler))
         .layer(CorsLayer::permissive())
@@ -434,6 +441,108 @@ async fn send_controller_chat_message(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     Ok(Json(serde_json::to_value(session).unwrap()))
+}
+
+// --- Notes ---
+
+async fn api_list_notes(
+    AxumState(state): AxumState<Arc<ServerState>>,
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let project_name = args["projectName"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing projectName".to_string()))?
+        .to_string();
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    let entries = notes::list_notes(&base_dir, &project_name)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::to_value(entries).unwrap()))
+}
+
+async fn api_read_note(
+    AxumState(state): AxumState<Arc<ServerState>>,
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let project_name = args["projectName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing projectName".to_string()))?.to_string();
+    let filename = args["filename"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?.to_string();
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    let content = notes::read_note(&base_dir, &project_name, &filename)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::to_value(content).unwrap()))
+}
+
+async fn api_write_note(
+    AxumState(state): AxumState<Arc<ServerState>>,
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let project_name = args["projectName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing projectName".to_string()))?.to_string();
+    let filename = args["filename"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?.to_string();
+    let content = args["content"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing content".to_string()))?.to_string();
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    notes::write_note(&base_dir, &project_name, &filename, &content)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(Value::Null))
+}
+
+async fn api_create_note(
+    AxumState(state): AxumState<Arc<ServerState>>,
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let project_name = args["projectName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing projectName".to_string()))?.to_string();
+    let title = args["title"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing title".to_string()))?.to_string();
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    let filename = notes::create_note(&base_dir, &project_name, &title)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::to_value(filename).unwrap()))
+}
+
+async fn api_delete_note(
+    AxumState(state): AxumState<Arc<ServerState>>,
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let project_name = args["projectName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing projectName".to_string()))?.to_string();
+    let filename = args["filename"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?.to_string();
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    notes::delete_note(&base_dir, &project_name, &filename)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(Value::Null))
+}
+
+async fn api_rename_note(
+    AxumState(state): AxumState<Arc<ServerState>>,
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let project_name = args["projectName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing projectName".to_string()))?.to_string();
+    let old_name = args["oldName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing oldName".to_string()))?.to_string();
+    let new_name = args["newName"].as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing newName".to_string()))?.to_string();
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    let filename = notes::rename_note(&base_dir, &project_name, &old_name, &new_name)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::to_value(filename).unwrap()))
 }
 
 // --- WebSocket ---

--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import { EditorState } from "@codemirror/state";
   import { EditorView, drawSelection } from "@codemirror/view";
   import { markdown } from "@codemirror/lang-markdown";
@@ -49,13 +50,18 @@
   $effect(() => {
     if (!hostEl || view) return;
 
+    // Use untrack to prevent this effect from depending on `value` and callback
+    // props. The value sync effect (below) handles value changes separately.
+    // Without untrack, every keystroke in insert mode would re-run this effect,
+    // destroying and recreating the view (and losing vim state + focus).
+    const initialValue = untrack(() => value);
     view = new EditorView({
-      state: buildState(value),
+      state: buildState(initialValue),
       parent: hostEl,
     });
 
     currentMode = "normal";
-    onModeChange?.(currentMode);
+    untrack(() => onModeChange?.(currentMode));
 
     const cm = getCM(view);
     const handleModeChange = (event: { mode?: string }) => {


### PR DESCRIPTION
## Summary
- Fix `$effect` in `CodeMirrorNoteEditor.svelte` that tracked `value` prop, causing view destruction on every keystroke in vim insert mode (losing vim state + focus)
- Wrap `value` and `onModeChange` reads in `untrack()` so the view-creation effect only runs once
- Add notes API endpoints to browser-mode axum server for Playwright testing
- Add Playwright e2e test verifying `o` key creates new line + enters insert mode
- Add `the-controller-debugging-ui-with-playwright` skill documenting the investigation methodology

## Test plan
- [x] All 230 vitest unit tests pass
- [x] All 16 Rust tests pass
- [x] Playwright e2e test `notes-vim-o.spec.ts` passes (2 tests: o-key in editor, o-key as entry from sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)