### PR TITLE
docs: add CONTRIBUTING.md and caveats section to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,4 +28,4 @@ Bad examples:
 
 The Controller is a strongly opinionated power tool built for efficiency, simplicity, and elegant design. It is maintained under a benevolent-dictator model — decisions about direction, scope, and taste ultimately rest with one person.
 
-Large feature requests that don't align with the current roadmap may not be prioritized or accepted. If you're unsure whether something fits, open an issue first to discuss before investing time in a PR.
+This is still a period of experimentation — the roadmap itself is unstable. Large feature requests that don't align with the current direction may not be prioritized or accepted. If you're unsure whether something fits, open an issue first to discuss before investing time in a PR.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Together they close the loop: take a screenshot, have the agent inspect the UI w
 
 ## Caveats
 
-The Controller is a strongly opinionated power tool — built for efficiency, simplicity, and elegant design, maintained under a benevolent-dictator model.
+The Controller is a strongly opinionated power tool — built for efficiency, simplicity, and elegant design, maintained under a benevolent-dictator model. This is still a period of experimentation, so even the roadmap is unstable.
 
 This project is in early stages. Some features may be overhauled or removed entirely without concern for backwards compatibility. Things will stabilize eventually, but not in the near term.
 


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with PR intention requirements, quality bar, and project direction (benevolent-dictator model, opinionated tool for efficiency/simplicity/elegant design)
- Add caveats section to `README.md` covering early-stage instability, fork recommendation, and link to contribution guide

## Test plan

- [x] All 273 frontend tests pass
- [x] All 16 Rust tests pass
- [ ] Review rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)