### PR TITLE
fix: add explicit text color to notes preview

### DIFF
--- a/src/lib/NotesEditor.svelte
+++ b/src/lib/NotesEditor.svelte
@@ -347,6 +347,7 @@
     box-sizing: border-box;
     flex: 1;
     background: var(--bg-void);
+    color: var(--text-primary);
   }
 
   .preview.split {


### PR DESCRIPTION
## Summary
- Notes preview mode had invisible text because the `.preview` container relied on CSS inheritance for text color
- Added explicit `color: var(--text-primary)` to the preview container to ensure text is visible against the black background

## Test plan
- [x] All 273 existing tests pass (1 pre-existing failure in retheme-migration unrelated to this change)
- [ ] Open a note in Preview or Split mode and verify text is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)