### PR TITLE
feat: support duplicating notes

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1392,6 +1392,15 @@ pub fn rename_note(
 }
 
 #[tauri::command]
+pub fn duplicate_note(
+    state: State<'_, AppState>,
+    project_name: String,
+    filename: String,
+) -> Result<String, String> {
+    notes::duplicate_note(state, project_name, filename)
+}
+
+#[tauri::command]
 pub fn delete_note(
     state: State<'_, AppState>,
     project_name: String,

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -70,6 +70,19 @@ pub(crate) fn rename_note(
         .map_err(|e| e.to_string())
 }
 
+pub(crate) fn duplicate_note(
+    state: State<'_, AppState>,
+    project_name: String,
+    filename: String,
+) -> Result<String, String> {
+    let base_dir = state
+        .storage
+        .lock()
+        .map_err(|e| e.to_string())?
+        .base_dir();
+    notes::duplicate_note(&base_dir, &project_name, &filename).map_err(|e| e.to_string())
+}
+
 pub(crate) fn delete_note(
     state: State<'_, AppState>,
     project_name: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub fn run() {
             commands::write_note,
             commands::create_note,
             commands::rename_note,
+            commands::duplicate_note,
             commands::delete_note,
             commands::send_note_ai_chat,
             commands::save_session_prompt,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::fs;
 use std::path::PathBuf;
+use uuid::Uuid;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct NoteEntry {
@@ -175,6 +176,33 @@ pub fn rename_note(
     Ok(new_filename)
 }
 
+/// Duplicate a note file. Creates a copy named `{stem}-{uuid}.md`.
+/// Returns the filename of the new copy.
+pub fn duplicate_note(
+    base: &std::path::Path,
+    project_name: &str,
+    filename: &str,
+) -> std::io::Result<String> {
+    validate_filename(filename)?;
+    let dir = notes_dir_with_base(base, project_name);
+    let src_path = dir.join(filename);
+
+    if !src_path.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("note '{}' not found", filename),
+        ));
+    }
+
+    let content = fs::read_to_string(&src_path)?;
+    let stem = filename.strip_suffix(".md").unwrap_or(filename);
+    let short_id = &Uuid::new_v4().to_string()[..8];
+    let copy_filename = format!("{}-{}.md", stem, short_id);
+
+    fs::write(dir.join(&copy_filename), content)?;
+    Ok(copy_filename)
+}
+
 /// Delete a note file. Returns Ok(()) even if the file doesn't exist (idempotent).
 pub fn delete_note(
     base: &std::path::Path,
@@ -305,6 +333,46 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let result = delete_note(tmp.path(), "proj", "nonexistent.md");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_note() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        create_note(base, "proj", "original").unwrap();
+        write_note(base, "proj", "original.md", "hello world").unwrap();
+
+        let copy = duplicate_note(base, "proj", "original.md").unwrap();
+        assert!(copy.starts_with("original-"), "expected 'original-<uuid>.md', got '{}'", copy);
+        assert!(copy.ends_with(".md"));
+        assert_ne!(copy, "original.md");
+
+        let content = read_note(base, "proj", &copy).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_duplicate_note_unique_names() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        create_note(base, "proj", "doc").unwrap();
+
+        let copy1 = duplicate_note(base, "proj", "doc.md").unwrap();
+        let copy2 = duplicate_note(base, "proj", "doc.md").unwrap();
+        assert_ne!(copy1, copy2);
+
+        // Both should exist with the same content
+        let c1 = read_note(base, "proj", &copy1).unwrap();
+        let c2 = read_note(base, "proj", &copy2).unwrap();
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn test_duplicate_nonexistent_note_fails() {
+        let tmp = TempDir::new().unwrap();
+        let result = duplicate_note(tmp.path(), "proj", "nope.md");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
     }
 
     #[test]

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -396,6 +396,11 @@
           dispatchAction({ type: "rename-note", projectId: currentFocus.projectId, filename: currentFocus.filename });
         }
         return true;
+      case "duplicate-note":
+        if (currentFocus?.type === "note") {
+          dispatchAction({ type: "duplicate-note", projectId: currentFocus.projectId, filename: currentFocus.filename });
+        }
+        return true;
       case "toggle-note-preview":
         dispatchAction({ type: "toggle-note-preview" });
         return true;

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -195,6 +195,10 @@
           renameNoteTarget = { projectId: action.projectId, filename: action.filename };
           break;
         }
+        case "duplicate-note": {
+          handleDuplicateNote(action.projectId, action.filename);
+          break;
+        }
       }
     });
     return unsub;
@@ -523,6 +527,21 @@
       }
       focusTarget.set({ type: "note", filename: newFilename, projectId });
       showToast("Note renamed", "info");
+    } catch (e) {
+      showToast(String(e), "error");
+    }
+  }
+
+  async function handleDuplicateNote(projectId: string, filename: string) {
+    const project = projectList.find(p => p.id === projectId);
+    if (!project) return;
+    try {
+      const newFilename: string = await command("duplicate_note", { projectName: project.name, filename });
+      const notes = await command<NoteEntry[]>("list_notes", { projectName: project.name });
+      noteEntries.update(m => { const next = new Map(m); next.set(project.id, notes); return next; });
+      activeNote.set({ projectId, filename: newFilename });
+      focusTarget.set({ type: "note", filename: newFilename, projectId });
+      showToast("Note duplicated", "info");
     } catch (e) {
       showToast(String(e), "error");
     }

--- a/src/lib/commands.test.ts
+++ b/src/lib/commands.test.ts
@@ -173,7 +173,7 @@ describe("command registry", () => {
     expect(panels.entries).toHaveLength(4);
 
     const notes = sections.find(s => s.label === "Notes")!;
-    expect(notes.entries).toHaveLength(4);
+    expect(notes.entries).toHaveLength(5);
     expect(notes.entries).toContainEqual({
       key: "p",
       description: "Cycle edit / preview / split",

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -27,6 +27,7 @@ export type CommandId =
   | "create-note"
   | "delete-note"
   | "rename-note"
+  | "duplicate-note"
   | "toggle-note-preview"
   | "save-prompt"
   | "load-prompt"
@@ -105,6 +106,7 @@ export const commands: CommandDef[] = [
   { id: "create-note", key: "n", section: "Notes", description: "Create new note", mode: "notes" },
   { id: "delete-note", key: "d", section: "Notes", description: "Delete focused note", mode: "notes" },
   { id: "rename-note", key: "r", section: "Notes", description: "Rename focused note", mode: "notes" },
+  { id: "duplicate-note", key: "y", section: "Notes", description: "Duplicate focused note", mode: "notes" },
   { id: "toggle-note-preview", key: "p", section: "Notes", description: "Cycle edit / preview / split", mode: "notes" },
   { id: "expand-collapse", key: "o", section: "Notes", description: "Open note for editing", mode: "notes", hidden: true },
   { id: "expand-collapse", key: "i", section: "Notes", description: "Open note for editing", mode: "notes", hidden: true },

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -263,6 +263,7 @@ export type HotkeyAction =
   | { type: "create-note" }
   | { type: "delete-note"; projectId: string; filename: string }
   | { type: "rename-note"; projectId: string; filename: string }
+  | { type: "duplicate-note"; projectId: string; filename: string }
   | { type: "toggle-note-preview" }
   | { type: "save-session-prompt"; sessionId: string; projectId: string }
   | { type: "pick-prompt-for-session"; projectId: string }


### PR DESCRIPTION
## Summary
- Adds `duplicate_note` Rust backend function that copies a note's content into `<stem>-<uuid>.md`
- Wires it through the full stack: Tauri command → hotkey (`y` in notes mode) → Sidebar handler
- Opens the duplicate immediately and shows a toast
- Includes 3 Rust unit tests (basic duplicate, unique names, nonexistent source)

## Test plan
- [x] `cargo test notes::` — all 17 tests pass
- [x] `npx vitest run` — all 247 tests pass
- [ ] Manual: focus a note in notes mode, press `y`, verify duplicate is created and opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)