### PR TITLE
fix: default session provider to claude instead of codex

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -158,7 +158,7 @@ export type WorkspaceMode = "development" | "agents" | "notes";
 export const workspaceMode = writable<WorkspaceMode>("development");
 export const workspaceModePickerVisible = writable<boolean>(false);
 export type SessionProvider = "claude" | "codex";
-export const selectedSessionProvider = writable<SessionProvider>("codex");
+export const selectedSessionProvider = writable<SessionProvider>("claude");
 
 export const activeNote = writable<{
   projectId: string;


### PR DESCRIPTION
## Summary
- Changes the default `selectedSessionProvider` from `"codex"` to `"claude"` so pressing `c` creates Claude sessions by default

## Test plan
- [x] All 230 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)