### PR TITLE
fix: resolve all clippy warnings for Rust 1.94 CI

### DIFF
--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -11,6 +11,7 @@ use crate::labels;
 use crate::models::GithubIssue;
 use crate::state::AppState;
 
+#[allow(clippy::type_complexity)]
 static IDLE_CHANNEL: Lazy<(std::sync::Mutex<mpsc::Sender<Uuid>>, std::sync::Mutex<mpsc::Receiver<Uuid>>)> = Lazy::new(|| {
     let (tx, rx) = mpsc::channel();
     (std::sync::Mutex::new(tx), std::sync::Mutex::new(rx))
@@ -210,7 +211,7 @@ impl AutoWorkerScheduler {
                     .iter()
                     .filter(|(_, s)| {
                         s.last_idle_at.is_some()
-                            && s.last_nudge_at.map_or(true, |t| t.elapsed() > Duration::from_secs(NUDGE_COOLDOWN_SECS))
+                            && s.last_nudge_at.is_none_or(|t| t.elapsed() > Duration::from_secs(NUDGE_COOLDOWN_SECS))
                     })
                     .map(|(pid, _)| *pid)
                     .collect();
@@ -382,7 +383,7 @@ impl AutoWorkerScheduler {
         let reconciliation = reconcile_startup_workers(candidates);
 
         for candidate in &reconciliation.restore {
-            let restored = startup_candidate_to_active_session(&candidate);
+            let restored = startup_candidate_to_active_session(candidate);
             let attach_result = {
                 let mut pty_manager = match state.pty_manager.lock() {
                     Ok(manager) => manager,
@@ -730,10 +731,9 @@ fn close_issue_sync(repo_path: &str, issue_number: u64) -> Result<(), String> {
 fn mark_issue_finished(state: &AppState, session: &ActiveSession) {
     let mut issue_closed = issue_is_closed_sync(&session.repo_path, session.issue_number).ok();
 
-    if issue_closed != Some(true) && has_merged_pr_sync(&session.repo_path, session.issue_number) {
-        if close_issue_sync(&session.repo_path, session.issue_number).is_ok() {
+    if issue_closed != Some(true) && has_merged_pr_sync(&session.repo_path, session.issue_number)
+        && close_issue_sync(&session.repo_path, session.issue_number).is_ok() {
             issue_closed = Some(true);
-        }
     }
 
     apply_worker_label_plan_sync(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -559,11 +559,9 @@ pub fn delete_project(
     storage.delete_project_dir(id).map_err(|e| e.to_string())?;
 
     // Optionally delete the repo directory
-    if delete_repo {
-        if Path::new(&project.repo_path).exists() {
-            std::fs::remove_dir_all(&project.repo_path)
-                .map_err(|e| format!("failed to delete repo: {}", e))?;
-        }
+    if delete_repo && Path::new(&project.repo_path).exists() {
+        std::fs::remove_dir_all(&project.repo_path)
+            .map_err(|e| format!("failed to delete repo: {}", e))?;
     }
 
     Ok(())
@@ -1310,7 +1308,7 @@ pub fn save_onboarding_config(state: State<AppState>, projects_root: String) -> 
 
 #[tauri::command]
 pub async fn check_claude_cli() -> Result<String, String> {
-    let result = tokio::task::spawn_blocking(|| config::check_claude_cli_status())
+    let result = tokio::task::spawn_blocking(config::check_claude_cli_status)
         .await
         .map_err(|e| format!("Task failed: {}", e))?;
     Ok(result)
@@ -1783,7 +1781,7 @@ fn discover_branch_commits(worktree_path: &str) -> Result<Vec<CommitInfo>, Strin
         if message.starts_with("Initial commit") {
             continue;
         }
-        let hash = format!("{}", &oid.to_string()[..7]);
+        let hash = oid.to_string()[..7].to_string();
         commits.push(CommitInfo { hash, message });
         if commits.len() >= 20 {
             break;

--- a/src-tauri/src/commands/media.rs
+++ b/src-tauri/src/commands/media.rs
@@ -31,6 +31,7 @@ pub(crate) async fn copy_image_file_to_clipboard(
 /// When `cropped` is false, captures the app window using the window ID.
 /// When `cropped` is true, launches interactive crop selection via `screencapture -i`.
 /// Returns the path to the screenshot file so the caller can pass it to `initial_prompt`.
+#[allow(unused_variables)]
 pub(crate) async fn capture_app_screenshot(app: AppHandle, cropped: bool) -> Result<String, String> {
     #[cfg(not(target_os = "macos"))]
     return Err("Screenshot capture is only supported on macOS".into());
@@ -61,7 +62,7 @@ pub(crate) async fn capture_app_screenshot(app: AppHandle, cropped: bool) -> Res
                 let handle = window.window_handle().map_err(|e| e.to_string())?;
                 match handle.as_raw() {
                     RawWindowHandle::AppKit(appkit) => {
-                        let ns_view = appkit.ns_view.as_ptr() as *mut std::ffi::c_void;
+                        let ns_view = appkit.ns_view.as_ptr();
                         unsafe { macos_window_number(ns_view) }
                     }
                     _ => return Err("Not a macOS window".into()),
@@ -106,9 +107,9 @@ unsafe fn macos_window_number(ns_view: *mut std::ffi::c_void) -> isize {
         ) -> *mut std::ffi::c_void;
     }
 
-    let sel_window = sel_registerName(b"window\0".as_ptr());
+    let sel_window = sel_registerName(c"window".as_ptr().cast());
     let ns_window = objc_msgSend(ns_view, sel_window);
 
-    let sel_number = sel_registerName(b"windowNumber\0".as_ptr());
+    let sel_number = sel_registerName(c"windowNumber".as_ptr().cast());
     objc_msgSend(ns_window, sel_number) as isize
 }

--- a/src-tauri/src/deploy/commands.rs
+++ b/src-tauri/src/deploy/commands.rs
@@ -44,7 +44,7 @@ pub async fn detect_project_type(repo_path: String) -> Result<ProjectSignals, St
 
 #[tauri::command]
 pub async fn get_deploy_credentials() -> Result<DeployCredentials, String> {
-    tokio::task::spawn_blocking(|| DeployCredentials::load())
+    tokio::task::spawn_blocking(DeployCredentials::load)
         .await
         .map_err(|e| e.to_string())?
 }

--- a/src-tauri/src/emitter.rs
+++ b/src-tauri/src/emitter.rs
@@ -8,6 +8,7 @@ pub trait EventEmitter: Send + Sync + 'static {
 pub struct NoopEmitter;
 
 impl NoopEmitter {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Arc<dyn EventEmitter> {
         Arc::new(Self)
     }
@@ -27,6 +28,7 @@ pub struct WsBroadcastEmitter {
 
 #[cfg(feature = "server")]
 impl WsBroadcastEmitter {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> (Arc<dyn EventEmitter>, tokio::sync::broadcast::Sender<String>) {
         let (tx, _) = tokio::sync::broadcast::channel(4096);
         let sender = tx.clone();
@@ -49,6 +51,7 @@ pub struct TauriEmitter {
 }
 
 impl TauriEmitter {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(app_handle: tauri::AppHandle) -> Arc<dyn EventEmitter> {
         Arc::new(Self { app_handle })
     }

--- a/src-tauri/src/labels.rs
+++ b/src-tauri/src/labels.rs
@@ -2,7 +2,6 @@
 ///
 /// All label names use the `key:value` format (no space after the colon).
 /// Both the maintainer and auto-worker import from here to prevent drift.
-
 // Priority labels
 pub const PRIORITY_LOW: &str = "priority:low";
 pub const PRIORITY_HIGH: &str = "priority:high";

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -169,7 +169,7 @@ impl MaintainerScheduler {
                     let interval = Duration::from_secs(project.maintainer.interval_minutes * 60);
                     let should_run = last_run
                         .get(&project.id)
-                        .map_or(true, |t| t.elapsed() >= interval);
+                        .is_none_or(|t| t.elapsed() >= interval);
 
                     if !should_run {
                         continue;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -47,15 +47,9 @@ impl Default for MaintainerConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AutoWorkerConfig {
     pub enabled: bool,
-}
-
-impl Default for AutoWorkerConfig {
-    fn default() -> Self {
-        Self { enabled: false }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -66,7 +66,7 @@ pub fn list_notes(
     for entry in fs::read_dir(&dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "md") {
+        if path.extension().is_some_and(|e| e == "md") {
             let metadata = fs::metadata(&path)?;
             let modified = metadata.modified()?;
             let modified_at: DateTime<Utc> = modified.into();
@@ -146,11 +146,7 @@ pub fn create_note(
         ));
     }
 
-    let display_title = if title.ends_with(".md") {
-        &title[..title.len() - 3]
-    } else {
-        title
-    };
+    let display_title = title.strip_suffix(".md").unwrap_or(title);
     fs::write(&path, format!("# {}\n", display_title))?;
     Ok(filename)
 }

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -26,6 +26,7 @@ pub struct PtySession {
     tmux_session: bool,
 }
 
+#[derive(Default)]
 pub struct PtyManager {
     pub(crate) sessions: HashMap<Uuid, PtySession>,
 }
@@ -41,6 +42,7 @@ impl PtyManager {
     /// otherwise falls back to a direct PTY (production path).
     /// When `continue_session` is true, passes `--continue` to claude to resume
     /// the last conversation in the working directory.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn_session(
         &mut self,
         session_id: Uuid,
@@ -93,6 +95,7 @@ impl PtyManager {
     }
 
     /// Spawn a command directly in a local PTY without tmux.
+    #[allow(clippy::too_many_arguments)]
     fn spawn_direct_session(
         &mut self,
         session_id: Uuid,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -20,6 +20,7 @@ impl CacheEntry {
     }
 }
 
+#[derive(Default)]
 pub struct IssueCache {
     pub entries: HashMap<String, CacheEntry>,
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -320,7 +320,7 @@ impl Storage {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().map_or(false, |e| e == "json") {
+            if path.extension().is_some_and(|e| e == "json") {
                 let json = fs::read_to_string(&path)?;
                 // Skip old-format files that fail to deserialize
                 if let Ok(log) = serde_json::from_str::<MaintainerRunLog>(&json) {

--- a/src-tauri/src/tmux.rs
+++ b/src-tauri/src/tmux.rs
@@ -193,7 +193,7 @@ impl TmuxManager {
             return None;
         }
         let text = String::from_utf8_lossy(&output.stdout);
-        let parts: Vec<&str> = text.trim().split_whitespace().collect();
+        let parts: Vec<&str> = text.split_whitespace().collect();
         if parts.len() == 2 {
             let cols = parts[0].parse::<u16>().ok()?;
             let rows = parts[1].parse::<u16>().ok()?;

--- a/src-tauri/src/token_usage.rs
+++ b/src-tauri/src/token_usage.rs
@@ -41,7 +41,7 @@ fn claude_project_dir(working_dir: &str) -> Result<PathBuf, String> {
     }
 
     // Claude Code encodes the working directory path by replacing `/` and `.` with `-`.
-    let encoded = working_dir.replace('/', "-").replace('.', "-");
+    let encoded = working_dir.replace(['/', '.'], "-");
 
     // Try exact match first
     let candidate = claude_projects.join(&encoded);
@@ -55,10 +55,9 @@ fn claude_project_dir(working_dir: &str) -> Result<PathBuf, String> {
     let mut best: Option<PathBuf> = None;
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if name.contains(&encoded) || encoded.contains(&name) {
-            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+        if (name.contains(&encoded) || encoded.contains(&name))
+            && entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                 best = Some(entry.path());
-            }
         }
     }
 
@@ -75,7 +74,7 @@ fn most_recent_jsonl(dir: &Path) -> Result<PathBuf, String> {
         if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
             if let Ok(meta) = fs::metadata(&path) {
                 let modified = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
-                if best.as_ref().map_or(true, |(_, t)| modified > *t) {
+                if best.as_ref().is_none_or(|(_, t)| modified > *t) {
                     best = Some((path, modified));
                 }
             }

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -343,6 +343,10 @@ mod tests {
         let repo_path = tmp.path().to_str().unwrap().to_string();
 
         let repo = Repository::init(&repo_path).expect("init repo");
+        // Set user config so git commands (e.g. rebase) work in CI without global config
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test").unwrap();
+        config.set_str("user.email", "test@example.com").unwrap();
         let sig = repo.signature().unwrap_or_else(|_| {
             git2::Signature::now("Test", "test@example.com").unwrap()
         });


### PR DESCRIPTION
## Summary
- Fixes 27 clippy warnings-as-errors introduced by Rust 1.94's stricter lints
- Changes across 14 files: `map_or` → `is_some_and`/`is_none_or`, derivable `Default` impls, collapsible `if`/`replace`, redundant closures, C-string literals, unnecessary casts, and more
- All tests pass (cargo test, vitest, svelte-check, clippy)

## Test plan
- [x] `cargo clippy -- -D warnings` passes clean
- [x] `cargo test` — 16 passed
- [x] `npx vitest run` — 270 passed
- [x] `npx svelte-check --threshold error` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)