### PR TITLE
fix: add --skip-git-repo-check to codex for notes AI

### DIFF
--- a/src-tauri/src/note_ai_chat.rs
+++ b/src-tauri/src/note_ai_chat.rs
@@ -63,6 +63,7 @@ pub fn parse_note_ai_response(raw: &str) -> Result<NoteAiResponse, String> {
 fn run_note_ai_turn(repo_path: String, prompt: String) -> Result<NoteAiResponse, String> {
     let output = std::process::Command::new("codex")
         .arg("exec")
+        .arg("--skip-git-repo-check")
         .arg("--sandbox")
         .arg("danger-full-access")
         .arg(&prompt)


### PR DESCRIPTION
## Summary
- Notes AI chat (`ga` in visual mode) invokes `codex exec` with working directory set to `/tmp`
- `/tmp` isn't a git repo, so codex's git trust check fails with "Not inside a trusted directory"
- Added `--skip-git-repo-check` flag to bypass since notes don't need git context

## Test plan
- [ ] Open a note, select text, press `ga`, type a prompt — should get a response instead of the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)