### PR TITLE
fix: align architecture explorer design with app conventions

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -449,7 +449,7 @@ describe("App architecture workspace", () => {
     render(App);
 
     const generateButton = await waitFor(() =>
-      screen.getByRole("button", { name: "Generate Architecture" }),
+      screen.getByRole("button", { name: "Generate" }),
     );
 
     await fireEvent.click(generateButton);
@@ -499,7 +499,7 @@ describe("App architecture workspace", () => {
       expect(screen.getByRole("heading", { name: "Backend Command Layer" })).toBeInTheDocument();
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Regenerate Architecture" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
 
     await waitFor(() => {
       expect(command).toHaveBeenCalledWith("generate_architecture", {

--- a/src/lib/ArchitectureExplorer.svelte
+++ b/src/lib/ArchitectureExplorer.svelte
@@ -162,34 +162,30 @@
 <div class="architecture-explorer">
   <section class="diagram-pane" aria-label="Architecture diagram">
     <div class="pane-header">
-      <div class="header-copy">
-        <p class="eyebrow">Architecture</p>
-        <h1>{architecture?.title ?? projectName}</h1>
-        <p class="note">Generated as a high-level systems view, not an exhaustive code index.</p>
-      </div>
+      <h2>{architecture?.title ?? projectName}</h2>
       <button
         type="button"
         class="generate-action"
         disabled={isGenerating}
         onclick={triggerArchitectureGeneration}
       >
-        {architecture ? "Regenerate Architecture" : "Generate Architecture"}
+        {architecture ? "Regenerate" : "Generate"}{isGenerating ? "…" : ""}
       </button>
     </div>
 
-    <div class="diagram-surface">
+    <div class="diagram-surface" class:is-generating={isGenerating && architecture}>
       {#if architecture}
         <div class="diagram-render" bind:this={diagramContainer}></div>
         {#if diagramError}
           <div class="diagram-error">
-            <h2>Diagram render failed</h2>
-            <p>{diagramError}</p>
+            <span class="error-label">Render failed</span>
+            <span>{diagramError}</span>
           </div>
         {/if}
       {:else}
         <div class="empty-state">
-          <h2>No architecture generated yet</h2>
-          <p>{projectName} does not have a cached architecture view yet.</p>
+          <span>No architecture generated yet</span>
+          <span class="empty-hint">press <kbd>r</kbd> to generate</span>
         </div>
       {/if}
     </div>
@@ -201,8 +197,8 @@
   <aside class="inspector-rail">
     <section class="component-list-pane">
       <div class="section-heading">
-        <h2>Components</h2>
-        <span>{components.length}</span>
+        <span class="section-title">Components</span>
+        <span class="section-count">{components.length}</span>
       </div>
 
       {#if components.length > 0}
@@ -221,83 +217,72 @@
           {/each}
         </ul>
       {:else}
-        <p class="placeholder-copy">Generate architecture to inspect components and relationships.</p>
+        <p class="placeholder-copy">Generate architecture to see components.</p>
       {/if}
     </section>
 
     <section class="details-pane" aria-label="Component details">
       {#if selectedComponent}
-        <h2>{selectedComponent.name}</h2>
+        <h3 class="detail-name">{selectedComponent.name}</h3>
         <p class="summary">{selectedComponent.summary}</p>
 
-        <div class="detail-group">
-          <h3>Contains</h3>
-          {#if selectedComponent.contains.length > 0}
+        {#if selectedComponent.contains.length > 0}
+          <div class="detail-group">
+            <h4>Contains</h4>
             <ul>
               {#each selectedComponent.contains as entry}
                 <li>{entry}</li>
               {/each}
             </ul>
-          {:else}
-            <p>No nested components listed.</p>
-          {/if}
-        </div>
+          </div>
+        {/if}
 
-        <div class="detail-group">
-          <h3>Outgoing relationships</h3>
-          {#if selectedComponent.outgoing_relationships.length > 0}
+        {#if selectedComponent.outgoing_relationships.length > 0}
+          <div class="detail-group">
+            <h4>Outgoing</h4>
             <ul>
               {#each selectedComponent.outgoing_relationships as relationship}
                 <li>{relationship.summary}</li>
               {/each}
             </ul>
-          {:else}
-            <p>No outgoing relationships.</p>
-          {/if}
-        </div>
+          </div>
+        {/if}
 
-        <div class="detail-group">
-          <h3>Incoming relationships</h3>
-          {#if selectedComponent.incoming_relationships.length > 0}
+        {#if selectedComponent.incoming_relationships.length > 0}
+          <div class="detail-group">
+            <h4>Incoming</h4>
             <ul>
               {#each selectedComponent.incoming_relationships as relationship}
                 <li>{relationship.summary}</li>
               {/each}
             </ul>
-          {:else}
-            <p>No incoming relationships.</p>
-          {/if}
-        </div>
+          </div>
+        {/if}
 
-        <div class="detail-group">
-          <h3>Evidence paths</h3>
-          {#if selectedComponent.evidence_paths.length > 0}
+        {#if selectedComponent.evidence_paths.length > 0}
+          <div class="detail-group">
+            <h4>Evidence</h4>
             <ul>
               {#each selectedComponent.evidence_paths as evidencePath}
                 <li><code>{evidencePath}</code></li>
               {/each}
             </ul>
-          {:else}
-            <p>No evidence paths captured.</p>
-          {/if}
-        </div>
+          </div>
+        {/if}
 
-        <div class="detail-group">
-          <h3>Evidence snippets</h3>
-          {#if selectedComponent.evidence_snippets.length > 0}
+        {#if selectedComponent.evidence_snippets.length > 0}
+          <div class="detail-group">
+            <h4>Snippets</h4>
             <ul class="evidence-snippets">
               {#each selectedComponent.evidence_snippets as evidenceSnippet}
                 <li><pre>{evidenceSnippet}</pre></li>
               {/each}
             </ul>
-          {:else}
-            <p>No evidence snippets captured.</p>
-          {/if}
-        </div>
+          </div>
+        {/if}
       {:else}
-        <div class="empty-details">
-          <h2>Component details</h2>
-          <p>Select a generated component to inspect its summary and relationships.</p>
+        <div class="empty-state">
+          <span>Select a component to inspect</span>
         </div>
       {/if}
     </section>
@@ -307,12 +292,10 @@
 <style>
   .architecture-explorer {
     display: grid;
-    grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);
+    grid-template-columns: minmax(0, 1fr) 320px;
     height: 100%;
     color: #cdd6f4;
-    background:
-      radial-gradient(circle at top left, rgba(137, 180, 250, 0.12), transparent 28%),
-      linear-gradient(180deg, #11111b 0%, #181825 100%);
+    background: #1e1e2e;
   }
 
   .diagram-pane,
@@ -323,74 +306,50 @@
   .diagram-pane {
     display: flex;
     flex-direction: column;
-    padding: 1.5rem;
-    border-right: 1px solid rgba(205, 214, 244, 0.1);
-    gap: 1rem;
+    padding: 16px 24px;
+    border-right: 1px solid #313244;
+    gap: 12px;
   }
 
   .pane-header {
     display: flex;
-    align-items: start;
+    align-items: center;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 12px;
   }
 
-  .header-copy {
-    min-width: 0;
-  }
-
-  .pane-header h1,
-  .section-heading h2,
-  .details-pane h2 {
+  .pane-header h2 {
     margin: 0;
-  }
-
-  .eyebrow {
-    margin: 0 0 0.35rem;
-    font-size: 0.78rem;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: #89b4fa;
-  }
-
-  .note,
-  .generation-error,
-  .placeholder-copy,
-  .summary,
-  .empty-state p,
-  .empty-details p {
-    color: #bac2de;
+    font-size: 16px;
+    font-weight: 600;
   }
 
   .generate-action {
     flex-shrink: 0;
-    padding: 0.65rem 1rem;
-    border: 1px solid rgba(137, 180, 250, 0.35);
-    border-radius: 999px;
-    background: rgba(137, 180, 250, 0.12);
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    background: #313244;
     color: #cdd6f4;
     font: inherit;
+    font-size: 12px;
     cursor: pointer;
-    transition:
-      border-color 120ms ease,
-      background 120ms ease,
-      transform 120ms ease;
+    transition: background 0.15s;
   }
 
   .generate-action:hover:enabled {
-    border-color: rgba(137, 180, 250, 0.65);
-    background: rgba(137, 180, 250, 0.18);
-    transform: translateY(-1px);
+    background: #45475a;
   }
 
   .generate-action:disabled {
-    opacity: 0.65;
-    cursor: wait;
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .generation-error {
     margin: 0;
-    color: #f2cdcd;
+    font-size: 12px;
+    color: #f38ba8;
   }
 
   .diagram-surface {
@@ -398,11 +357,15 @@
     flex: 1;
     min-height: 0;
     overflow: auto;
-    padding: 1.25rem;
-    border: 1px solid rgba(205, 214, 244, 0.1);
-    border-radius: 18px;
-    background: rgba(24, 24, 37, 0.88);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    padding: 16px;
+    border: 1px solid #313244;
+    border-radius: 6px;
+    background: #181825;
+    transition: opacity 0.15s;
+  }
+
+  .diagram-surface.is-generating {
+    opacity: 0.5;
   }
 
   .diagram-render {
@@ -412,24 +375,21 @@
 
   .diagram-error {
     position: sticky;
-    left: 1rem;
-    bottom: 1rem;
-    display: inline-grid;
-    gap: 0.25rem;
-    margin-top: 1rem;
-    padding: 0.85rem 1rem;
-    border: 1px solid rgba(243, 139, 168, 0.35);
-    border-radius: 14px;
-    background: rgba(30, 30, 46, 0.94);
+    left: 12px;
+    bottom: 12px;
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+    padding: 8px 12px;
+    border: 1px solid rgba(243, 139, 168, 0.3);
+    border-radius: 6px;
+    background: #1e1e2e;
+    font-size: 12px;
   }
 
-  .diagram-error h2,
-  .diagram-error p {
-    margin: 0;
-  }
-
-  .diagram-error p {
-    color: #f2cdcd;
+  .error-label {
+    color: #f38ba8;
+    font-weight: 600;
   }
 
   .diagram-render :global(svg) {
@@ -456,9 +416,8 @@
   .diagram-render :global(g.cluster circle),
   .diagram-render :global(g.cluster ellipse) {
     transition:
-      stroke 120ms ease,
-      stroke-width 120ms ease,
-      filter 120ms ease;
+      stroke 0.15s,
+      stroke-width 0.15s;
   }
 
   .diagram-render :global(g.architecture-node-selected rect),
@@ -466,62 +425,88 @@
   .diagram-render :global(g.architecture-node-selected path),
   .diagram-render :global(g.architecture-node-selected circle),
   .diagram-render :global(g.architecture-node-selected ellipse) {
-    stroke: #f9e2af !important;
-    stroke-width: 3px !important;
-    filter: drop-shadow(0 0 16px rgba(249, 226, 175, 0.18));
+    stroke: #89b4fa !important;
+    stroke-width: 2px !important;
   }
 
   .diagram-render :global(g.architecture-node-selected .nodeLabel),
   .diagram-render :global(g.architecture-node-selected text) {
-    font-weight: 700;
-    fill: #f9e2af !important;
+    font-weight: 600;
+    fill: #89b4fa !important;
   }
 
-  .empty-state,
-  .empty-details {
-    display: grid;
-    place-items: start;
-    gap: 0.5rem;
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: 8px;
+    font-size: 16px;
+    font-weight: 500;
   }
 
-  .empty-state h2,
-  .empty-details h2,
-  .detail-group h3 {
-    margin: 0;
+  .empty-hint {
+    font-size: 13px;
+    font-weight: 400;
+    color: #6c7086;
+  }
+
+  .empty-hint kbd {
+    background: #313244;
+    color: #89b4fa;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 12px;
   }
 
   .inspector-rail {
     display: grid;
-    grid-template-rows: minmax(0, 0.9fr) minmax(0, 1.1fr);
-    background: rgba(17, 17, 27, 0.9);
+    grid-template-rows: auto minmax(0, 1fr);
+    background: #11111b;
   }
 
   .component-list-pane,
   .details-pane {
     min-height: 0;
     overflow: auto;
-    padding: 1.25rem;
+    padding: 12px 16px;
   }
 
   .component-list-pane {
-    border-bottom: 1px solid rgba(205, 214, 244, 0.1);
+    border-bottom: 1px solid #313244;
   }
 
   .section-heading {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 0.9rem;
+    margin-bottom: 8px;
   }
 
-  .section-heading span {
-    color: #89dceb;
-    font-size: 0.9rem;
+  .section-title {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .section-count {
+    font-size: 11px;
+    color: #6c7086;
+    background: #313244;
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+
+  .placeholder-copy {
+    font-size: 12px;
+    color: #6c7086;
   }
 
   .component-list {
-    display: grid;
-    gap: 0.65rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -529,47 +514,69 @@
 
   .component-list button {
     width: 100%;
-    border: 1px solid rgba(205, 214, 244, 0.09);
-    border-radius: 14px;
-    padding: 0.8rem 0.95rem;
-    background: rgba(30, 30, 46, 0.9);
-    color: inherit;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 12px;
+    background: transparent;
+    color: #a6adc8;
+    font: inherit;
+    font-size: 12px;
     text-align: left;
     cursor: pointer;
-    transition:
-      border-color 120ms ease,
-      transform 120ms ease,
-      background 120ms ease;
+    transition: color 0.15s, background 0.15s;
   }
 
   .component-list button:hover {
-    border-color: rgba(137, 180, 250, 0.45);
-    transform: translateY(-1px);
+    background: rgba(49, 50, 68, 0.5);
+    color: #cdd6f4;
   }
 
   .component-list button.selected {
-    border-color: #89b4fa;
-    background: rgba(49, 50, 68, 0.96);
-    box-shadow: 0 0 0 1px rgba(137, 180, 250, 0.18);
+    background: rgba(137, 180, 250, 0.1);
+    color: #cdd6f4;
+    outline: 1px solid rgba(137, 180, 250, 0.4);
+    outline-offset: -1px;
   }
 
-  .detail-group + .detail-group {
-    margin-top: 1.25rem;
+  .detail-name {
+    margin: 0 0 4px;
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  .summary {
+    margin: 0 0 12px;
+    font-size: 12px;
+    color: #bac2de;
+    line-height: 1.5;
+  }
+
+  .detail-group {
+    margin-bottom: 12px;
+  }
+
+  .detail-group h4 {
+    margin: 0 0 4px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #6c7086;
+    text-transform: uppercase;
   }
 
   .detail-group ul {
-    margin: 0.55rem 0 0;
-    padding-left: 1.1rem;
-  }
-
-  .detail-group code,
-  .evidence-snippets pre {
-    font-family: "SFMono-Regular", "SF Mono", "Cascadia Code", "JetBrains Mono",
-      Consolas, "Liberation Mono", Menlo, monospace;
+    margin: 0;
+    padding-left: 16px;
+    font-size: 12px;
   }
 
   .detail-group li + li {
-    margin-top: 0.35rem;
+    margin-top: 4px;
+  }
+
+  .detail-group code {
+    font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 11px;
+    color: #a6adc8;
   }
 
   .evidence-snippets {
@@ -580,11 +587,22 @@
   .evidence-snippets pre {
     margin: 0;
     white-space: pre-wrap;
-    border: 1px solid rgba(205, 214, 244, 0.08);
-    border-radius: 12px;
-    padding: 0.8rem 0.9rem;
-    background: rgba(30, 30, 46, 0.92);
-    color: #f5e0dc;
+    border: 1px solid rgba(49, 50, 68, 0.5);
+    border-radius: 6px;
+    padding: 8px 12px;
+    background: #1e1e2e;
+    color: #cdd6f4;
+    font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 11px;
+  }
+
+  .evidence-snippets li + li {
+    margin-top: 6px;
+  }
+
+  .details-pane .empty-state {
+    font-size: 13px;
+    color: #6c7086;
   }
 
   @media (max-width: 980px) {
@@ -595,11 +613,7 @@
 
     .diagram-pane {
       border-right: 0;
-      border-bottom: 1px solid rgba(205, 214, 244, 0.1);
-    }
-
-    .inspector-rail {
-      grid-template-rows: minmax(200px, 0.8fr) minmax(0, 1fr);
+      border-bottom: 1px solid #313244;
     }
   }
 </style>

--- a/src/lib/ArchitectureExplorer.test.ts
+++ b/src/lib/ArchitectureExplorer.test.ts
@@ -172,9 +172,9 @@ describe("ArchitectureExplorer", () => {
     expect(
       screen.getByText("Receives generated architecture payloads from the backend command."),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Evidence paths" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Evidence" })).toBeInTheDocument();
     expect(screen.getByText("src/App.svelte")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Evidence snippets" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Snippets" })).toBeInTheDocument();
     expect(
       screen.getByText('{#if workspaceModeState.current === "architecture"}'),
     ).toBeInTheDocument();
@@ -205,7 +205,7 @@ describe("ArchitectureExplorer", () => {
       },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Generate Architecture" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Generate" }));
 
     expect(onGenerateArchitecture).toHaveBeenCalledTimes(1);
   });
@@ -220,7 +220,7 @@ describe("ArchitectureExplorer", () => {
       },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Regenerate Architecture" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Regenerate" }));
 
     expect(onGenerateArchitecture).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- Overhauls ArchitectureExplorer.svelte styling to match the visual patterns established by AgentDashboard, NotesEditor, and Sidebar
- Fixes border radii (18px/999px → 4-6px), background (gradient → flat), button style (pill → standard), selection accent (yellow → blue), font sizes, spacing, and empty state patterns
- Adds loading state dimming during regeneration, kbd hint in empty state, and hides empty detail sections

## Test plan
- [x] All 251 frontend tests pass
- [x] Visual comparison via Playwright screenshots confirms consistency with other workspace modes
- [x] Architecture diagram rendering and selection sync preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)