### PR TITLE
fix: resilient architecture relationship JSON parsing

### DIFF
--- a/src-tauri/src/architecture.rs
+++ b/src-tauri/src/architecture.rs
@@ -150,7 +150,9 @@ pub struct ArchitectureComponent {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArchitectureRelationship {
+    #[serde(default, alias = "target", alias = "target_id", alias = "id")]
     pub component_id: String,
+    #[serde(default)]
     pub summary: String,
 }
 
@@ -286,6 +288,7 @@ Requirements:\n\
 - \"title\" must be a short architecture title.\n\
 - \"mermaid\" must be a valid Mermaid flowchart using stable component ids.\n\
 - \"components\" must be an array of objects with: id, name, summary, contains, incoming_relationships, outgoing_relationships, evidence_paths, evidence_snippets.\n\
+- Each entry in incoming_relationships and outgoing_relationships must be an object with exactly two keys: \"component_id\" (the id of the related component) and \"summary\" (a short description of the relationship).\n\
 - Every component id must appear as a Mermaid node id.\n\
 - evidence_paths and evidence_snippets must cite only the files shown below.\n\
 - Output JSON only. No prose, no markdown fences.\n\n\
@@ -1525,6 +1528,87 @@ That should be enough to render the view."#;
         let error = parse_architecture_output(output).expect_err("missing id should fail");
         assert!(error.contains("component"));
         assert!(error.contains("id"));
+    }
+
+    #[test]
+    fn accepts_relationship_with_target_alias_for_component_id() {
+        let output = r#"{
+          "title": "Aliased relationships",
+          "mermaid": "flowchart TD\napi[API]\nworker[Worker]\napi --> worker",
+          "components": [
+            {
+              "id": "api",
+              "name": "API",
+              "summary": "Handles requests",
+              "contains": [],
+              "incoming_relationships": [],
+              "outgoing_relationships": [
+                {
+                  "target": "worker",
+                  "summary": "Sends jobs"
+                }
+              ],
+              "evidence_paths": [],
+              "evidence_snippets": []
+            },
+            {
+              "id": "worker",
+              "name": "Worker",
+              "summary": "Processes jobs",
+              "contains": [],
+              "incoming_relationships": [
+                {
+                  "target_id": "api",
+                  "summary": "Receives jobs"
+                }
+              ],
+              "outgoing_relationships": [],
+              "evidence_paths": [],
+              "evidence_snippets": []
+            }
+          ]
+        }"#;
+
+        let parsed = parse_architecture_output(output).expect("aliased fields should parse");
+        assert_eq!(parsed.components[0].outgoing_relationships[0].component_id, "worker");
+        assert_eq!(parsed.components[1].incoming_relationships[0].component_id, "api");
+    }
+
+    #[test]
+    fn rejects_relationship_with_missing_component_id_and_no_alias() {
+        let output = r#"{
+          "title": "Missing relationship target",
+          "mermaid": "flowchart TD\napi[API]\nworker[Worker]\napi --> worker",
+          "components": [
+            {
+              "id": "api",
+              "name": "API",
+              "summary": "Handles requests",
+              "contains": [],
+              "incoming_relationships": [],
+              "outgoing_relationships": [
+                {
+                  "summary": "Sends jobs"
+                }
+              ],
+              "evidence_paths": [],
+              "evidence_snippets": []
+            },
+            {
+              "id": "worker",
+              "name": "Worker",
+              "summary": "Processes jobs",
+              "contains": [],
+              "incoming_relationships": [],
+              "outgoing_relationships": [],
+              "evidence_paths": [],
+              "evidence_snippets": []
+            }
+          ]
+        }"#;
+
+        let error = parse_architecture_output(output).expect_err("missing component_id should fail in validation");
+        assert!(error.contains("missing component id"), "error should mention missing component id: {}", error);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `#[serde(alias)]` for `"target"`, `"target_id"`, and `"id"` on `component_id` field in `ArchitectureRelationship`, plus `#[serde(default)]` on both fields — prevents hard serde failures when the LLM uses alternate field names
- Make the architecture prompt explicitly describe the relationship object shape (`{"component_id": "...", "summary": "..."}`) to reduce LLM variation
- Add two tests: one verifying aliases work, one verifying missing fields still get caught by validation

## Test plan
- [x] `cargo test architecture` — all 34 tests pass
- [x] `npx vitest run` — 273/274 pass (1 pre-existing retheme migration failure, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)