### PR TITLE
feat: forward frontend JS errors to staging log

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2038,6 +2038,11 @@ pub async fn get_maintainer_issue_detail(
     github::get_maintainer_issue_detail(repo_path, github_repo, issue_number).await
 }
 
+#[tauri::command]
+pub fn log_frontend_error(message: String) {
+    eprintln!("[FRONTEND] {}", message);
+}
+
 fn find_main_branch_oid(repo: &git2::Repository) -> Option<git2::Oid> {
     for name in &["refs/heads/master", "refs/heads/main"] {
         if let Ok(reference) = repo.find_reference(name) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ pub fn run() {
             deploy::commands::is_deploy_provisioned,
             deploy::commands::deploy_project,
             deploy::commands::list_deployed_services,
+            commands::log_frontend_error,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,23 @@
+import { invoke } from "@tauri-apps/api/core";
 import App from "./App.svelte";
 import "./app.css";
 import { mount } from "svelte";
+
+function logToBackend(message: string) {
+  invoke("log_frontend_error", { message }).catch(() => {});
+}
+
+window.addEventListener("error", (e) => {
+  const loc = e.filename ? ` at ${e.filename}:${e.lineno}:${e.colno}` : "";
+  logToBackend(`${e.message}${loc}\n${e.error?.stack || ""}`);
+});
+
+window.addEventListener("unhandledrejection", (e) => {
+  const reason = e.reason instanceof Error
+    ? `${e.reason.message}\n${e.reason.stack}`
+    : String(e.reason);
+  logToBackend(`Unhandled rejection: ${reason}`);
+});
 
 const app = mount(App, {
   target: document.getElementById("app")!,


### PR DESCRIPTION
## Summary
- Add global `window.error` and `unhandledrejection` handlers in `main.ts` that forward JS runtime errors to the Rust backend via Tauri IPC
- Add `log_frontend_error` Tauri command that writes error details to stderr
- Since staging redirects stderr to `staging.log`, frontend errors now appear in the log for CLI-based diagnosis

## Test plan
- [x] All 274 frontend tests pass
- [x] All 16 Rust tests pass
- [x] `cargo check` compiles cleanly
- [ ] Stage a session with a known JS error → verify the error appears in `staging.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)