### PR TITLE
fix: make text readable in vim visual mode selection

### DIFF
--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -206,9 +206,15 @@
   /* Hide native browser selection — drawSelection() renders its own overlay.
      CodeMirror's built-in hideNativeSelection CSS doesn't reliably suppress
      the native ::selection in WebKit/WKWebView (Tauri), causing a visible
-     "smeared" highlight alongside (or persisting after) the custom overlay. */
+     "smeared" highlight alongside (or persisting after) the custom overlay.
+     The :focus variants are needed to override CodeMirror's own
+     `.cm-content :focus::selection { background-color: highlight }` rule. */
   .note-code-editor :global(.cm-content::selection),
-  .note-code-editor :global(.cm-content *::selection) {
-    background-color: transparent !important;
+  .note-code-editor :global(.cm-content *::selection),
+  .note-code-editor :global(.cm-content :focus::selection),
+  .note-code-editor :global(.cm-content :focus *::selection) {
+    background-color: rgba(255, 255, 255, 0.15) !important;
+    color: var(--text-emphasis) !important;
+    -webkit-text-fill-color: var(--text-emphasis) !important;
   }
 </style>


### PR DESCRIPTION
## Summary
- CodeMirror's `.cm-content :focus::selection { background-color: highlight }` rule was overriding our `transparent` background with the system highlight color (lavender), making text nearly invisible in WKWebView visual mode
- Added `:focus` selector variants to match CodeMirror's specificity
- Set explicit `rgba(255, 255, 255, 0.15)` selection background and forced white text via `color` and `-webkit-text-fill-color`

## Test plan
- [x] `npx vitest run` — 274 tests pass
- [x] `cargo test` — 16 tests pass
- [x] Playwright confirmed: text is clearly readable (white on selection highlight) in visual mode
- [ ] Manual: open a note, press `V` then `G` to select all — text should be white and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)