### PR TITLE
fix: migrate remaining Catppuccin hex values to CSS custom properties

### DIFF
--- a/src/lib/DeploySetupModal.svelte
+++ b/src/lib/DeploySetupModal.svelte
@@ -118,8 +118,8 @@
   }
 
   .modal {
-    background: #1e1e2e;
-    border: 1px solid #313244;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
     border-radius: 8px;
     padding: 24px;
     min-width: 400px;
@@ -129,14 +129,14 @@
   .modal-title {
     font-size: 16px;
     font-weight: 600;
-    color: #cdd6f4;
+    color: var(--text-emphasis);
     margin-bottom: 20px;
   }
 
   .field-label {
     display: block;
     font-size: 12px;
-    color: #a6adc8;
+    color: var(--text-secondary);
     margin-bottom: 6px;
     margin-top: 12px;
   }
@@ -144,27 +144,27 @@
   .field-input {
     width: 100%;
     padding: 8px 12px;
-    background: #11111b;
-    border: 1px solid #313244;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
     border-radius: 4px;
-    color: #cdd6f4;
+    color: var(--text-primary);
     font-size: 13px;
     outline: none;
     box-sizing: border-box;
   }
 
   .field-input:focus {
-    border-color: #89b4fa;
+    border-color: var(--focus-ring);
   }
 
   .hint {
     font-size: 11px;
-    color: #6c7086;
+    color: var(--text-tertiary);
     margin-top: 6px;
   }
 
-  .status { color: #89b4fa; font-size: 14px; }
-  .error { color: #f38ba8; font-size: 13px; }
+  .status { color: var(--text-emphasis); font-size: 14px; }
+  .error { color: var(--status-error); font-size: 13px; }
 
   .actions {
     display: flex;
@@ -181,6 +181,6 @@
     border: none;
   }
 
-  .cancel { background: #313244; color: #a6adc8; }
-  .primary { background: #89b4fa; color: #1e1e2e; font-weight: 600; }
+  .cancel { background: var(--bg-active); color: var(--text-secondary); }
+  .primary { background: var(--focus-ring); color: var(--bg-void); font-weight: 600; }
 </style>

--- a/src/lib/InfrastructureDashboard.svelte
+++ b/src/lib/InfrastructureDashboard.svelte
@@ -83,8 +83,8 @@
 <style>
   .container {
     height: 100%;
-    background: #11111b;
-    color: #cdd6f4;
+    background: var(--bg-void);
+    color: var(--text-primary);
     display: flex;
   }
 
@@ -97,9 +97,9 @@
   }
 
   .title { font-size: 18px; font-weight: 600; margin-bottom: 8px; }
-  .subtitle { font-size: 14px; color: #a6adc8; margin-bottom: 16px; }
-  .hint { font-size: 12px; color: #6c7086; }
-  kbd { background: #313244; padding: 2px 6px; border-radius: 3px; font-family: monospace; font-size: 11px; }
+  .subtitle { font-size: 14px; color: var(--text-secondary); margin-bottom: 16px; }
+  .hint { font-size: 12px; color: var(--text-tertiary); }
+  kbd { background: var(--bg-active); padding: 2px 6px; border-radius: 3px; font-family: monospace; font-size: 11px; }
 
   .dashboard {
     flex: 1;
@@ -116,31 +116,31 @@
   }
 
   .service-card {
-    background: #1e1e2e;
-    border: 1px solid #313244;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
     border-radius: 6px;
     padding: 12px 16px;
     cursor: pointer;
     text-align: left;
-    color: #cdd6f4;
+    color: var(--text-primary);
     font-family: inherit;
     font-size: 13px;
   }
 
-  .service-card:hover { border-color: #45475a; }
-  .service-card.selected { border-color: #89b4fa; background: rgba(137, 180, 250, 0.05); }
+  .service-card:hover { border-color: var(--text-tertiary); }
+  .service-card.selected { border-color: var(--focus-ring); background: rgba(255, 255, 255, 0.05); }
 
   .service-header { display: flex; align-items: center; gap: 8px; }
   .status-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
   .service-name { font-weight: 600; flex: 1; }
-  .service-status { font-size: 12px; color: #a6adc8; }
+  .service-status { font-size: 12px; color: var(--text-secondary); }
 
-  .service-meta { display: flex; gap: 12px; margin-top: 6px; font-size: 11px; color: #6c7086; }
+  .service-meta { display: flex; gap: 12px; margin-top: 6px; font-size: 11px; color: var(--text-tertiary); }
 
   .log-panel {
     flex: 1;
-    background: #1e1e2e;
-    border: 1px solid #313244;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
     border-radius: 6px;
     display: flex;
     flex-direction: column;
@@ -149,9 +149,9 @@
 
   .log-header {
     padding: 8px 12px;
-    border-bottom: 1px solid #313244;
+    border-bottom: 1px solid var(--border-default);
     font-size: 12px;
-    color: #a6adc8;
+    color: var(--text-secondary);
   }
 
   .log-content {
@@ -160,7 +160,7 @@
     overflow-y: auto;
     font-family: monospace;
     font-size: 12px;
-    color: #a6adc8;
+    color: var(--text-secondary);
   }
 
   .log-line { padding: 1px 0; }


### PR DESCRIPTION
## Summary
- Replaced hardcoded Catppuccin hex color values in `InfrastructureDashboard.svelte` and `DeploySetupModal.svelte` style blocks with CSS custom properties (`--bg-void`, `--bg-surface`, `--border-default`, `--text-primary`, etc.)
- Fixes the failing `retheme-migration.test.ts` test

## Test plan
- [x] `npx vitest run` passes (274/274 tests, including the previously failing retheme migration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)