### PR TITLE
fix: add explicit text color to notes editor content

### DIFF
--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -165,6 +165,7 @@
 
   .note-code-editor :global(.cm-content) {
     padding: 16px;
+    color: var(--text-primary);
     caret-color: var(--text-primary);
   }
 


### PR DESCRIPTION
## Summary
- Add explicit `color: var(--text-primary)` to `.cm-content` in the CodeMirror notes editor
- Same root cause as #409 (preview fix) — WKWebView doesn't reliably inherit CSS `color` from parent elements
- Without this, editor text is invisible (light text defaults to an unreadable color against the black background)

## Test plan
- [x] Verified retheme-migration test failure is pre-existing on master
- [x] All other frontend tests pass (273/274)
- [x] All Rust tests pass (16/16)
- [ ] Visual verification: open a note in Edit mode in Tauri — text should be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)