### PR TITLE
fix: use dark text for vim visual mode selection

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -30,6 +30,9 @@
   --status-error: #c44040;
   --status-exited: #555555;
 
+  /* Selection */
+  --text-selection: #111111;
+
   /* Focus */
   --focus-ring: #ffffff;
 

--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -214,7 +214,7 @@
   .note-code-editor :global(.cm-content :focus::selection),
   .note-code-editor :global(.cm-content :focus *::selection) {
     background-color: rgba(255, 255, 255, 0.15) !important;
-    color: var(--text-emphasis) !important;
-    -webkit-text-fill-color: var(--text-emphasis) !important;
+    color: var(--text-selection) !important;
+    -webkit-text-fill-color: var(--text-selection) !important;
   }
 </style>


### PR DESCRIPTION
## Summary
- Changed vim visual mode selection text from white (`--text-emphasis`) to dark (`--text-selection: #111111`) for readability against macOS native lavender selection background
- Added `--text-selection` CSS custom property to avoid hardcoded Catppuccin hex values

## Test plan
- [x] All 274 frontend tests pass (including retheme-migration test)
- [x] All 16 Rust tests pass
- [ ] Visual verification: enter vim visual mode in notes editor, confirm text is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)