### PR TITLE
feat: symlink .env into worktrees instead of copying

### DIFF
--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -98,12 +98,18 @@ impl WorktreeManager {
         repo.worktree(branch_name, worktree_dir, Some(&opts))
             .map_err(|e| format!("failed to create worktree: {}", e))?;
 
-        // Copy .env from the main repo into the worktree if it exists
+        // Symlink .env from the main repo into the worktree so all sessions
+        // share the same secrets file (and controller-cli env set updates are
+        // immediately visible).
         let env_src = Path::new(repo_path).join(".env");
-        if env_src.exists() {
-            if let Err(e) = std::fs::copy(&env_src, worktree_dir.join(".env")) {
-                eprintln!("Warning: failed to copy .env to worktree: {}", e);
-            }
+        let env_dst = worktree_dir.join(".env");
+        #[cfg(unix)]
+        if let Err(e) = std::os::unix::fs::symlink(&env_src, &env_dst) {
+            eprintln!("Warning: failed to symlink .env to worktree: {}", e);
+        }
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_file(&env_src, &env_dst) {
+            eprintln!("Warning: failed to symlink .env to worktree: {}", e);
         }
 
         Ok(worktree_dir.to_path_buf())
@@ -493,8 +499,12 @@ mod tests {
             git2::Signature::now("Test", "test@example.com").unwrap()
         });
 
-        // Write an empty tree
-        let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
+        // Add .gitignore that excludes .env (matches real projects)
+        std::fs::write(tmp.path().join(".gitignore"), ".env\n").unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(".gitignore")).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
         let tree = repo.find_tree(tree_id).unwrap();
 
         // Create initial commit
@@ -615,10 +625,9 @@ mod tests {
     }
 
     #[test]
-    fn test_create_worktree_copies_env_file() {
+    fn test_create_worktree_symlinks_env_file() {
         let (_tmp, repo_path) = setup_test_repo();
 
-        // Create a .env file in the repo
         let env_content = "SECRET_KEY=abc123\nDB_URL=postgres://localhost/test\n";
         std::fs::write(Path::new(&repo_path).join(".env"), env_content).unwrap();
 
@@ -628,27 +637,47 @@ mod tests {
         let wt_path = WorktreeManager::create_worktree(&repo_path, "env-test", &worktree_dir)
             .expect("create worktree");
 
-        // .env should have been copied into the worktree
-        let copied_env = wt_path.join(".env");
-        assert!(copied_env.exists(), ".env should be copied to worktree");
+        let wt_env = wt_path.join(".env");
+        assert!(wt_env.is_symlink(), ".env should be a symlink");
         assert_eq!(
-            std::fs::read_to_string(&copied_env).unwrap(),
+            std::fs::read_to_string(&wt_env).unwrap(),
             env_content,
-            ".env contents should match"
+            ".env contents should match via symlink"
+        );
+
+        // Updating the source .env should be visible through the symlink
+        let updated = "SECRET_KEY=updated\n";
+        std::fs::write(Path::new(&repo_path).join(".env"), updated).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&wt_env).unwrap(),
+            updated,
+            "worktree should see updated .env"
         );
     }
 
     #[test]
-    fn test_create_worktree_no_env_file_is_fine() {
+    fn test_create_worktree_symlinks_env_even_when_missing() {
         let (_tmp, repo_path) = setup_test_repo();
-        // No .env file in repo — should not fail
+        // No .env in repo yet
         let wt_dir = TempDir::new().expect("create wt temp dir");
         let worktree_dir = wt_dir.path().join("no-env-test");
 
         let wt_path = WorktreeManager::create_worktree(&repo_path, "no-env-test", &worktree_dir)
             .expect("create worktree");
 
-        assert!(!wt_path.join(".env").exists(), ".env should not exist in worktree");
+        let wt_env = wt_path.join(".env");
+        // Symlink exists but target doesn't — that's fine
+        assert!(wt_env.is_symlink(), ".env symlink should exist");
+        assert!(!wt_env.exists(), "symlink target should not exist yet");
+
+        // Creating .env in the repo makes it visible through the symlink
+        let content = "NEW_KEY=value\n";
+        std::fs::write(Path::new(&repo_path).join(".env"), content).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&wt_env).unwrap(),
+            content,
+            "worktree should see newly created .env"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Worktree `.env` was a one-time copy at session creation, so secrets added later via `controller-cli env set` were invisible to existing sessions
- Changed to symlink the main repo's `.env` so all worktrees share the same file and see updates immediately
- Symlink is created unconditionally (even if `.env` doesn't exist yet) — it resolves once the file is created

## Test plan
- [x] `test_create_worktree_symlinks_env_file` — verifies symlink exists, content readable, and source updates are visible
- [x] `test_create_worktree_symlinks_env_even_when_missing` — verifies dangling symlink works once `.env` is later created
- [x] `test_is_worktree_clean_on_clean_worktree` — still passes (test repos now include `.gitignore` with `.env`)
- [x] Full Rust test suite (316 unit + 4 CLI + 16 integration) passes
- [x] Full frontend test suite (245 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)