### PR TITLE
fix: make ga trigger AI chat when entire note is selected

### DIFF
--- a/e2e/specs/notes-ai-chat.spec.ts
+++ b/e2e/specs/notes-ai-chat.spec.ts
@@ -166,3 +166,32 @@ test("multiline visual selection works with ga", async ({ page }) => {
   await page.waitForTimeout(300);
   await expect(panel).not.toBeVisible();
 });
+
+test("ga works when entire note is selected with ggVG", async ({ page }) => {
+  const editor = await navigateToNote(page, "the-controller", "ai-chat-test.md");
+
+  // Select the entire note: gg (go to top), V (visual line), G (to bottom)
+  await page.keyboard.press("g");
+  await page.waitForTimeout(100);
+  await page.keyboard.press("g");
+  await page.waitForTimeout(200);
+  await page.keyboard.press("Shift+v");
+  await page.waitForTimeout(200);
+  await page.keyboard.press("Shift+g");
+  await page.waitForTimeout(200);
+
+  // Press ga to trigger AI chat
+  await page.keyboard.press("g");
+  await page.waitForTimeout(100);
+  await page.keyboard.press("a");
+  await page.waitForTimeout(500);
+
+  // Panel should appear even though position 0 may be scrolled off-screen
+  const panel = page.locator('[data-testid="note-ai-panel"]');
+  await expect(panel).toBeVisible({ timeout: 3_000 });
+
+  // Dismiss
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(300);
+  await expect(panel).not.toBeVisible();
+});

--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -95,7 +95,10 @@
       const from = sel.from;
       const to = sel.to;
       const selectedText = view.state.doc.sliceString(from, to);
-      const coords = view.coordsAtPos(from);
+      // coordsAtPos returns null for off-screen positions. When the entire
+      // note is selected (ggVG), `from` (pos 0) is scrolled out of view
+      // while `to` (cursor end) is visible — fall back to `to` coords.
+      const coords = view.coordsAtPos(from) ?? view.coordsAtPos(to);
       if (!coords) return;
       onAiChat?.({
         selectedText,


### PR DESCRIPTION
## Summary
- `ga` in visual mode failed to open the AI chat panel when the entire note was selected (e.g. `ggVG`)
- Root cause: `coordsAtPos(from)` returns `null` when position 0 is scrolled off-screen after selecting to the bottom
- Fix: fall back to `coordsAtPos(to)` which is always visible (cursor end position)

## Test plan
- [ ] Added E2E test for `ggVG` + `ga` scenario
- [ ] Existing `ga` tests still pass
- [ ] Rust tests pass (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)