### PR TITLE
fix: resolve svelte-check CI failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^25.4.0",
         "glob": "^13.0.6",
         "jsdom": "^28.1.0",
         "svelte": "^5.0.0",
@@ -2187,6 +2188,17 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
+      "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -4838,6 +4850,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.4.0",
     "glob": "^13.0.6",
     "jsdom": "^28.1.0",
     "svelte": "^5.0.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,8 +42,9 @@
   const selectedSessionProviderState = fromStore(selectedSessionProvider);
   let currentSessionProvider = $derived(selectedSessionProviderState.current);
   let currentArchitectureProject = $derived.by(() => {
+    const focus = focusTargetState.current;
     const focusedProjectId =
-      focusTargetState.current?.projectId ??
+      (focus && "projectId" in focus ? focus.projectId : undefined) ??
       projectsState.current.find((project) =>
         project.sessions.some((session) => session.id === activeSessionIdState.current),
       )?.id ??
@@ -117,7 +118,7 @@
 
   function getTargetProject(): Project | undefined {
     const focus = focusTargetState.current;
-    if (!focus) return undefined;
+    if (!focus || !("projectId" in focus)) return undefined;
     return projectsState.current.find((p) => p.id === focus.projectId);
   }
 
@@ -140,7 +141,7 @@
 
   async function toggleAutoWorkerEnabled() {
     const focus = focusTargetState.current;
-    if (!focus) return;
+    if (!focus || !("projectId" in focus)) return;
     const project = projectsState.current.find((p) => p.id === focus.projectId);
     if (!project) return;
     const newEnabled = !project.auto_worker.enabled;

--- a/src/lib/CodeMirrorNoteEditor.svelte
+++ b/src/lib/CodeMirrorNoteEditor.svelte
@@ -18,7 +18,7 @@
     ) {
       return _origVimKeyFromEvent.call(
         this,
-        { key: e.key.toUpperCase(), shiftKey: e.shiftKey, ctrlKey: e.ctrlKey, altKey: e.altKey, metaKey: e.metaKey, code: e.code },
+        { key: e.key.toUpperCase(), shiftKey: e.shiftKey, ctrlKey: e.ctrlKey, altKey: e.altKey, metaKey: e.metaKey, code: e.code } as unknown as KeyboardEvent,
         vim,
       );
     }

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -284,7 +284,7 @@
         if (activeId) {
           const proj = projectList.find((p) => p.sessions.some((s) => s.id === activeId));
           const sess = proj?.sessions.find((s) => s.id === activeId);
-          dispatchHotkeyAction({ type: "finish-branch", sessionId: activeId, kind: sess?.kind });
+          dispatchHotkeyAction({ type: "finish-branch", sessionId: activeId, kind: sess?.kind as "claude" | "codex" | undefined });
         }
         return true;
       case "save-prompt": {

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -28,7 +28,7 @@
   let mergeSessionTarget: { sessionId: string; projectId: string; label: string } | null = $state(null);
   let mergeInProgress = $state(false);
   let staging = $state(false);
-  let finishBranchTarget: { sessionId: string; kind?: string } | null = $state(null);
+  let finishBranchTarget: { sessionId: string; kind?: "claude" | "codex" } | null = $state(null);
   const workspaceModeState = fromStore(workspaceMode);
   let currentMode = $derived(workspaceModeState.current);
   const selectedSessionProviderState = fromStore(selectedSessionProvider);

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -248,7 +248,7 @@ export type HotkeyAction =
       issue: GithubIssue;
     }
   | { type: "merge-session"; sessionId: string; projectId: string }
-  | { type: "finish-branch"; sessionId: string; kind?: string }
+  | { type: "finish-branch"; sessionId: string; kind?: "claude" | "codex" }
   | { type: "screenshot-to-session"; preview?: boolean; cropped?: boolean }
   | { type: "toggle-maintainer-enabled" }
   | { type: "toggle-auto-worker-enabled" }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "strict": true,
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
-    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"],
+    "paths": {
+      "$lib/*": ["./src/lib/*"],
+      "$lib": ["./src/lib"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.svelte", "vitest-setup.ts"]
 }


### PR DESCRIPTION
## Summary
- Add `$lib` path alias to `tsconfig.json` so `svelte-check` can resolve `$lib/*` imports
- Install missing `@types/node` dev dependency (referenced in tsconfig but not installed)
- Narrow `SessionKind` types and fix `FocusTarget` union type narrowing in App.svelte
- Cast synthetic keyboard event in CodeMirrorNoteEditor.svelte

## Test plan
- [x] `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors (was 60+)
- [x] `npx vitest run` — 270/270 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)