### PR TITLE
fix: clean up orphaned staging processes and log staging output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vite.config.ts.timestamp-*
 e2e/results/
 test-results/
 playwright-report/
+staging.log

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -879,7 +879,10 @@ pub async fn stage_session(
             if alive {
                 return Err("A session is already staged — unstage it first".to_string());
             }
-            // Stale record — clear it
+            // Stale record — kill orphaned children (e.g. Vite, esbuild that outlived
+            // the process leader), clean up the socket, then clear the record.
+            kill_process_group(staged.pid);
+            let _ = std::fs::remove_file(crate::status_socket::staged_socket_path());
             let mut p = project.clone();
             p.staged_session = None;
             storage.save_project(&p).map_err(|e| e.to_string())?;
@@ -1046,12 +1049,18 @@ pub async fn stage_session(
         .emit("staging-status", &format!("Starting on port {}...", port));
 
     let wt = worktree_path.clone();
+    let log_path = PathBuf::from(&wt).join("staging.log");
+    let log_file = std::fs::File::create(&log_path)
+        .map_err(|e| format!("Failed to create staging log: {}", e))?;
+    let log_stderr = log_file
+        .try_clone()
+        .map_err(|e| format!("Failed to clone log file: {}", e))?;
     let child = std::process::Command::new("bash")
         .args(["./dev.sh", &port.to_string()])
         .current_dir(&wt)
         .env("CONTROLLER_SOCKET", crate::status_socket::staged_socket_path())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::from(log_file))
+        .stderr(Stdio::from(log_stderr))
         .process_group(0)
         .spawn()
         .map_err(|e| format!("Failed to spawn staged instance: {}", e))?;


### PR DESCRIPTION
## Summary
- When detecting a stale staged session (dead process leader), now also kills the orphaned process group (catches surviving Vite/esbuild children) and removes the stale staged socket file before clearing the record
- Redirects staging output to `staging.log` in the worktree instead of `/dev/null` so errors are visible for debugging

## Root cause
When a staged Controller instance dies, `kill_process_group` sends SIGTERM/SIGKILL to the group. However, child processes (Vite, esbuild) can survive if the leader dies first. The stale session guard detected the dead leader and cleared the record, but left orphaned children running on staging ports. Subsequent staging attempts could then hit port conflicts or stale sockets, causing whitescreens.

## Test plan
- [x] `cargo test` — 16 passed
- [x] `npx vitest run` — 273 passed, 1 pre-existing failure (retheme-migration)
- [ ] Stage a session, unstage, re-stage — verify no orphaned processes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)