### PR TITLE
fix: resolve svelte-check type error and port overflow in CI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3410,7 +3410,9 @@ mod staging_tests {
     fn test_find_free_port_skips_occupied() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let occupied_port = listener.local_addr().unwrap().port();
-        let base = occupied_port - 1000;
+        let Some(base) = occupied_port.checked_sub(STAGING_PORT_OFFSET) else {
+            return; // OS assigned a port too low to construct a valid base
+        };
         let port = find_staging_port(base).unwrap();
         assert!(port > occupied_port);
         assert!(port <= occupied_port + 100);

--- a/src/lib/markdownLivePreview.ts
+++ b/src/lib/markdownLivePreview.ts
@@ -7,7 +7,7 @@ import {
   WidgetType,
 } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
-import { RangeSetBuilder, type EditorState, Facet } from "@codemirror/state";
+import { type Extension, RangeSetBuilder, type EditorState, Facet } from "@codemirror/state";
 
 /** CSS classes applied by mark decorations. */
 const headingMark = {
@@ -224,7 +224,7 @@ export interface LivePreviewOptions {
 }
 
 export function markdownLivePreview(options?: LivePreviewOptions) {
-  const extensions = [livePreviewPlugin];
+  const extensions: Extension[] = [livePreviewPlugin];
   if (options?.resolveImageSrc) {
     extensions.unshift(imageResolverFacet.of(options.resolveImageSrc));
   }


### PR DESCRIPTION
## Summary
- Type the `markdownLivePreview` extensions array as `Extension[]` to fix svelte-check error where `Facet.of()` return type wasn't assignable to inferred `ViewPlugin[]`
- Use `checked_sub` in `test_find_free_port_skips_occupied` to prevent u16 overflow when the OS assigns a low ephemeral port

## Test plan
- [x] `npx svelte-check --threshold error` passes with 0 errors
- [x] `cargo test --lib` passes all 355 tests
- [x] `npx vitest run` passes all 273 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)