### PR TITLE
fix: clarify contains field in architecture prompt

### DIFF
--- a/src-tauri/src/architecture.rs
+++ b/src-tauri/src/architecture.rs
@@ -288,6 +288,7 @@ Requirements:\n\
 - \"title\" must be a short architecture title.\n\
 - \"mermaid\" must be a valid Mermaid flowchart using stable component ids.\n\
 - \"components\" must be an array of objects with: id, name, summary, contains, incoming_relationships, outgoing_relationships, evidence_paths, evidence_snippets.\n\
+- \"contains\" must be an array of component ids (from this same components array) that are children of the component, or an empty array if the component has no children.\n\
 - Each entry in incoming_relationships and outgoing_relationships must be an object with exactly two keys: \"component_id\" (the id of the related component) and \"summary\" (a short description of the relationship).\n\
 - Every component id must appear as a Mermaid node id.\n\
 - evidence_paths and evidence_snippets must cite only the files shown below.\n\


### PR DESCRIPTION
## Summary
- The AI model generating architecture was putting descriptive text in the `contains` field instead of valid component IDs, causing validation to reject the output with: "Component 'tooling' contains unknown component 'npm scripts for dev, build, tauri, unit tests, and e2e tests'"
- Added explicit instruction in the prompt that `contains` must be an array of component IDs from the same components array, or empty

## Test plan
- [x] All 34 architecture Rust tests pass
- [x] All 273 frontend tests pass
- [ ] Run `r` in architecture mode and verify it no longer errors on the `contains` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)