### PR TITLE
feat: install controller-cli to stable PATH location

### DIFF
--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+
+/// Return the path to the controller CLI binary directory (`~/.the-controller/bin`).
+pub fn controller_bin_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".the-controller").join("bin"))
+}
+
+/// Return PATH with `~/.the-controller/bin` prepended, so spawned sessions
+/// can invoke `controller-cli` without knowing its exact location.
+pub fn path_with_controller_bin() -> Option<String> {
+    let bin_dir = controller_bin_dir()?;
+    let current_path = std::env::var("PATH").unwrap_or_default();
+    Some(format!("{}:{}", bin_dir.display(), current_path))
+}
+
+/// Copy the `controller-cli` binary from next to the running executable
+/// into `~/.the-controller/bin/controller-cli`.
+///
+/// Runs at app startup so the CLI is always available on a stable path.
+/// Silently skips if the source binary isn't found (e.g. production bundle
+/// that doesn't include it yet).
+pub fn install_controller_cli() {
+    let Some(bin_dir) = controller_bin_dir() else {
+        eprintln!("Warning: could not determine home directory for controller-cli install");
+        return;
+    };
+
+    let Ok(current_exe) = std::env::current_exe() else {
+        return;
+    };
+    let Some(exe_dir) = current_exe.parent() else {
+        return;
+    };
+
+    let source = exe_dir.join("controller-cli");
+    if !source.exists() {
+        return;
+    }
+
+    if let Err(e) = std::fs::create_dir_all(&bin_dir) {
+        eprintln!("Warning: could not create {}: {}", bin_dir.display(), e);
+        return;
+    }
+
+    let dest = bin_dir.join("controller-cli");
+    if let Err(e) = std::fs::copy(&source, &dest) {
+        eprintln!("Warning: could not install controller-cli: {}", e);
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn controller_bin_dir_ends_with_expected_suffix() {
+        if let Some(dir) = controller_bin_dir() {
+            let path_str = dir.to_string_lossy();
+            assert!(
+                path_str.ends_with(".the-controller/bin"),
+                "expected path ending with .the-controller/bin, got: {}",
+                path_str
+            );
+        }
+    }
+
+    #[test]
+    fn path_with_controller_bin_prepends_bin_dir() {
+        if let Some(path) = path_with_controller_bin() {
+            let bin_dir = controller_bin_dir().unwrap();
+            let prefix = format!("{}:", bin_dir.display());
+            assert!(
+                path.starts_with(&prefix),
+                "PATH should start with bin_dir, got: {}",
+                path
+            );
+        }
+    }
+
+    #[test]
+    fn path_with_controller_bin_preserves_original_path() {
+        if let Some(path) = path_with_controller_bin() {
+            if let Ok(original) = std::env::var("PATH") {
+                assert!(
+                    path.ends_with(&original),
+                    "PATH should end with original PATH"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn install_copies_binary_to_bin_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_dir = temp.path().join("source");
+        std::fs::create_dir_all(&source_dir).unwrap();
+
+        // Create a fake controller-cli binary
+        let source = source_dir.join("controller-cli");
+        std::fs::write(&source, b"fake-binary-content").unwrap();
+
+        let bin_dir = temp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        let dest = bin_dir.join("controller-cli");
+        std::fs::copy(&source, &dest).unwrap();
+
+        assert!(dest.exists());
+        assert_eq!(
+            std::fs::read_to_string(&dest).unwrap(),
+            "fake-binary-content"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use tauri::Manager;
 
 pub mod architecture;
 pub mod auto_worker;
+pub mod cli_install;
 pub mod commands;
 pub mod config;
 pub mod emitter;
@@ -48,6 +49,7 @@ pub fn run() {
                 }
             };
             app.manage(app_state);
+            cli_install::install_controller_cli();
             skills::sync_skills();
             status_socket::start_listener(app.handle().clone());
             maintainer::MaintainerScheduler::start(app.handle().clone());

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -117,6 +117,10 @@ impl PtyManager {
         cmd.cwd(working_dir);
         cmd.env_remove("CLAUDECODE");
         cmd.env("THE_CONTROLLER_SESSION_ID", session_id.to_string());
+        // Prepend ~/.the-controller/bin to PATH so controller-cli is available
+        if let Some(path_val) = crate::cli_install::path_with_controller_bin() {
+            cmd.env("PATH", path_val);
+        }
         for arg in
             crate::session_args::build_session_args(command, session_id, false, initial_prompt)
         {

--- a/src-tauri/src/tmux.rs
+++ b/src-tauri/src/tmux.rs
@@ -66,8 +66,13 @@ impl TmuxManager {
             "24".to_string(),
             "-e".to_string(),
             format!("THE_CONTROLLER_SESSION_ID={}", session_id),
-            command.to_string(),
         ];
+        // Prepend ~/.the-controller/bin to PATH so controller-cli is available
+        if let Some(path_val) = crate::cli_install::path_with_controller_bin() {
+            args.push("-e".to_string());
+            args.push(format!("PATH={}", path_val));
+        }
+        args.push(command.to_string());
         args.extend(crate::session_args::build_session_args(
             command,
             session_id,
@@ -353,6 +358,47 @@ mod tests {
         assert!(
             e_idx < cmd_idx,
             "-e flag must come before the shell command"
+        );
+    }
+
+    #[test]
+    fn test_create_args_prepends_controller_bin_to_path() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let args = TmuxManager::build_create_args(id, "/tmp", "claude", false, None);
+
+        // Find the PATH -e flag (second -e, after THE_CONTROLLER_SESSION_ID)
+        let e_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "-e")
+            .map(|(i, _)| i)
+            .collect();
+
+        // Should have at least 2 -e flags (session ID + PATH)
+        assert!(
+            e_positions.len() >= 2,
+            "expected at least 2 -e flags, got {}",
+            e_positions.len()
+        );
+
+        let path_e_idx = e_positions[1];
+        let path_val = &args[path_e_idx + 1];
+        assert!(
+            path_val.starts_with("PATH="),
+            "second -e should set PATH, got: {}",
+            path_val
+        );
+        assert!(
+            path_val.contains(".the-controller/bin"),
+            "PATH should contain .the-controller/bin, got: {}",
+            path_val
+        );
+
+        // PATH -e must come before the shell command
+        let cmd_idx = args.iter().position(|a| a == "claude").unwrap();
+        assert!(
+            path_e_idx < cmd_idx,
+            "PATH -e flag must come before the shell command"
         );
     }
 


### PR DESCRIPTION
## Summary
- New `cli_install` module that copies the `controller-cli` binary from the app's build directory to `~/.the-controller/bin/` on startup
- Prepends `~/.the-controller/bin` to `PATH` in every spawned session (both tmux via `-e` flag and direct PTY via `cmd.env`)
- Agents can now just run `controller-cli` without searching for ephemeral worktree build paths

## Test plan
- [x] All 331 Rust tests pass (including new tests for PATH prepending in tmux args, bin dir path, and PATH construction)
- [x] All 245 frontend tests pass
- [x] Verified tmux `build_create_args` includes `-e PATH=...` before the command
- [x] Verified direct PTY sessions set PATH with bin dir prepended

closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)