### PR TITLE
fix: AI chat panel positioned off-screen with vG selection

### DIFF
--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -114,10 +114,13 @@
       const from = sel.from;
       const to = sel.to;
       const selectedText = view.state.doc.sliceString(from, to);
-      // coordsAtPos returns null for off-screen positions. When the entire
-      // note is selected (ggVG), `from` (pos 0) is scrolled out of view
-      // while `to` (cursor end) is visible — fall back to `to` coords.
-      const coords = view.coordsAtPos(from) ?? view.coordsAtPos(to);
+      // coordsAtPos returns null for some off-screen positions, but for
+      // positions scrolled above the viewport it may return very negative
+      // coordinates instead.  When the entire note is selected (vG / ggVG),
+      // `from` (pos 0) is scrolled out of view while `to` (cursor end) is
+      // visible — fall back to `to` coords in either case.
+      const fromCoords = view.coordsAtPos(from);
+      const coords = (fromCoords && fromCoords.bottom >= 0) ? fromCoords : view.coordsAtPos(to);
       if (!coords) return;
       onAiChat?.({
         selectedText,

--- a/src/lib/NoteAiPanel.svelte
+++ b/src/lib/NoteAiPanel.svelte
@@ -28,11 +28,16 @@
   let currentFrom = $state(request.from);
   let currentTo = $state(request.to);
 
-  // Position the panel near the selection
+  // Position the panel near the selection, clamped within the viewport
   let panelStyle = $derived((() => {
     const { coords } = request;
-    const left = Math.max(8, coords.left);
-    const top = coords.bottom + 8;
+    const maxHeight = 340; // matches CSS max-height
+    const left = Math.min(Math.max(8, coords.left), window.innerWidth - 408);
+    let top = coords.bottom + 8;
+    // If the panel would overflow below the viewport, flip it above the selection
+    if (top + maxHeight > window.innerHeight) {
+      top = Math.max(8, coords.top - maxHeight - 8);
+    }
     return `left: ${left}px; top: ${top}px;`;
   })());
 


### PR DESCRIPTION
## Summary
- `coordsAtPos(from)` returns very negative coordinates (not null) for positions scrolled above the viewport, so the `??` fallback to `coordsAtPos(to)` never triggered — the AI panel was rendered at `top: -1480px`
- Fixed fallback to check for negative `bottom` coords, not just null
- Added viewport clamping: panel flips above the selection when it would overflow below, and `left` is clamped to prevent horizontal overflow

## Test plan
- [x] Playwright e2e: `v + G + ga` on long note — panel appears within viewport (was y=-1480, now y=344)
- [x] Playwright e2e: `ggVG + ga` — panel within viewport
- [x] Playwright e2e: `v$ + ga` on-screen selection — panel positioned near selection (no regression)
- [x] `npx vitest run` — 273/274 pass (1 pre-existing retheme failure)
- [x] `cargo test` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)