### PR TITLE
feat: add git version control for notes

### DIFF
--- a/src-tauri/src/bin/server.rs
+++ b/src-tauri/src/bin/server.rs
@@ -61,6 +61,7 @@ async fn main() {
         .route("/api/create_folder", post(api_create_folder))
         .route("/api/rename_folder", post(api_rename_folder))
         .route("/api/delete_folder", post(api_delete_folder))
+        .route("/api/commit_notes", post(api_commit_notes))
         .route("/ws", get(ws_upgrade))
         .fallback(post(fallback_handler))
         .layer(CorsLayer::permissive())
@@ -481,6 +482,15 @@ async fn send_note_ai_chat(
 }
 // --- Notes ---
 
+fn server_try_commit(state: &Arc<ServerState>, message: &str) {
+    if let Ok(storage) = state.app.storage.lock() {
+        let base_dir = storage.base_dir();
+        if let Err(e) = notes::commit_notes(&base_dir, message) {
+            eprintln!("notes git commit failed: {}", e);
+        }
+    }
+}
+
 async fn api_list_notes(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
@@ -544,6 +554,7 @@ async fn api_create_note(
         .base_dir();
     let filename = notes::create_note(&base_dir, &folder, &title)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    server_try_commit(&state, &format!("create {}/{}", folder, filename));
     Ok(Json(serde_json::to_value(filename).unwrap()))
 }
 
@@ -560,6 +571,7 @@ async fn api_delete_note(
         .base_dir();
     notes::delete_note(&base_dir, &folder, &filename)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    server_try_commit(&state, &format!("delete {}/{}", folder, filename));
     Ok(Json(Value::Null))
 }
 
@@ -578,6 +590,7 @@ async fn api_rename_note(
         .base_dir();
     let filename = notes::rename_note(&base_dir, &folder, &old_name, &new_name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    server_try_commit(&state, &format!("rename {}/{} → {}", folder, old_name, filename));
     Ok(Json(serde_json::to_value(filename).unwrap()))
 }
 
@@ -604,6 +617,7 @@ async fn api_create_folder(
         .base_dir();
     notes::create_folder(&base_dir, &name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    server_try_commit(&state, &format!("create folder {}", name));
     Ok(Json(Value::Null))
 }
 
@@ -620,6 +634,7 @@ async fn api_rename_folder(
         .base_dir();
     notes::rename_folder(&base_dir, &old_name, &new_name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    server_try_commit(&state, &format!("rename folder {} → {}", old_name, new_name));
     Ok(Json(Value::Null))
 }
 
@@ -635,7 +650,19 @@ async fn api_delete_folder(
         .base_dir();
     notes::delete_folder(&base_dir, &name, force)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    server_try_commit(&state, &format!("delete folder {}", name));
     Ok(Json(Value::Null))
+}
+
+async fn api_commit_notes(
+    AxumState(state): AxumState<Arc<ServerState>>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let base_dir = state.app.storage.lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    let committed = notes::commit_notes(&base_dir, "update notes")
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::to_value(committed).unwrap()))
 }
 
 // --- WebSocket ---

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1548,6 +1548,11 @@ pub fn delete_folder(state: State<'_, AppState>, name: String, force: bool) -> R
 }
 
 #[tauri::command]
+pub fn commit_notes(state: State<'_, AppState>) -> Result<bool, String> {
+    notes::commit_notes(state)
+}
+
+#[tauri::command]
 pub async fn send_note_ai_chat(
     note_content: String,
     selected_text: String,

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -3,6 +3,13 @@ use tauri::State;
 use crate::notes::{self, NoteEntry};
 use crate::state::AppState;
 
+/// Best-effort git commit. Logs errors but doesn't fail the operation.
+fn try_commit(base_dir: &std::path::Path, message: &str) {
+    if let Err(e) = notes::commit_notes(base_dir, message) {
+        eprintln!("notes git commit failed: {}", e);
+    }
+}
+
 pub(crate) fn list_notes(
     state: State<'_, AppState>,
     folder: String,
@@ -40,6 +47,7 @@ pub(crate) fn write_note(
         .map_err(|e| e.to_string())?
         .base_dir();
     notes::write_note(&base_dir, &folder, &filename, &content).map_err(|e| e.to_string())
+    // No git commit here — batched via commit_notes command
 }
 
 pub(crate) fn create_note(
@@ -52,7 +60,9 @@ pub(crate) fn create_note(
         .lock()
         .map_err(|e| e.to_string())?
         .base_dir();
-    notes::create_note(&base_dir, &folder, &title).map_err(|e| e.to_string())
+    let filename = notes::create_note(&base_dir, &folder, &title).map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("create {}/{}", folder, filename));
+    Ok(filename)
 }
 
 pub(crate) fn rename_note(
@@ -66,8 +76,10 @@ pub(crate) fn rename_note(
         .lock()
         .map_err(|e| e.to_string())?
         .base_dir();
-    notes::rename_note(&base_dir, &folder, &old_name, &new_name)
-        .map_err(|e| e.to_string())
+    let new_filename = notes::rename_note(&base_dir, &folder, &old_name, &new_name)
+        .map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("rename {}/{} → {}", folder, old_name, new_filename));
+    Ok(new_filename)
 }
 
 pub(crate) fn duplicate_note(
@@ -80,7 +92,9 @@ pub(crate) fn duplicate_note(
         .lock()
         .map_err(|e| e.to_string())?
         .base_dir();
-    notes::duplicate_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())
+    let copy = notes::duplicate_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("duplicate {}/{} → {}", folder, filename, copy));
+    Ok(copy)
 }
 
 pub(crate) fn delete_note(
@@ -93,7 +107,9 @@ pub(crate) fn delete_note(
         .lock()
         .map_err(|e| e.to_string())?
         .base_dir();
-    notes::delete_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())
+    notes::delete_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("delete {}/{}", folder, filename));
+    Ok(())
 }
 
 pub(crate) fn list_folders(
@@ -108,7 +124,9 @@ pub(crate) fn create_folder(
     name: String,
 ) -> Result<(), String> {
     let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
-    notes::create_folder(&base_dir, &name).map_err(|e| e.to_string())
+    notes::create_folder(&base_dir, &name).map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("create folder {}", name));
+    Ok(())
 }
 
 pub(crate) fn rename_folder(
@@ -117,7 +135,9 @@ pub(crate) fn rename_folder(
     new_name: String,
 ) -> Result<(), String> {
     let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
-    notes::rename_folder(&base_dir, &old_name, &new_name).map_err(|e| e.to_string())
+    notes::rename_folder(&base_dir, &old_name, &new_name).map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("rename folder {} → {}", old_name, new_name));
+    Ok(())
 }
 
 pub(crate) fn delete_folder(
@@ -126,5 +146,20 @@ pub(crate) fn delete_folder(
     force: bool,
 ) -> Result<(), String> {
     let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
-    notes::delete_folder(&base_dir, &name, force).map_err(|e| e.to_string())
+    notes::delete_folder(&base_dir, &name, force).map_err(|e| e.to_string())?;
+    try_commit(&base_dir, &format!("delete folder {}", name));
+    Ok(())
+}
+
+/// Commit any pending note changes (content edits).
+/// Called by the frontend when switching notes.
+pub(crate) fn commit_notes(
+    state: State<'_, AppState>,
+) -> Result<bool, String> {
+    let base_dir = state
+        .storage
+        .lock()
+        .map_err(|e| e.to_string())?
+        .base_dir();
+    notes::commit_notes(&base_dir, "update notes").map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,6 +117,7 @@ pub fn run() {
             commands::create_folder,
             commands::rename_folder,
             commands::delete_folder,
+            commands::commit_notes,
             commands::send_note_ai_chat,
             commands::save_session_prompt,
             commands::list_project_prompts,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
+use git2::{Repository, Signature};
 use serde::Serialize;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Clone)]
@@ -322,6 +323,66 @@ pub fn delete_folder(base: &std::path::Path, name: &str, force: bool) -> std::io
     }
 }
 
+// ── Git version control ─────────────────────────────────────────────
+
+/// Returns the notes root directory: `{base}/notes/`
+fn notes_root(base: &Path) -> PathBuf {
+    base.join("notes")
+}
+
+/// Open or initialize the notes git repo at `{base}/notes/`.
+fn open_or_init_repo(base: &Path) -> Result<Repository, git2::Error> {
+    let root = notes_root(base);
+    fs::create_dir_all(&root).map_err(|e| {
+        git2::Error::from_str(&format!("failed to create notes dir: {}", e))
+    })?;
+    match Repository::open(&root) {
+        Ok(repo) => Ok(repo),
+        Err(_) => {
+            let repo = Repository::init(&root)?;
+            let sig = Signature::now("the-controller", "noreply@the-controller")?;
+            let tree_id = repo.index()?.write_tree()?;
+            {
+                let tree = repo.find_tree(tree_id)?;
+                repo.commit(Some("HEAD"), &sig, &sig, "init notes", &tree, &[])?;
+            }
+            Ok(repo)
+        }
+    }
+}
+
+/// Stage all changes and commit with the given message.
+/// Returns Ok(true) if a commit was created, Ok(false) if there was nothing to commit.
+pub fn commit_notes(base: &Path, message: &str) -> Result<bool, git2::Error> {
+    let repo = open_or_init_repo(base)?;
+    let mut index = repo.index()?;
+
+    index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
+    index.update_all(["*"].iter(), None)?;
+    index.write()?;
+
+    let head_commit = repo.head()?.peel_to_commit()?;
+    let head_tree = head_commit.tree()?;
+    let new_tree_id = index.write_tree()?;
+    let new_tree = repo.find_tree(new_tree_id)?;
+
+    let diff = repo.diff_tree_to_tree(Some(&head_tree), Some(&new_tree), None)?;
+    if diff.deltas().count() == 0 {
+        return Ok(false);
+    }
+
+    let sig = Signature::now("the-controller", "noreply@the-controller")?;
+    repo.commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        message,
+        &new_tree,
+        &[&head_commit],
+    )?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -636,5 +697,56 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let result = delete_folder(tmp.path(), "nope", false);
         assert!(result.is_ok());
+    }
+
+    // ── Git tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_commit_notes_creates_repo_and_commits() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        create_note(base, "proj", "hello").unwrap();
+
+        let committed = commit_notes(base, "add hello").unwrap();
+        assert!(committed);
+
+        let repo = Repository::open(notes_root(base)).unwrap();
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.message().unwrap(), "add hello");
+    }
+
+    #[test]
+    fn test_commit_notes_noop_when_no_changes() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        create_note(base, "proj", "hello").unwrap();
+        commit_notes(base, "first").unwrap();
+
+        let committed = commit_notes(base, "second").unwrap();
+        assert!(!committed);
+    }
+
+    #[test]
+    fn test_commit_notes_tracks_deletes() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        create_note(base, "proj", "temp").unwrap();
+        commit_notes(base, "add temp").unwrap();
+
+        delete_note(base, "proj", "temp.md").unwrap();
+        let committed = commit_notes(base, "delete temp").unwrap();
+        assert!(committed);
+    }
+
+    #[test]
+    fn test_commit_notes_tracks_content_changes() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        create_note(base, "proj", "doc").unwrap();
+        commit_notes(base, "create").unwrap();
+
+        write_note(base, "proj", "doc.md", "updated content").unwrap();
+        let committed = commit_notes(base, "update doc").unwrap();
+        assert!(committed);
     }
 }

--- a/src/lib/NotesEditor.svelte
+++ b/src/lib/NotesEditor.svelte
@@ -58,6 +58,10 @@
           }
         }
       }
+      // Commit any pending note edits to git
+      if (prev) {
+        command("commit_notes", {}).catch(() => {});
+      }
       prevNoteKey = key;
 
       if (currentNote && folderName && key) {


### PR DESCRIPTION
## Summary
- Initialize `~/.the-controller/notes/` as a git repo using `git2`
- Auto-commit on structural changes (create, delete, rename, duplicate, folder ops)
- Content edits are batched — committed when switching notes via `commit_notes` command
- Git errors are best-effort (logged but don't block note operations)

## Test plan
- [x] 4 new Rust tests for git commit behavior (create, noop, delete, content change)
- [x] All 370+ existing tests pass
- [ ] Manual: create/edit/delete notes, verify commits appear in `~/.the-controller/notes/.git/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)