### PR TITLE
fix: stop staging info from appearing in current window title

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -328,13 +328,10 @@
     }
   }
 
-  function updateWindowTitle(branch: string, commit: string, staging?: string) {
+  function updateWindowTitle(branch: string, commit: string) {
     try {
       const parts = [commit, branch, `localhost:${__DEV_PORT__}`];
-      let title = `The Controller (${parts.join(", ")})`;
-      if (staging) {
-        title += ` — ${staging}`;
-      }
+      const title = `The Controller (${parts.join(", ")})`;
       getCurrentWindow().setTitle(title);
     } catch {
       // Browser mode — no Tauri window API available
@@ -407,24 +404,6 @@
       showToast(`Failed to generate architecture: ${error}`, "error");
     }
   }
-
-  $effect(() => {
-    const stagedProject = projectsState.current.find((p) => p.staged_session);
-    if (stagedProject) {
-      const session = stagedProject.sessions.find(
-        (s) => s.id === stagedProject.staged_session!.session_id,
-      );
-      const label = session?.label ?? "unknown";
-      const port = stagedProject.staged_session!.port;
-      updateWindowTitle(
-        __BUILD_BRANCH__,
-        __BUILD_COMMIT__,
-        `staging: ${label} (localhost:${port})`,
-      );
-    } else {
-      updateWindowTitle(__BUILD_BRANCH__, __BUILD_COMMIT__);
-    }
-  });
 
   onMount(() => {
     const unlistenSecureEnv = listen<string>("secure-env-requested", (payload) => {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -327,7 +327,7 @@ describe("Window title updates on staging", () => {
     });
   });
 
-  it("updates title with staging info when a session is staged", async () => {
+  it("does not change title when a session is staged", async () => {
     vi.mocked(command).mockImplementation(async (cmd: string) => {
       if (cmd === "restore_sessions") return;
       if (cmd === "check_onboarding") return { projects_root: "/tmp/projects" };
@@ -335,73 +335,31 @@ describe("Window title updates on staging", () => {
     });
 
     render(App);
-
-    // Stage a session by updating the projects store
-    projects.set([{
-      ...baseProject,
-      staged_session: {
-        session_id: "sess-1",
-        pid: 12345,
-        port: 1421,
-      },
-      maintainer: { enabled: false, interval_minutes: 60 },
-      auto_worker: { enabled: false },
-      prompts: [],
-      sessions: [{ id: "sess-1", label: "fix-foo", worktree_path: null, worktree_branch: null, archived: false, kind: "claude", github_issue: null, initial_prompt: null, auto_worker_session: false }],
-    }]);
-
-    await waitFor(() => {
-      expect(mocks.setTitle).toHaveBeenCalledWith(
-        "The Controller (test-commit, test-branch, localhost:1420) \u2014 staging: fix-foo (localhost:1421)",
-      );
-    });
-  });
-
-  it("reverts title when session is unstaged", async () => {
-    vi.mocked(command).mockImplementation(async (cmd: string) => {
-      if (cmd === "restore_sessions") return;
-      if (cmd === "check_onboarding") return { projects_root: "/tmp/projects" };
-      return;
-    });
-
-    render(App);
-
-    // Stage
-    projects.set([{
-      ...baseProject,
-      staged_session: {
-        session_id: "sess-1",
-        pid: 12345,
-        port: 1421,
-      },
-      maintainer: { enabled: false, interval_minutes: 60 },
-      auto_worker: { enabled: false },
-      prompts: [],
-      sessions: [{ id: "sess-1", label: "fix-foo", worktree_path: null, worktree_branch: null, archived: false, kind: "claude", github_issue: null, initial_prompt: null, auto_worker_session: false }],
-    }]);
-
-    await waitFor(() => {
-      expect(mocks.setTitle).toHaveBeenCalledWith(
-        "The Controller (test-commit, test-branch, localhost:1420) \u2014 staging: fix-foo (localhost:1421)",
-      );
-    });
-
-    // Unstage
-    mocks.setTitle.mockClear();
-    projects.set([{
-      ...baseProject,
-      staged_session: null,
-      maintainer: { enabled: false, interval_minutes: 60 },
-      auto_worker: { enabled: false },
-      prompts: [],
-      sessions: [],
-    }]);
 
     await waitFor(() => {
       expect(mocks.setTitle).toHaveBeenCalledWith(
         "The Controller (test-commit, test-branch, localhost:1420)",
       );
     });
+
+    // Stage a session — title should NOT change
+    mocks.setTitle.mockClear();
+    projects.set([{
+      ...baseProject,
+      staged_session: {
+        session_id: "sess-1",
+        pid: 12345,
+        port: 1421,
+      },
+      maintainer: { enabled: false, interval_minutes: 60 },
+      auto_worker: { enabled: false },
+      prompts: [],
+      sessions: [{ id: "sess-1", label: "fix-foo", worktree_path: null, worktree_branch: null, archived: false, kind: "claude", github_issue: null, initial_prompt: null, auto_worker_session: false }],
+    }]);
+
+    // Give reactivity a tick, then verify title was NOT updated
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mocks.setTitle).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Removed the `$effect` that appended staging info (session label + port) to the **current** window's title when staging started
- The staged instance already shows its own branch/port via its own Vite build-time defines, so no extra logic is needed
- Updated tests to assert the current window title is **not** modified on staging

## Test plan
- [x] All 282 frontend tests pass
- [x] All 16 Rust tests pass
- [x] New test verifies `setTitle` is not called when staging state changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)