### PR TITLE
docs: reframe headline as shapeable personal desktop system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Controller
 
-A desktop app for orchestrating multiple Claude Code terminal sessions.
+A shapeable, personal desktop system — starting with terminal multiplexing.
 
 Built with Tauri v2 + Svelte 5 + Rust.
 


### PR DESCRIPTION
## Summary
- Updated README headline from "A desktop app for orchestrating multiple Claude Code terminal sessions" to "A shapeable, personal desktop system — starting with terminal multiplexing"

## Test plan
- [x] All frontend tests pass (271)
- [x] All Rust tests pass (16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)