### PR TITLE
docs: add worktree/metadata layout to ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,3 +54,70 @@ Claude Code is the first-class citizen for this project. Codex handles backgroun
 - Parallel execution of well-defined, independent implementation tasks
 
 Since the project's current focus is heavily design-oriented — shaping interactions, defining workflows, refining the development experience — Claude Code is the better fit for the primary development loop.
+
+## Metadata and Worktree Layout
+
+Session state lives on disk in two places: project metadata (JSON) and git worktrees. Understanding the layout is essential for manual recovery.
+
+### Directory Structure
+
+```
+~/.the-controller/
+├── config.json                              # App-level config (projects_root)
+├── projects/
+│   └── {project-uuid}/
+│       └── project.json                     # Project + all session metadata
+└── worktrees/
+    └── {project-name}/
+        └── {session-label}/                 # Git worktree checkout
+            ├── .env -> ../../.env           # Symlinked from main repo
+            └── ...                          # Full working copy
+```
+
+### Project Metadata (`project.json`)
+
+Each project gets a `project.json` keyed by UUID under `~/.the-controller/projects/`. It contains the project name, repo path, and an array of `SessionConfig` entries — one per session. Each session records:
+
+- `id` — Session UUID
+- `label` — Human-readable label (e.g., `session-3-a1b2c3`)
+- `worktree_path` — Absolute path to the worktree directory
+- `worktree_branch` — Git branch name (matches the label)
+- `archived`, `kind`, `github_issue`, `initial_prompt`, `done_commits`
+
+This is the authoritative record. If a worktree directory exists but has no matching session in `project.json`, the controller won't know about it.
+
+### Session Labels
+
+Labels are auto-generated: `session-{N}-{6-char-uuid}`. The number increments based on the highest existing session number in the project. The UUID suffix ensures uniqueness across parallel creation.
+
+See: `commands.rs` (`next_session_label`)
+
+### Worktree Creation
+
+When a session is created:
+
+1. A new git branch is created with the session label as its name
+2. `git2::Repository::worktree()` creates a worktree at `~/.the-controller/worktrees/{project-name}/{session-label}/`
+3. The main repo's `.env` is symlinked into the worktree so secrets are shared
+4. If the repo has no commits (unborn branch), the repo path is used directly — no worktree is created
+
+See: `worktree.rs` (`create_worktree`)
+
+### Worktree Cleanup
+
+- **Close session** with `delete_worktree=true`: removes the directory, prunes the git worktree reference, and deletes the branch
+- **Delete project**: iterates all sessions, closes PTYs, and removes each worktree
+- **Failed spawn**: if PTY spawn fails after worktree creation, the worktree and branch are rolled back automatically
+
+See: `worktree.rs` (`remove_worktree`), `commands.rs` (`cleanup_failed_session_spawn`)
+
+### Recovery
+
+If the app crashes or metadata gets corrupted, here's what you need to know:
+
+- **Worktrees are plain git worktrees.** You can list them with `git worktree list` from the main repo. They're normal checkouts — you can `cd` into them and work directly.
+- **Branches match session labels.** Each worktree branch is named after the session label, so `git branch` in the main repo shows all session branches.
+- **Metadata is JSON.** You can read/edit `~/.the-controller/projects/{uuid}/project.json` directly to fix session records or update stale `worktree_path` values.
+- **Orphaned worktrees** (directory exists, no metadata entry) can be recovered by adding a session entry back to `project.json`, or cleaned up with `git worktree remove`.
+- **Orphaned metadata** (entry exists, directory missing) will fail on connect. Remove the session entry from `project.json` or recreate the worktree manually with `git worktree add`.
+- **Legacy migration**: older installs used `worktrees/{project-uuid}/` instead of `worktrees/{project-name}/`. The `restore_sessions` command migrates these on startup automatically.


### PR DESCRIPTION
## Summary
- Added a "Metadata and Worktree Layout" section to ARCHITECTURE.md documenting the on-disk directory structure, project metadata format, session label convention, worktree creation/cleanup flows, and recovery procedures for orphaned state.

## Test plan
- [x] Frontend tests pass (273/273)
- [x] Rust tests pass (16/16)
- Docs-only change, no runtime behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)