### PR TITLE
fix: normalize Shift+letter key events for vim plugin in WKWebView

### DIFF
--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -5,6 +5,25 @@
   import { markdown } from "@codemirror/lang-markdown";
   import { Vim, getCM, vim } from "@replit/codemirror-vim";
 
+  // WKWebView (Tauri on macOS) may report Shift+letter keydown events with
+  // a lowercase `key` and `shiftKey: true` instead of the uppercase `key` the
+  // vim plugin expects.  Patch `vimKeyFromEvent` so 'g' + shiftKey → 'G'.
+  const _origVimKeyFromEvent = Vim.vimKeyFromEvent;
+  Vim.vimKeyFromEvent = function (e: any, vim: any) {
+    if (
+      e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey &&
+      typeof e.key === "string" && e.key.length === 1 &&
+      e.key >= "a" && e.key <= "z"
+    ) {
+      return _origVimKeyFromEvent.call(
+        this,
+        { key: e.key.toUpperCase(), shiftKey: e.shiftKey, ctrlKey: e.ctrlKey, altKey: e.altKey, metaKey: e.metaKey, code: e.code },
+        vim,
+      );
+    }
+    return _origVimKeyFromEvent.call(this, e, vim);
+  };
+
   export type VimMode = "normal" | "insert" | "visual" | "replace";
 
   export interface AiChatRequest {


### PR DESCRIPTION
## Summary
- WKWebView (Tauri on macOS) can report `Shift+G` as `{key: "g", shiftKey: true}` instead of `{key: "G"}`, causing the vim plugin to misread `G` (go-to-last-line) as `g` (prefix key)
- This broke `v + Shift+G + ga` and `ggVG + ga` sequences for triggering AI chat in notes mode
- Patches `Vim.vimKeyFromEvent` to normalize lowercase keys to uppercase when `shiftKey` is true

## Test plan
- [x] E2E: `vG + ga` opens AI chat panel (was broken, now passes)
- [x] E2E: `ggVG + ga` opens AI chat panel (was broken, now passes)
- [x] E2E: `v$ + ga` still works (baseline, unaffected)
- [x] E2E: multiline visual selection + ga still works
- [x] E2E: ga in normal mode still does nothing
- [x] Unit tests: 273/274 pass (1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)