### PR TITLE
fix: restore CI after voice mode changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libasound2-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - run: cd src-tauri && cargo clippy -- -D warnings
       - run: cd src-tauri && cargo test

--- a/src-tauri/src/architecture.rs
+++ b/src-tauri/src/architecture.rs
@@ -1571,8 +1571,14 @@ That should be enough to render the view."#;
         }"#;
 
         let parsed = parse_architecture_output(output).expect("aliased fields should parse");
-        assert_eq!(parsed.components[0].outgoing_relationships[0].component_id, "worker");
-        assert_eq!(parsed.components[1].incoming_relationships[0].component_id, "api");
+        assert_eq!(
+            parsed.components[0].outgoing_relationships[0].component_id,
+            "worker"
+        );
+        assert_eq!(
+            parsed.components[1].incoming_relationships[0].component_id,
+            "api"
+        );
     }
 
     #[test]
@@ -1608,8 +1614,13 @@ That should be enough to render the view."#;
           ]
         }"#;
 
-        let error = parse_architecture_output(output).expect_err("missing component_id should fail in validation");
-        assert!(error.contains("missing component id"), "error should mention missing component id: {}", error);
+        let error = parse_architecture_output(output)
+            .expect_err("missing component_id should fail in validation");
+        assert!(
+            error.contains("missing component id"),
+            "error should mention missing component id: {}",
+            error
+        );
     }
 
     #[test]

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -12,7 +12,10 @@ use crate::models::GithubIssue;
 use crate::state::AppState;
 
 #[allow(clippy::type_complexity)]
-static IDLE_CHANNEL: Lazy<(std::sync::Mutex<mpsc::Sender<Uuid>>, std::sync::Mutex<mpsc::Receiver<Uuid>>)> = Lazy::new(|| {
+static IDLE_CHANNEL: Lazy<(
+    std::sync::Mutex<mpsc::Sender<Uuid>>,
+    std::sync::Mutex<mpsc::Receiver<Uuid>>,
+)> = Lazy::new(|| {
     let (tx, rx) = mpsc::channel();
     (std::sync::Mutex::new(tx), std::sync::Mutex::new(rx))
 });
@@ -57,7 +60,10 @@ fn worker_cleanup_label_plan(issue_closed: Option<bool>) -> WorkerLabelPlan {
     if issue_closed == Some(false) {
         remove.push(LABEL_ASSIGNED_TO_AUTO_WORKER);
     }
-    WorkerLabelPlan { add: vec![], remove }
+    WorkerLabelPlan {
+        add: vec![],
+        remove,
+    }
 }
 
 fn label_definition(label: &str) -> Option<LabelDefinition> {
@@ -78,7 +84,12 @@ fn label_definition(label: &str) -> Option<LabelDefinition> {
     }
 }
 
-fn apply_worker_label_plan_sync(state: &AppState, repo_path: &str, issue_number: u64, plan: &WorkerLabelPlan) {
+fn apply_worker_label_plan_sync(
+    state: &AppState,
+    repo_path: &str,
+    issue_number: u64,
+    plan: &WorkerLabelPlan,
+) {
     for label in &plan.add {
         let _ = add_label_sync(state, repo_path, issue_number, label);
     }
@@ -125,7 +136,10 @@ impl AutoWorkerScheduler {
     /// Called on startup before any sessions exist — any `in-progress` label
     /// is orphaned from a previous run and must be cleaned up so the issue
     /// becomes eligible again.
-    fn cleanup_stale_labels(app_handle: &AppHandle, protected_issues: &HashMap<String, HashSet<u64>>) {
+    fn cleanup_stale_labels(
+        app_handle: &AppHandle,
+        protected_issues: &HashMap<String, HashSet<u64>>,
+    ) {
         let state = match app_handle.try_state::<AppState>() {
             Some(s) => s,
             None => return,
@@ -160,8 +174,16 @@ impl AutoWorkerScheduler {
                     .map(|issues| issues.contains(&issue.number))
                     .unwrap_or(false);
                 if labels.contains(&LABEL_IN_PROGRESS) && !protected {
-                    eprintln!("Auto-worker: removing stale in-progress label from #{}", issue.number);
-                    let _ = remove_label_sync(state.inner(), &project.repo_path, issue.number, LABEL_IN_PROGRESS);
+                    eprintln!(
+                        "Auto-worker: removing stale in-progress label from #{}",
+                        issue.number
+                    );
+                    let _ = remove_label_sync(
+                        state.inner(),
+                        &project.repo_path,
+                        issue.number,
+                        LABEL_IN_PROGRESS,
+                    );
                 }
             }
         }
@@ -193,16 +215,28 @@ impl AutoWorkerScheduler {
                 // 1. Check timed-out sessions
                 let timed_out: Vec<Uuid> = active_sessions
                     .iter()
-                    .filter(|(_, s)| s.spawned_at.elapsed() > Duration::from_secs(SESSION_TIMEOUT_SECS))
+                    .filter(|(_, s)| {
+                        s.spawned_at.elapsed() > Duration::from_secs(SESSION_TIMEOUT_SECS)
+                    })
                     .map(|(pid, _)| *pid)
                     .collect();
 
                 for project_id in timed_out {
                     if let Some(session) = active_sessions.remove(&project_id) {
-                        eprintln!("Auto-worker: session timed out for #{}", session.issue_number);
+                        eprintln!(
+                            "Auto-worker: session timed out for #{}",
+                            session.issue_number
+                        );
                         let (issue_number, issue_title) = session_issue_context(&session);
                         kill_session(&state, &session);
-                        emit_status(&state, project_id, "idle", Some("Session timed out"), issue_number, issue_title);
+                        emit_status(
+                            &state,
+                            project_id,
+                            "idle",
+                            Some("Session timed out"),
+                            issue_number,
+                            issue_title,
+                        );
                     }
                 }
 
@@ -211,7 +245,9 @@ impl AutoWorkerScheduler {
                     .iter()
                     .filter(|(_, s)| {
                         s.last_idle_at.is_some()
-                            && s.last_nudge_at.is_none_or(|t| t.elapsed() > Duration::from_secs(NUDGE_COOLDOWN_SECS))
+                            && s.last_nudge_at.is_none_or(|t| {
+                                t.elapsed() > Duration::from_secs(NUDGE_COOLDOWN_SECS)
+                            })
                     })
                     .map(|(pid, _)| *pid)
                     .collect();
@@ -220,10 +256,20 @@ impl AutoWorkerScheduler {
                     if let Some(session) = active_sessions.get_mut(&project_id) {
                         if session.nudge_count >= MAX_NUDGES {
                             let session = active_sessions.remove(&project_id).unwrap();
-                            eprintln!("Auto-worker: killed after {} nudges for #{}", MAX_NUDGES, session.issue_number);
+                            eprintln!(
+                                "Auto-worker: killed after {} nudges for #{}",
+                                MAX_NUDGES, session.issue_number
+                            );
                             let (issue_number, issue_title) = session_issue_context(&session);
                             kill_session(&state, &session);
-                            emit_status(&state, project_id, "idle", Some("Killed after max nudges"), issue_number, issue_title);
+                            emit_status(
+                                &state,
+                                project_id,
+                                "idle",
+                                Some("Killed after max nudges"),
+                                issue_number,
+                                issue_title,
+                            );
                         } else {
                             nudge_session(&state, session);
                         }
@@ -245,7 +291,10 @@ impl AutoWorkerScheduler {
 
                 for project_id in exited {
                     if let Some(session) = active_sessions.remove(&project_id) {
-                        eprintln!("Auto-worker: session completed for #{}", session.issue_number);
+                        eprintln!(
+                            "Auto-worker: session completed for #{}",
+                            session.issue_number
+                        );
                         let (issue_number, issue_title) = session_issue_context(&session);
                         mark_issue_finished(state.inner(), &session);
                         cleanup_session(&state, &session);
@@ -286,7 +335,10 @@ impl AutoWorkerScheduler {
                     let issues = match fetch_issues_sync(&project.repo_path) {
                         Ok(issues) => issues,
                         Err(e) => {
-                            eprintln!("Auto-worker: failed to fetch issues for {}: {}", project.name, e);
+                            eprintln!(
+                                "Auto-worker: failed to fetch issues for {}: {}",
+                                project.name, e
+                            );
                             continue;
                         }
                     };
@@ -304,21 +356,34 @@ impl AutoWorkerScheduler {
                                 eligible.number,
                                 &worker_claim_label_plan(),
                             );
-                            emit_status(&state, project.id, "working", None, Some(eligible.number), Some(&eligible.title));
-                            active_sessions.insert(project.id, ActiveSession {
-                                session_id,
-                                project_id: project.id,
-                                issue_number: eligible.number,
-                                issue_title: eligible.title.clone(),
-                                repo_path: project.repo_path.clone(),
-                                spawned_at: Instant::now(),
-                                nudge_count: 0,
-                                last_idle_at: None,
-                                last_nudge_at: None,
-                            });
+                            emit_status(
+                                &state,
+                                project.id,
+                                "working",
+                                None,
+                                Some(eligible.number),
+                                Some(&eligible.title),
+                            );
+                            active_sessions.insert(
+                                project.id,
+                                ActiveSession {
+                                    session_id,
+                                    project_id: project.id,
+                                    issue_number: eligible.number,
+                                    issue_title: eligible.title.clone(),
+                                    repo_path: project.repo_path.clone(),
+                                    spawned_at: Instant::now(),
+                                    nudge_count: 0,
+                                    last_idle_at: None,
+                                    last_nudge_at: None,
+                                },
+                            );
                         }
                         Err(e) => {
-                            eprintln!("Auto-worker: failed to spawn session for #{}: {}", eligible.number, e);
+                            eprintln!(
+                                "Auto-worker: failed to spawn session for #{}: {}",
+                                eligible.number, e
+                            );
                         }
                     }
                 }
@@ -426,18 +491,31 @@ impl AutoWorkerScheduler {
     }
 }
 
-fn emit_status(state: &AppState, project_id: Uuid, status: &str, message: Option<&str>, issue_number: Option<u64>, issue_title: Option<&str>) {
+fn emit_status(
+    state: &AppState,
+    project_id: Uuid,
+    status: &str,
+    message: Option<&str>,
+    issue_number: Option<u64>,
+    issue_title: Option<&str>,
+) {
     let payload = serde_json::json!({
         "status": status,
         "message": message.unwrap_or(""),
         "issue_number": issue_number,
         "issue_title": issue_title.unwrap_or(""),
     });
-    let _ = state.emitter.emit(&format!("auto-worker-status:{}", project_id), &payload.to_string());
+    let _ = state.emitter.emit(
+        &format!("auto-worker-status:{}", project_id),
+        &payload.to_string(),
+    );
 }
 
 fn session_issue_context(session: &ActiveSession) -> (Option<u64>, Option<&str>) {
-    (Some(session.issue_number), Some(session.issue_title.as_str()))
+    (
+        Some(session.issue_number),
+        Some(session.issue_title.as_str()),
+    )
 }
 
 fn startup_candidate_to_active_session(candidate: &StartupWorkerCandidate) -> ActiveSession {
@@ -496,7 +574,9 @@ fn finalize_startup_restoration(
     finalized
 }
 
-fn protected_issue_numbers_by_repo(candidates: &[StartupWorkerCandidate]) -> HashMap<String, HashSet<u64>> {
+fn protected_issue_numbers_by_repo(
+    candidates: &[StartupWorkerCandidate],
+) -> HashMap<String, HashSet<u64>> {
     let mut protected = HashMap::new();
 
     for candidate in candidates {
@@ -511,7 +591,14 @@ fn protected_issue_numbers_by_repo(candidates: &[StartupWorkerCandidate]) -> Has
 
 fn fetch_issues_sync(repo_path: &str) -> Result<Vec<GithubIssue>, String> {
     let output = Command::new("gh")
-        .args(["issue", "list", "--json", "number,title,url,body,labels", "--limit", "50"])
+        .args([
+            "issue",
+            "list",
+            "--json",
+            "number,title,url,body,labels",
+            "--limit",
+            "50",
+        ])
         .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run gh: {}", e))?;
@@ -521,8 +608,7 @@ fn fetch_issues_sync(repo_path: &str) -> Result<Vec<GithubIssue>, String> {
         return Err(format!("gh issue list failed: {}", stderr));
     }
 
-    serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("Failed to parse gh output: {}", e))
+    serde_json::from_slice(&output.stdout).map_err(|e| format!("Failed to parse gh output: {}", e))
 }
 
 fn finish_label_edit<F>(state: &AppState, repo_path: &str, edit: F) -> Result<(), String>
@@ -538,7 +624,12 @@ where
     Ok(())
 }
 
-fn edit_label_sync(repo_path: &str, issue_number: u64, mode: &str, label: &str) -> Result<(), String> {
+fn edit_label_sync(
+    repo_path: &str,
+    issue_number: u64,
+    mode: &str,
+    label: &str,
+) -> Result<(), String> {
     if mode == "--add-label" {
         if let Some(definition) = label_definition(label) {
             let _ = Command::new("gh")
@@ -570,17 +661,37 @@ fn edit_label_sync(repo_path: &str, issue_number: u64, mode: &str, label: &str) 
     Ok(())
 }
 
-fn add_label_sync(state: &AppState, repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
-    finish_label_edit(state, repo_path, || edit_label_sync(repo_path, issue_number, "--add-label", label))
+fn add_label_sync(
+    state: &AppState,
+    repo_path: &str,
+    issue_number: u64,
+    label: &str,
+) -> Result<(), String> {
+    finish_label_edit(state, repo_path, || {
+        edit_label_sync(repo_path, issue_number, "--add-label", label)
+    })
 }
 
-fn remove_label_sync(state: &AppState, repo_path: &str, issue_number: u64, label: &str) -> Result<(), String> {
-    finish_label_edit(state, repo_path, || edit_label_sync(repo_path, issue_number, "--remove-label", label))
+fn remove_label_sync(
+    state: &AppState,
+    repo_path: &str,
+    issue_number: u64,
+    label: &str,
+) -> Result<(), String> {
+    finish_label_edit(state, repo_path, || {
+        edit_label_sync(repo_path, issue_number, "--remove-label", label)
+    })
 }
 
 fn issue_is_closed_sync(repo_path: &str, issue_number: u64) -> Result<bool, String> {
     let output = Command::new("gh")
-        .args(["issue", "view", &issue_number.to_string(), "--json", "state"])
+        .args([
+            "issue",
+            "view",
+            &issue_number.to_string(),
+            "--json",
+            "state",
+        ])
         .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to run gh: {}", e))?;
@@ -610,28 +721,30 @@ fn spawn_auto_worker_session(
     };
     let worktree_dir = base_dir.join("worktrees").join(&project.name).join(&label);
 
-    let (session_dir, wt_path, wt_branch) =
-        match crate::worktree::WorktreeManager::create_worktree(&project.repo_path, &label, &worktree_dir) {
-            Ok(worktree_path) => {
-                let wt_str = worktree_path
-                    .to_str()
-                    .ok_or_else(|| "worktree path is not valid UTF-8".to_string())?
-                    .to_string();
-                (wt_str.clone(), Some(wt_str), Some(label.clone()))
-            }
-            Err(e) if e == "unborn_branch" => {
-                (project.repo_path.clone(), None, None)
-            }
-            Err(e) => return Err(e),
-        };
+    let (session_dir, wt_path, wt_branch) = match crate::worktree::WorktreeManager::create_worktree(
+        &project.repo_path,
+        &label,
+        &worktree_dir,
+    ) {
+        Ok(worktree_path) => {
+            let wt_str = worktree_path
+                .to_str()
+                .ok_or_else(|| "worktree path is not valid UTF-8".to_string())?
+                .to_string();
+            (wt_str.clone(), Some(wt_str), Some(label.clone()))
+        }
+        Err(e) if e == "unborn_branch" => (project.repo_path.clone(), None, None),
+        Err(e) => return Err(e),
+    };
 
-    let initial_prompt = crate::session_args::build_issue_prompt(
-        issue.number, &issue.title, &issue.url, true,
-    );
+    let initial_prompt =
+        crate::session_args::build_issue_prompt(issue.number, &issue.title, &issue.url, true);
 
     {
         let storage = state.storage.lock().map_err(|e| e.to_string())?;
-        let mut proj = storage.load_project(project.id).map_err(|e| e.to_string())?;
+        let mut proj = storage
+            .load_project(project.id)
+            .map_err(|e| e.to_string())?;
         proj.sessions.push(crate::models::SessionConfig {
             id: session_id,
             label: label.clone(),
@@ -669,7 +782,10 @@ fn nudge_session(state: &AppState, session: &mut ActiveSession) {
     }
     session.nudge_count += 1;
     session.last_nudge_at = Some(Instant::now());
-    eprintln!("Auto-worker: nudged session for #{} (nudge {})", session.issue_number, session.nudge_count);
+    eprintln!(
+        "Auto-worker: nudged session for #{} (nudge {})",
+        session.issue_number, session.nudge_count
+    );
 }
 
 fn kill_session(state: &AppState, session: &ActiveSession) {
@@ -690,25 +806,35 @@ fn has_merged_pr_sync(repo_path: &str, issue_number: u64) -> bool {
     let search_query = format!("#{}", issue_number);
     let output = Command::new("gh")
         .args([
-            "pr", "list",
-            "--search", &search_query,
-            "--state", "merged",
-            "--json", "number",
-            "--limit", "1",
+            "pr",
+            "list",
+            "--search",
+            &search_query,
+            "--state",
+            "merged",
+            "--json",
+            "number",
+            "--limit",
+            "1",
         ])
         .current_dir(repo_path)
         .output();
 
     match output {
-        Ok(o) if o.status.success() => {
-            json_has_results(&String::from_utf8_lossy(&o.stdout))
-        }
+        Ok(o) if o.status.success() => json_has_results(&String::from_utf8_lossy(&o.stdout)),
         Ok(o) => {
-            eprintln!("Auto-worker: gh pr list failed for #{}: {}", issue_number, String::from_utf8_lossy(&o.stderr));
+            eprintln!(
+                "Auto-worker: gh pr list failed for #{}: {}",
+                issue_number,
+                String::from_utf8_lossy(&o.stderr)
+            );
             false
         }
         Err(e) => {
-            eprintln!("Auto-worker: failed to run gh pr list for #{}: {}", issue_number, e);
+            eprintln!(
+                "Auto-worker: failed to run gh pr list for #{}: {}",
+                issue_number, e
+            );
             false
         }
     }
@@ -731,9 +857,11 @@ fn close_issue_sync(repo_path: &str, issue_number: u64) -> Result<(), String> {
 fn mark_issue_finished(state: &AppState, session: &ActiveSession) {
     let mut issue_closed = issue_is_closed_sync(&session.repo_path, session.issue_number).ok();
 
-    if issue_closed != Some(true) && has_merged_pr_sync(&session.repo_path, session.issue_number)
-        && close_issue_sync(&session.repo_path, session.issue_number).is_ok() {
-            issue_closed = Some(true);
+    if issue_closed != Some(true)
+        && has_merged_pr_sync(&session.repo_path, session.issue_number)
+        && close_issue_sync(&session.repo_path, session.issue_number).is_ok()
+    {
+        issue_closed = Some(true);
     }
 
     apply_worker_label_plan_sync(
@@ -744,13 +872,32 @@ fn mark_issue_finished(state: &AppState, session: &ActiveSession) {
     );
 
     if issue_closed == Some(true) {
-        let _ = add_label_sync(state, &session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
-        eprintln!("Auto-worker: finalized #{} as completed", session.issue_number);
+        let _ = add_label_sync(
+            state,
+            &session.repo_path,
+            session.issue_number,
+            LABEL_FINISHED_BY_WORKER,
+        );
+        eprintln!(
+            "Auto-worker: finalized #{} as completed",
+            session.issue_number
+        );
     } else if issue_closed == Some(false) {
-        let _ = remove_label_sync(state, &session.repo_path, session.issue_number, LABEL_FINISHED_BY_WORKER);
-        eprintln!("Auto-worker: #{} exited while still open", session.issue_number);
+        let _ = remove_label_sync(
+            state,
+            &session.repo_path,
+            session.issue_number,
+            LABEL_FINISHED_BY_WORKER,
+        );
+        eprintln!(
+            "Auto-worker: #{} exited while still open",
+            session.issue_number
+        );
     } else {
-        eprintln!("Auto-worker: #{} cleanup could not confirm issue state", session.issue_number);
+        eprintln!(
+            "Auto-worker: #{} cleanup could not confirm issue state",
+            session.issue_number
+        );
     }
 }
 fn cleanup_startup_worker(
@@ -777,14 +924,20 @@ fn cleanup_startup_worker(
 fn cleanup_session(state: &AppState, session: &ActiveSession) {
     if let Ok(storage) = state.storage.lock() {
         if let Ok(mut project) = storage.load_project(session.project_id) {
-            let sess = project.sessions.iter().find(|s| s.id == session.session_id).cloned();
+            let sess = project
+                .sessions
+                .iter()
+                .find(|s| s.id == session.session_id)
+                .cloned();
             project.sessions.retain(|s| s.id != session.session_id);
             let _ = storage.save_project(&project);
 
             if let Some(sess) = sess {
                 if let (Some(wt_path), Some(branch)) = (sess.worktree_path, sess.worktree_branch) {
                     let _ = crate::worktree::WorktreeManager::remove_worktree(
-                        &wt_path, &project.repo_path, &branch,
+                        &wt_path,
+                        &project.repo_path,
+                        &branch,
                     );
                 }
             }
@@ -820,7 +973,12 @@ mod tests {
             title: "Test".to_string(),
             url: "https://github.com/o/r/issues/1".to_string(),
             body: None,
-            labels: labels.iter().map(|l| GithubLabel { name: l.to_string() }).collect(),
+            labels: labels
+                .iter()
+                .map(|l| GithubLabel {
+                    name: l.to_string(),
+                })
+                .collect(),
         }
     }
 
@@ -868,7 +1026,12 @@ mod tests {
 
     #[test]
     fn finished_by_worker_not_eligible() {
-        let issue = make_issue(&["priority:high", "complexity:low", "triaged", "finished-by-worker"]);
+        let issue = make_issue(&[
+            "priority:high",
+            "complexity:low",
+            "triaged",
+            "finished-by-worker",
+        ]);
         assert!(!is_eligible(&issue));
     }
 
@@ -931,7 +1094,11 @@ mod tests {
     #[test]
     fn successful_label_edit_invalidates_issue_cache() {
         let tmp = TempDir::new().unwrap();
-        let state = AppState::from_storage(Storage::new(tmp.path().to_path_buf()), crate::emitter::NoopEmitter::new()).unwrap();
+        let state = AppState::from_storage(
+            Storage::new(tmp.path().to_path_buf()),
+            crate::emitter::NoopEmitter::new(),
+        )
+        .unwrap();
         let repo_path = "/tmp/repo";
 
         {
@@ -948,7 +1115,11 @@ mod tests {
     #[test]
     fn failed_label_edit_keeps_issue_cache() {
         let tmp = TempDir::new().unwrap();
-        let state = AppState::from_storage(Storage::new(tmp.path().to_path_buf()), crate::emitter::NoopEmitter::new()).unwrap();
+        let state = AppState::from_storage(
+            Storage::new(tmp.path().to_path_buf()),
+            crate::emitter::NoopEmitter::new(),
+        )
+        .unwrap();
         let repo_path = "/tmp/repo";
 
         {

--- a/src-tauri/src/bin/controller-cli.rs
+++ b/src-tauri/src/bin/controller-cli.rs
@@ -39,7 +39,10 @@ where
     Err: Write,
 {
     let Some((project, key)) = parse_args(args) else {
-        let _ = writeln!(stderr, "Usage: controller-cli env set --project <project> --key <ENV_KEY>");
+        let _ = writeln!(
+            stderr,
+            "Usage: controller-cli env set --project <project> --key <ENV_KEY>"
+        );
         return 2;
     };
 
@@ -175,7 +178,12 @@ mod tests {
                 "--key",
                 "OPENAI_API_KEY",
             ],
-            || Ok(Box::new(FakeStream::new("ok|updated|req-123\n", writes.clone()))),
+            || {
+                Ok(Box::new(FakeStream::new(
+                    "ok|updated|req-123\n",
+                    writes.clone(),
+                )))
+            },
             &mut stdout,
             &mut stderr,
             "req-123",
@@ -207,7 +215,12 @@ mod tests {
                 "--key",
                 "OPENAI_API_KEY",
             ],
-            || Err(std::io::Error::new(std::io::ErrorKind::NotFound, "missing socket")),
+            || {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "missing socket",
+                ))
+            },
             &mut stdout,
             &mut stderr,
             "req-123",
@@ -236,7 +249,12 @@ mod tests {
                 "--key",
                 "OPENAI_API_KEY",
             ],
-            || Ok(Box::new(FakeStream::new("error|cancelled|req-123\n", writes.clone()))),
+            || {
+                Ok(Box::new(FakeStream::new(
+                    "error|cancelled|req-123\n",
+                    writes.clone(),
+                )))
+            },
             &mut stdout,
             &mut stderr,
             "req-123",

--- a/src-tauri/src/bin/server.rs
+++ b/src-tauri/src/bin/server.rs
@@ -11,11 +11,7 @@ use axum::{
 use serde_json::Value;
 use std::sync::Arc;
 use the_controller_lib::{
-    config,
-    emitter::WsBroadcastEmitter,
-    note_ai_chat,
-    notes,
-    state::AppState,
+    config, emitter::WsBroadcastEmitter, note_ai_chat, notes, state::AppState,
 };
 
 use tokio::sync::broadcast;
@@ -448,9 +444,7 @@ async fn merge_session_branch(
     ))
 }
 
-async fn send_note_ai_chat(
-    Json(args): Json<Value>,
-) -> Result<Json<Value>, (StatusCode, String)> {
+async fn send_note_ai_chat(Json(args): Json<Value>) -> Result<Json<Value>, (StatusCode, String)> {
     let note_content = args["noteContent"]
         .as_str()
         .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing noteContent".to_string()))?
@@ -465,8 +459,7 @@ async fn send_note_ai_chat(
         .to_string();
 
     let conversation_history: Vec<note_ai_chat::NoteAiChatMessage> =
-        serde_json::from_value(args["conversationHistory"].clone())
-            .unwrap_or_default();
+        serde_json::from_value(args["conversationHistory"].clone()).unwrap_or_default();
 
     let response = note_ai_chat::send_note_ai_message(
         std::env::temp_dir().to_string_lossy().to_string(),
@@ -499,7 +492,10 @@ async fn api_list_notes(
         .as_str()
         .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?
         .to_string();
-    let base_dir = state.app.storage.lock()
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     let entries = notes::list_notes(&base_dir, &folder)
@@ -511,11 +507,18 @@ async fn api_read_note(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let folder = args["folder"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?.to_string();
-    let filename = args["filename"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let folder = args["folder"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?
+        .to_string();
+    let filename = args["filename"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     let content = notes::read_note(&base_dir, &folder, &filename)
@@ -527,13 +530,22 @@ async fn api_write_note(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let folder = args["folder"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?.to_string();
-    let filename = args["filename"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?.to_string();
-    let content = args["content"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing content".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let folder = args["folder"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?
+        .to_string();
+    let filename = args["filename"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?
+        .to_string();
+    let content = args["content"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing content".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     notes::write_note(&base_dir, &folder, &filename, &content)
@@ -545,11 +557,18 @@ async fn api_create_note(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let folder = args["folder"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?.to_string();
-    let title = args["title"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing title".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let folder = args["folder"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?
+        .to_string();
+    let title = args["title"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing title".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     let filename = notes::create_note(&base_dir, &folder, &title)
@@ -562,11 +581,18 @@ async fn api_delete_note(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let folder = args["folder"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?.to_string();
-    let filename = args["filename"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let folder = args["folder"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?
+        .to_string();
+    let filename = args["filename"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing filename".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     notes::delete_note(&base_dir, &folder, &filename)
@@ -579,18 +605,30 @@ async fn api_rename_note(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let folder = args["folder"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?.to_string();
-    let old_name = args["oldName"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing oldName".to_string()))?.to_string();
-    let new_name = args["newName"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing newName".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let folder = args["folder"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing folder".to_string()))?
+        .to_string();
+    let old_name = args["oldName"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing oldName".to_string()))?
+        .to_string();
+    let new_name = args["newName"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing newName".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     let filename = notes::rename_note(&base_dir, &folder, &old_name, &new_name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    server_try_commit(&state, &format!("rename {}/{} → {}", folder, old_name, filename));
+    server_try_commit(
+        &state,
+        &format!("rename {}/{} → {}", folder, old_name, filename),
+    );
     Ok(Json(serde_json::to_value(filename).unwrap()))
 }
 
@@ -598,7 +636,10 @@ async fn api_list_folders(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(_args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let base_dir = state.app.storage.lock()
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     let folders = notes::list_folders(&base_dir)
@@ -610,9 +651,14 @@ async fn api_create_folder(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let name = args["name"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing name".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let name = args["name"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing name".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     notes::create_folder(&base_dir, &name)
@@ -625,16 +671,26 @@ async fn api_rename_folder(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let old_name = args["oldName"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing oldName".to_string()))?.to_string();
-    let new_name = args["newName"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing newName".to_string()))?.to_string();
-    let base_dir = state.app.storage.lock()
+    let old_name = args["oldName"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing oldName".to_string()))?
+        .to_string();
+    let new_name = args["newName"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing newName".to_string()))?
+        .to_string();
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     notes::rename_folder(&base_dir, &old_name, &new_name)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    server_try_commit(&state, &format!("rename folder {} → {}", old_name, new_name));
+    server_try_commit(
+        &state,
+        &format!("rename folder {} → {}", old_name, new_name),
+    );
     Ok(Json(Value::Null))
 }
 
@@ -642,10 +698,15 @@ async fn api_delete_folder(
     AxumState(state): AxumState<Arc<ServerState>>,
     Json(args): Json<Value>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let name = args["name"].as_str()
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing name".to_string()))?.to_string();
+    let name = args["name"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing name".to_string()))?
+        .to_string();
     let force = args["force"].as_bool().unwrap_or(false);
-    let base_dir = state.app.storage.lock()
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     notes::delete_folder(&base_dir, &name, force)
@@ -657,7 +718,10 @@ async fn api_delete_folder(
 async fn api_commit_notes(
     AxumState(state): AxumState<Arc<ServerState>>,
 ) -> Result<Json<Value>, (StatusCode, String)> {
-    let base_dir = state.app.storage.lock()
+    let base_dir = state
+        .app
+        .storage
+        .lock()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .base_dir();
     let committed = notes::commit_notes(&base_dir, "update notes")

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -567,7 +567,6 @@ pub fn delete_project(
     Ok(())
 }
 
-
 #[tauri::command]
 pub fn get_agents_md(state: State<AppState>, project_id: String) -> Result<String, String> {
     let id = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
@@ -793,10 +792,7 @@ pub async fn submit_secure_env_value(
 }
 
 #[tauri::command]
-pub fn cancel_secure_env_request(
-    state: State<AppState>,
-    request_id: String,
-) -> Result<(), String> {
+pub fn cancel_secure_env_request(state: State<AppState>, request_id: String) -> Result<(), String> {
     crate::secure_env::cancel_secure_env_request(&state, &request_id)
 }
 
@@ -830,15 +826,19 @@ fn find_staging_port(base_port: u16) -> Result<u16, String> {
 pub(crate) fn kill_process_group(pid: u32) {
     #[cfg(unix)]
     {
-        use libc::{kill, SIGTERM, SIGKILL};
+        use libc::{kill, SIGKILL, SIGTERM};
         if let Ok(pgid) = i32::try_from(pid) {
-            unsafe { kill(-pgid, SIGTERM); }
+            unsafe {
+                kill(-pgid, SIGTERM);
+            }
             std::thread::spawn(move || {
                 std::thread::sleep(std::time::Duration::from_secs(2));
                 // Only send SIGKILL if the process group is still alive
                 // (kill with signal 0 checks existence without sending a signal)
                 if unsafe { kill(-pgid, 0) } == 0 {
-                    unsafe { kill(-pgid, SIGKILL); }
+                    unsafe {
+                        kill(-pgid, SIGKILL);
+                    }
                 }
             });
         }
@@ -1060,7 +1060,10 @@ pub async fn stage_session(
     let mut child = std::process::Command::new("bash")
         .args(["./dev.sh", &port.to_string()])
         .current_dir(&wt)
-        .env("CONTROLLER_SOCKET", crate::status_socket::staged_socket_path())
+        .env(
+            "CONTROLLER_SOCKET",
+            crate::status_socket::staged_socket_path(),
+        )
         .stdout(Stdio::from(log_file))
         .stderr(Stdio::from(log_stderr))
         .process_group(0)
@@ -1213,7 +1216,6 @@ pub fn list_project_prompts(
         .map_err(|e| e.to_string())?;
     Ok(project.prompts)
 }
-
 
 #[tauri::command]
 pub fn close_session(
@@ -1536,7 +1538,11 @@ pub fn create_folder(state: State<'_, AppState>, name: String) -> Result<(), Str
 }
 
 #[tauri::command]
-pub fn rename_folder(state: State<'_, AppState>, old_name: String, new_name: String) -> Result<(), String> {
+pub fn rename_folder(
+    state: State<'_, AppState>,
+    old_name: String,
+    new_name: String,
+) -> Result<(), String> {
     notes::rename_folder(state, old_name, new_name)
 }
 
@@ -1557,11 +1563,7 @@ pub fn save_note_image(
     image_bytes: Vec<u8>,
     extension: String,
 ) -> Result<String, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     crate::notes::save_note_image(&base_dir, &folder, &image_bytes, &extension)
         .map_err(|e| e.to_string())
 }
@@ -1572,11 +1574,7 @@ pub fn resolve_note_asset_path(
     folder: String,
     relative_path: String,
 ) -> Result<String, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     crate::notes::resolve_note_asset_path(&base_dir, &folder, &relative_path)
         .map(|p| p.to_string_lossy().to_string())
         .map_err(|e| e.to_string())
@@ -2099,9 +2097,7 @@ pub fn log_frontend_error(message: String) {
 }
 
 #[tauri::command]
-pub async fn start_voice_pipeline(
-    state: tauri::State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn start_voice_pipeline(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let mut pipeline = state.voice_pipeline.lock().await;
     if pipeline.is_some() {
         return Ok(()); // Already running
@@ -2113,9 +2109,7 @@ pub async fn start_voice_pipeline(
 }
 
 #[tauri::command]
-pub async fn stop_voice_pipeline(
-    state: tauri::State<'_, AppState>,
-) -> Result<(), String> {
+pub async fn stop_voice_pipeline(state: tauri::State<'_, AppState>) -> Result<(), String> {
     let mut pipeline = state.voice_pipeline.lock().await;
     if let Some(mut p) = pipeline.take() {
         p.stop();
@@ -3121,7 +3115,11 @@ mod tests {
                 .save_project(&Project {
                     id: Uuid::new_v4(),
                     name: "stored-project".to_string(),
-                    repo_path: projects_root.path().join("stored-project").to_string_lossy().to_string(),
+                    repo_path: projects_root
+                        .path()
+                        .join("stored-project")
+                        .to_string_lossy()
+                        .to_string(),
                     created_at: "2026-03-10T00:00:00Z".to_string(),
                     archived: true,
                     maintainer: crate::models::MaintainerConfig::default(),
@@ -3258,13 +3256,26 @@ mod tests {
     #[test]
     fn test_build_auto_worker_queue_filters_and_pins_active_issue() {
         let issues = vec![
-            make_issue(11, "Eligible queued issue", &["priority:high", "complexity:low"]),
-            make_issue(12, "Busy issue", &["priority:high", "complexity:low", "in-progress"]),
+            make_issue(
+                11,
+                "Eligible queued issue",
+                &["priority:high", "complexity:low"],
+            ),
+            make_issue(
+                12,
+                "Busy issue",
+                &["priority:high", "complexity:low", "in-progress"],
+            ),
         ];
         let active_issue = Some(make_issue(
             12,
             "Busy issue",
-            &["priority:high", "complexity:low", "in-progress", "assigned-to-auto-worker"],
+            &[
+                "priority:high",
+                "complexity:low",
+                "in-progress",
+                "assigned-to-auto-worker",
+            ],
         ));
 
         let queue = build_auto_worker_queue(issues, active_issue);
@@ -3278,8 +3289,16 @@ mod tests {
 
     #[test]
     fn test_build_auto_worker_queue_avoids_duplicate_active_issue() {
-        let issues = vec![make_issue(21, "Already active", &["priority:high", "complexity:low"])];
-        let active_issue = Some(make_issue(21, "Already active", &["priority:high", "complexity:low"]));
+        let issues = vec![make_issue(
+            21,
+            "Already active",
+            &["priority:high", "complexity:low"],
+        )];
+        let active_issue = Some(make_issue(
+            21,
+            "Already active",
+            &["priority:high", "complexity:low"],
+        ));
 
         let queue = build_auto_worker_queue(issues, active_issue);
 
@@ -3335,7 +3354,11 @@ mod tests {
             issue_cache.insert(
                 repo_path.to_string_lossy().to_string(),
                 vec![
-                    make_issue(33, "Active worker issue", &["priority:high", "complexity:low"]),
+                    make_issue(
+                        33,
+                        "Active worker issue",
+                        &["priority:high", "complexity:low"],
+                    ),
                     make_issue(34, "Queued issue", &["priority:high", "complexity:low"]),
                     make_issue(35, "Ineligible issue", &["priority:high"]),
                 ],
@@ -3411,11 +3434,8 @@ mod tests {
         )
         .expect("begin secure env request");
 
-        cancel_secure_env_request(
-            state_from_ref(&app_state),
-            "req-123".to_string(),
-        )
-        .expect("cancel secure env request");
+        cancel_secure_env_request(state_from_ref(&app_state), "req-123".to_string())
+            .expect("cancel secure env request");
 
         assert!(app_state.secure_env_request.lock().unwrap().is_none());
     }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -241,7 +241,9 @@ pub(crate) async fn add_github_label(
 ) -> Result<(), String> {
     let nwo = extract_github_repo_async(repo_path.clone()).await?;
 
-    let desc = description.as_deref().unwrap_or("Issue is being worked on in a session");
+    let desc = description
+        .as_deref()
+        .unwrap_or("Issue is being worked on in a session");
     let col = color.as_deref().unwrap_or("F9E2AF");
 
     // Ensure the label exists on the repo (ignore errors if it already exists)
@@ -353,8 +355,7 @@ pub(crate) async fn get_maintainer_issues(
         return Err(format!("gh issue list failed: {}", stderr));
     }
 
-    serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("Failed to parse gh output: {}", e))
+    serde_json::from_slice(&output.stdout).map_err(|e| format!("Failed to parse gh output: {}", e))
 }
 
 pub(crate) async fn get_maintainer_issue_detail(
@@ -386,8 +387,7 @@ pub(crate) async fn get_maintainer_issue_detail(
         return Err(format!("gh issue view failed: {}", stderr));
     }
 
-    serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("Failed to parse gh output: {}", e))
+    serde_json::from_slice(&output.stdout).map_err(|e| format!("Failed to parse gh output: {}", e))
 }
 
 pub(crate) async fn list_assigned_issues(repo_path: String) -> Result<Vec<AssignedIssue>, String> {
@@ -430,12 +430,18 @@ pub(crate) async fn get_worker_reports(repo_path: String) -> Result<Vec<WorkerRe
 
     let output = tokio::process::Command::new("gh")
         .args([
-            "issue", "list",
-            "--repo", &nwo,
-            "--label", LABEL_ASSIGNED_TO_AUTO_WORKER,
-            "--state", "all",
-            "--json", "number,title,state,comments,updatedAt",
-            "--limit", "50",
+            "issue",
+            "list",
+            "--repo",
+            &nwo,
+            "--label",
+            LABEL_ASSIGNED_TO_AUTO_WORKER,
+            "--state",
+            "all",
+            "--json",
+            "number,title,state,comments,updatedAt",
+            "--limit",
+            "50",
         ])
         .output()
         .await

--- a/src-tauri/src/commands/media.rs
+++ b/src-tauri/src/commands/media.rs
@@ -32,7 +32,10 @@ pub(crate) async fn copy_image_file_to_clipboard(
 /// When `cropped` is true, launches interactive crop selection via `screencapture -i`.
 /// Returns the path to the screenshot file so the caller can pass it to `initial_prompt`.
 #[allow(unused_variables)]
-pub(crate) async fn capture_app_screenshot(app: AppHandle, cropped: bool) -> Result<String, String> {
+pub(crate) async fn capture_app_screenshot(
+    app: AppHandle,
+    cropped: bool,
+) -> Result<String, String> {
     #[cfg(not(target_os = "macos"))]
     return Err("Screenshot capture is only supported on macOS".into());
 

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -14,11 +14,7 @@ pub(crate) fn list_notes(
     state: State<'_, AppState>,
     folder: String,
 ) -> Result<Vec<NoteEntry>, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::list_notes(&base_dir, &folder).map_err(|e| e.to_string())
 }
 
@@ -27,11 +23,7 @@ pub(crate) fn read_note(
     folder: String,
     filename: String,
 ) -> Result<String, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::read_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())
 }
 
@@ -41,11 +33,7 @@ pub(crate) fn write_note(
     filename: String,
     content: String,
 ) -> Result<(), String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::write_note(&base_dir, &folder, &filename, &content).map_err(|e| e.to_string())
     // No git commit here — batched via commit_notes command
 }
@@ -55,11 +43,7 @@ pub(crate) fn create_note(
     folder: String,
     title: String,
 ) -> Result<String, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     let filename = notes::create_note(&base_dir, &folder, &title).map_err(|e| e.to_string())?;
     try_commit(&base_dir, &format!("create {}/{}", folder, filename));
     Ok(filename)
@@ -71,14 +55,13 @@ pub(crate) fn rename_note(
     old_name: String,
     new_name: String,
 ) -> Result<String, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
-    let new_filename = notes::rename_note(&base_dir, &folder, &old_name, &new_name)
-        .map_err(|e| e.to_string())?;
-    try_commit(&base_dir, &format!("rename {}/{} → {}", folder, old_name, new_filename));
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
+    let new_filename =
+        notes::rename_note(&base_dir, &folder, &old_name, &new_name).map_err(|e| e.to_string())?;
+    try_commit(
+        &base_dir,
+        &format!("rename {}/{} → {}", folder, old_name, new_filename),
+    );
     Ok(new_filename)
 }
 
@@ -87,13 +70,12 @@ pub(crate) fn duplicate_note(
     folder: String,
     filename: String,
 ) -> Result<String, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     let copy = notes::duplicate_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())?;
-    try_commit(&base_dir, &format!("duplicate {}/{} → {}", folder, filename, copy));
+    try_commit(
+        &base_dir,
+        &format!("duplicate {}/{} → {}", folder, filename, copy),
+    );
     Ok(copy)
 }
 
@@ -102,27 +84,18 @@ pub(crate) fn delete_note(
     folder: String,
     filename: String,
 ) -> Result<(), String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::delete_note(&base_dir, &folder, &filename).map_err(|e| e.to_string())?;
     try_commit(&base_dir, &format!("delete {}/{}", folder, filename));
     Ok(())
 }
 
-pub(crate) fn list_folders(
-    state: State<'_, AppState>,
-) -> Result<Vec<String>, String> {
+pub(crate) fn list_folders(state: State<'_, AppState>) -> Result<Vec<String>, String> {
     let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::list_folders(&base_dir).map_err(|e| e.to_string())
 }
 
-pub(crate) fn create_folder(
-    state: State<'_, AppState>,
-    name: String,
-) -> Result<(), String> {
+pub(crate) fn create_folder(state: State<'_, AppState>, name: String) -> Result<(), String> {
     let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::create_folder(&base_dir, &name).map_err(|e| e.to_string())?;
     try_commit(&base_dir, &format!("create folder {}", name));
@@ -136,7 +109,10 @@ pub(crate) fn rename_folder(
 ) -> Result<(), String> {
     let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::rename_folder(&base_dir, &old_name, &new_name).map_err(|e| e.to_string())?;
-    try_commit(&base_dir, &format!("rename folder {} → {}", old_name, new_name));
+    try_commit(
+        &base_dir,
+        &format!("rename folder {} → {}", old_name, new_name),
+    );
     Ok(())
 }
 
@@ -153,13 +129,7 @@ pub(crate) fn delete_folder(
 
 /// Commit any pending note changes (content edits).
 /// Called by the frontend when switching notes.
-pub(crate) fn commit_notes(
-    state: State<'_, AppState>,
-) -> Result<bool, String> {
-    let base_dir = state
-        .storage
-        .lock()
-        .map_err(|e| e.to_string())?
-        .base_dir();
+pub(crate) fn commit_notes(state: State<'_, AppState>) -> Result<bool, String> {
+    let base_dir = state.storage.lock().map_err(|e| e.to_string())?.base_dir();
     notes::commit_notes(&base_dir, "update notes").map_err(|e| e.to_string())
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -196,7 +196,10 @@ mod tests {
     #[test]
     fn test_config_path_returns_expected() {
         let base = Path::new("/tmp/test-base");
-        assert_eq!(config_path(base), PathBuf::from("/tmp/test-base/config.json"));
+        assert_eq!(
+            config_path(base),
+            PathBuf::from("/tmp/test-base/config.json")
+        );
     }
 
     #[test]

--- a/src-tauri/src/deploy/cloudflare.rs
+++ b/src-tauri/src/deploy/cloudflare.rs
@@ -52,7 +52,8 @@ impl CloudflareClient {
             "ttl": 1,
         });
 
-        let resp = self.client
+        let resp = self
+            .client
             .post(format!(
                 "https://api.cloudflare.com/client/v4/zones/{}/dns_records",
                 self.zone_id
@@ -74,11 +75,14 @@ impl CloudflareClient {
             return Err(format!("Cloudflare error: {}", msgs.join(", ")));
         }
 
-        cf_resp.result.ok_or_else(|| "No result in Cloudflare response".to_string())
+        cf_resp
+            .result
+            .ok_or_else(|| "No result in Cloudflare response".to_string())
     }
 
     pub async fn list_dns_records(&self) -> Result<Vec<DnsRecord>, String> {
-        let resp = self.client
+        let resp = self
+            .client
             .get(format!(
                 "https://api.cloudflare.com/client/v4/zones/{}/dns_records",
                 self.zone_id
@@ -98,7 +102,9 @@ impl CloudflareClient {
             return Err(format!("Cloudflare error: {}", msgs.join(", ")));
         }
 
-        cf_resp.result.ok_or_else(|| "No result in Cloudflare response".to_string())
+        cf_resp
+            .result
+            .ok_or_else(|| "No result in Cloudflare response".to_string())
     }
 }
 

--- a/src-tauri/src/emitter.rs
+++ b/src-tauri/src/emitter.rs
@@ -29,7 +29,10 @@ pub struct WsBroadcastEmitter {
 #[cfg(feature = "server")]
 impl WsBroadcastEmitter {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> (Arc<dyn EventEmitter>, tokio::sync::broadcast::Sender<String>) {
+    pub fn new() -> (
+        Arc<dyn EventEmitter>,
+        tokio::sync::broadcast::Sender<String>,
+    ) {
         let (tx, _) = tokio::sync::broadcast::channel(4096);
         let sender = tx.clone();
         (Arc::new(Self { tx }), sender)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,7 +150,8 @@ pub fn run() {
                             for project in &inventory.projects {
                                 if let Some(staged) = &project.staged_session {
                                     commands::kill_process_group(staged.pid);
-                                    let _ = std::fs::remove_file(status_socket::staged_socket_path());
+                                    let _ =
+                                        std::fs::remove_file(status_socket::staged_socket_path());
                                     // Clear stale staged_session record
                                     let mut p = project.clone();
                                     p.staged_session = None;

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -177,8 +177,9 @@ impl MaintainerScheduler {
 
                     last_run.insert(project.id, Instant::now());
 
-                    let _ =
-                        state.emitter.emit(&format!("maintainer-status:{}", project.id), "running");
+                    let _ = state
+                        .emitter
+                        .emit(&format!("maintainer-status:{}", project.id), "running");
 
                     let github_repo = project.maintainer.github_repo.as_deref();
                     let result = run_maintainer_check(&project.repo_path, project.id, github_repo);
@@ -192,14 +193,17 @@ impl MaintainerScheduler {
                                 }
                             }
 
-                            let _ = state.emitter
+                            let _ = state
+                                .emitter
                                 .emit(&format!("maintainer-status:{}", project.id), "idle");
                         }
                         Err(e) => {
                             eprintln!("Maintainer check failed for {}: {}", project.name, e);
-                            let _ = state.emitter
+                            let _ = state
+                                .emitter
                                 .emit(&format!("maintainer-status:{}", project.id), "error");
-                            let _ = state.emitter
+                            let _ = state
+                                .emitter
                                 .emit(&format!("maintainer-error:{}", project.id), &e.to_string());
                         }
                     }
@@ -335,7 +339,8 @@ fn sanitize_finding(finding: CandidateFinding) -> Option<CandidateFinding> {
 }
 
 fn normalize_text_for_matching(input: &str) -> String {
-    input.chars()
+    input
+        .chars()
         .map(|ch| {
             if ch.is_ascii_alphanumeric() {
                 ch.to_ascii_lowercase()
@@ -1055,7 +1060,11 @@ pub fn run_maintainer_check(
             if skipped_closed > 0 {
                 skip_reasons.push(format!("{} closed", skipped_closed));
             }
-            parts.push(format!("skipped {} ({})", issues_skipped, skip_reasons.join(", ")));
+            parts.push(format!(
+                "skipped {} ({})",
+                issues_skipped,
+                skip_reasons.join(", ")
+            ));
         }
         parts.join(", ")
     };

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -420,8 +420,12 @@ mod tests {
             url: "https://github.com/owner/repo/issues/42".to_string(),
             body: None,
             labels: vec![
-                GithubLabel { name: "bug".to_string() },
-                GithubLabel { name: "priority".to_string() },
+                GithubLabel {
+                    name: "bug".to_string(),
+                },
+                GithubLabel {
+                    name: "priority".to_string(),
+                },
             ],
         };
         let json = serde_json::to_string(&issue).unwrap();

--- a/src-tauri/src/note_ai_chat.rs
+++ b/src-tauri/src/note_ai_chat.rs
@@ -39,15 +39,18 @@ fn build_note_ai_prompt(
         Do NOT wrap JSON in markdown code fences. Return raw JSON only.".to_string(),
     );
 
-    parts.push(format!("--- NOTE CONTENT ---\n{}\n--- END NOTE CONTENT ---", note_content));
+    parts.push(format!(
+        "--- NOTE CONTENT ---\n{}\n--- END NOTE CONTENT ---",
+        note_content
+    ));
     parts.push(format!(
         "--- SELECTED TEXT ---\n{}\n--- END SELECTED TEXT ---",
         selected_text
     ));
 
     if !conversation_history.is_empty() {
-        let history_json = serde_json::to_string(conversation_history)
-            .unwrap_or_else(|_| "[]".to_string());
+        let history_json =
+            serde_json::to_string(conversation_history).unwrap_or_else(|_| "[]".to_string());
         parts.push(format!(
             "--- CONVERSATION HISTORY ---\n{}\n--- END CONVERSATION HISTORY ---",
             history_json
@@ -90,8 +93,12 @@ pub async fn send_note_ai_message(
     conversation_history: Vec<NoteAiChatMessage>,
     prompt: String,
 ) -> Result<NoteAiResponse, String> {
-    let full_prompt =
-        build_note_ai_prompt(&note_content, &selected_text, &conversation_history, &prompt);
+    let full_prompt = build_note_ai_prompt(
+        &note_content,
+        &selected_text,
+        &conversation_history,
+        &prompt,
+    );
 
     tokio::task::spawn_blocking(move || run_note_ai_turn(repo_path, full_prompt))
         .await
@@ -178,6 +185,9 @@ mod tests {
     #[test]
     fn build_prompt_mentions_image_syntax() {
         let prompt = build_note_ai_prompt("note", "selected", &[], "help");
-        assert!(prompt.contains("!["), "prompt should mention image markdown syntax");
+        assert!(
+            prompt.contains("!["),
+            "prompt should mention image markdown syntax"
+        );
     }
 }

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -13,7 +13,11 @@ pub struct NoteEntry {
 
 /// Validates that a filename does not escape the notes directory.
 fn validate_filename(filename: &str) -> std::io::Result<()> {
-    if filename.contains('/') || filename.contains('\\') || filename.contains("..") || filename.is_empty() {
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+        || filename.is_empty()
+    {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("invalid note filename: {}", filename),
@@ -37,9 +41,7 @@ fn validate_folder_name(name: &str) -> std::io::Result<()> {
 /// `~/.the-controller/notes/{folder}/`
 pub fn notes_dir(folder: &str) -> PathBuf {
     let home = dirs::home_dir().expect("could not determine home directory");
-    home.join(".the-controller")
-        .join("notes")
-        .join(folder)
+    home.join(".the-controller").join("notes").join(folder)
 }
 
 /// Returns the notes directory for a folder under a custom base path (for testing).
@@ -53,10 +55,7 @@ pub fn notes_root_with_base(base: &std::path::Path) -> PathBuf {
 }
 
 /// List all `.md` files in the folder's notes directory, sorted by modified time (newest first).
-pub fn list_notes(
-    base: &std::path::Path,
-    folder: &str,
-) -> std::io::Result<Vec<NoteEntry>> {
+pub fn list_notes(base: &std::path::Path, folder: &str) -> std::io::Result<Vec<NoteEntry>> {
     let dir = notes_dir_with_base(base, folder);
     if !dir.exists() {
         return Ok(Vec::new());
@@ -86,22 +85,14 @@ pub fn list_notes(
 }
 
 /// Read the content of a note file.
-pub fn read_note(
-    base: &std::path::Path,
-    folder: &str,
-    filename: &str,
-) -> std::io::Result<String> {
+pub fn read_note(base: &std::path::Path, folder: &str, filename: &str) -> std::io::Result<String> {
     validate_filename(filename)?;
     let path = notes_dir_with_base(base, folder).join(filename);
     fs::read_to_string(path)
 }
 
 /// Check whether a note file exists after validating its filename.
-pub fn note_exists(
-    base: &std::path::Path,
-    folder: &str,
-    filename: &str,
-) -> std::io::Result<bool> {
+pub fn note_exists(base: &std::path::Path, folder: &str, filename: &str) -> std::io::Result<bool> {
     validate_filename(filename)?;
     let path = notes_dir_with_base(base, folder).join(filename);
     Ok(path.exists())
@@ -123,11 +114,7 @@ pub fn write_note(
 /// Create a new note with the given title. Auto-appends `.md` if not present.
 /// The file content is initialized to `# {title}\n`.
 /// Returns an error if a note with that filename already exists.
-pub fn create_note(
-    base: &std::path::Path,
-    folder: &str,
-    title: &str,
-) -> std::io::Result<String> {
+pub fn create_note(base: &std::path::Path, folder: &str, title: &str) -> std::io::Result<String> {
     let filename = if title.ends_with(".md") {
         title.to_string()
     } else {
@@ -198,7 +185,10 @@ fn strip_uuid_suffixes(stem: &str) -> &str {
             break;
         }
         let (head, tail) = s.split_at(s.len() - 9);
-        if tail.starts_with('-') && tail[1..].bytes().all(|b| b.is_ascii_hexdigit()) && !head.is_empty() {
+        if tail.starts_with('-')
+            && tail[1..].bytes().all(|b| b.is_ascii_hexdigit())
+            && !head.is_empty()
+        {
             s = head;
         } else {
             break;
@@ -237,11 +227,7 @@ pub fn duplicate_note(
 }
 
 /// Delete a note file. Returns Ok(()) even if the file doesn't exist (idempotent).
-pub fn delete_note(
-    base: &std::path::Path,
-    folder: &str,
-    filename: &str,
-) -> std::io::Result<()> {
+pub fn delete_note(base: &std::path::Path, folder: &str, filename: &str) -> std::io::Result<()> {
     validate_filename(filename)?;
     let path = notes_dir_with_base(base, folder).join(filename);
     match fs::remove_file(path) {
@@ -284,7 +270,11 @@ pub fn create_folder(base: &std::path::Path, name: &str) -> std::io::Result<()> 
 }
 
 /// Rename a folder. Returns error if target already exists.
-pub fn rename_folder(base: &std::path::Path, old_name: &str, new_name: &str) -> std::io::Result<()> {
+pub fn rename_folder(
+    base: &std::path::Path,
+    old_name: &str,
+    new_name: &str,
+) -> std::io::Result<()> {
     validate_folder_name(old_name)?;
     validate_folder_name(new_name)?;
     let old_dir = notes_dir_with_base(base, old_name);
@@ -325,7 +315,11 @@ const ALLOWED_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp"]
 
 /// Validate that a relative asset path (e.g. "assets/foo.png") is safe.
 fn validate_asset_path(relative_path: &str) -> std::io::Result<()> {
-    if relative_path.starts_with('/') || relative_path.contains("..") || relative_path.contains('\\') || relative_path.is_empty() {
+    if relative_path.starts_with('/')
+        || relative_path.contains("..")
+        || relative_path.contains('\\')
+        || relative_path.is_empty()
+    {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("invalid asset path: {}", relative_path),
@@ -382,9 +376,8 @@ fn notes_root(base: &Path) -> PathBuf {
 /// Open or initialize the notes git repo at `{base}/notes/`.
 fn open_or_init_repo(base: &Path) -> Result<Repository, git2::Error> {
     let root = notes_root(base);
-    fs::create_dir_all(&root).map_err(|e| {
-        git2::Error::from_str(&format!("failed to create notes dir: {}", e))
-    })?;
+    fs::create_dir_all(&root)
+        .map_err(|e| git2::Error::from_str(&format!("failed to create notes dir: {}", e)))?;
     match Repository::open(&root) {
         Ok(repo) => Ok(repo),
         Err(_) => {
@@ -489,7 +482,10 @@ mod tests {
         create_note(tmp.path(), "proj", "dup").unwrap();
         let result = create_note(tmp.path(), "proj", "dup");
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
     }
 
     #[test]
@@ -529,7 +525,10 @@ mod tests {
         create_note(tmp.path(), "proj", "b").unwrap();
         let result = rename_note(tmp.path(), "proj", "a.md", "b");
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
     }
 
     #[test]
@@ -569,7 +568,11 @@ mod tests {
         write_note(base, "proj", "original.md", "hello world").unwrap();
 
         let copy = duplicate_note(base, "proj", "original.md").unwrap();
-        assert!(copy.starts_with("original-"), "expected 'original-<uuid>.md', got '{}'", copy);
+        assert!(
+            copy.starts_with("original-"),
+            "expected 'original-<uuid>.md', got '{}'",
+            copy
+        );
         assert!(copy.ends_with(".md"));
         assert_ne!(copy, "original.md");
 
@@ -589,7 +592,11 @@ mod tests {
 
         // Second duplicate of the copy: should still be blog-<uuid2>, not blog-<uuid1>-<uuid2>
         let copy2 = duplicate_note(base, "proj", &copy1).unwrap();
-        assert!(copy2.starts_with("blog-"), "expected 'blog-<uuid>.md', got '{}'", copy2);
+        assert!(
+            copy2.starts_with("blog-"),
+            "expected 'blog-<uuid>.md', got '{}'",
+            copy2
+        );
         // Should only have one UUID segment (blog + dash + 8 hex + .md = stem of length 13)
         let stem2 = copy2.strip_suffix(".md").unwrap();
         assert_eq!(stem2.len(), 13, "expected 'blog-<8hex>', got '{}'", stem2);
@@ -643,15 +650,24 @@ mod tests {
 
         let read_result = read_note(tmp.path(), "proj", malicious);
         assert!(read_result.is_err());
-        assert_eq!(read_result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            read_result.unwrap_err().kind(),
+            std::io::ErrorKind::InvalidInput
+        );
 
         let write_result = write_note(tmp.path(), "proj", malicious, "pwned");
         assert!(write_result.is_err());
-        assert_eq!(write_result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            write_result.unwrap_err().kind(),
+            std::io::ErrorKind::InvalidInput
+        );
 
         let delete_result = delete_note(tmp.path(), "proj", malicious);
         assert!(delete_result.is_err());
-        assert_eq!(delete_result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            delete_result.unwrap_err().kind(),
+            std::io::ErrorKind::InvalidInput
+        );
     }
 
     #[test]
@@ -691,7 +707,10 @@ mod tests {
         create_folder(tmp.path(), "dup").unwrap();
         let result = create_folder(tmp.path(), "dup");
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
     }
 
     #[test]
@@ -712,7 +731,10 @@ mod tests {
         create_folder(tmp.path(), "b").unwrap();
         let result = rename_folder(tmp.path(), "a", "b");
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::AlreadyExists
+        );
     }
 
     #[test]

--- a/src-tauri/src/session_args.rs
+++ b/src-tauri/src/session_args.rs
@@ -139,7 +139,12 @@ mod tests {
 
     #[test]
     fn build_issue_prompt_without_background() {
-        let prompt = build_issue_prompt(42, "Fix the bug", "https://github.com/foo/bar/issues/42", false);
+        let prompt = build_issue_prompt(
+            42,
+            "Fix the bug",
+            "https://github.com/foo/bar/issues/42",
+            false,
+        );
         assert!(prompt.contains("GitHub issue #42: Fix the bug"));
         assert!(prompt.contains("closes #42"));
         assert!(!prompt.contains("autonomous background worker"));
@@ -147,7 +152,12 @@ mod tests {
 
     #[test]
     fn build_issue_prompt_with_background() {
-        let prompt = build_issue_prompt(42, "Fix the bug", "https://github.com/foo/bar/issues/42", true);
+        let prompt = build_issue_prompt(
+            42,
+            "Fix the bug",
+            "https://github.com/foo/bar/issues/42",
+            true,
+        );
         assert!(prompt.contains("GitHub issue #42: Fix the bug"));
         assert!(prompt.contains("closes #42"));
         assert!(prompt.contains("autonomous background worker"));
@@ -166,7 +176,12 @@ mod tests {
 
     #[test]
     fn build_issue_prompt_finalizes_issue_before_syncing_local_master() {
-        let prompt = build_issue_prompt(42, "Fix the bug", "https://github.com/foo/bar/issues/42", true);
+        let prompt = build_issue_prompt(
+            42,
+            "Fix the bug",
+            "https://github.com/foo/bar/issues/42",
+            true,
+        );
         let finalize_index = prompt.find("Finalize issue state").unwrap();
         let sync_index = prompt.find("Sync local master").unwrap();
 

--- a/src-tauri/src/status_socket.rs
+++ b/src-tauri/src/status_socket.rs
@@ -18,8 +18,7 @@ pub fn staged_socket_path() -> &'static str {
 
 /// Return the socket path, checking the CONTROLLER_SOCKET env var first.
 pub fn socket_path() -> String {
-    std::env::var("CONTROLLER_SOCKET")
-        .unwrap_or_else(|_| DEFAULT_SOCKET_PATH.to_string())
+    std::env::var("CONTROLLER_SOCKET").unwrap_or_else(|_| DEFAULT_SOCKET_PATH.to_string())
 }
 
 /// Parse a "working:uuid", "idle:uuid", or "cleanup:uuid" message.
@@ -57,7 +56,10 @@ fn parse_socket_message(msg: &str) -> Result<SocketMessage, String> {
 }
 
 fn write_socket_response(stream: &mut UnixStream, response: &crate::secure_env::SecureEnvResponse) {
-    let line = format!("{}\n", crate::secure_env::format_secure_env_response(response));
+    let line = format!(
+        "{}\n",
+        crate::secure_env::format_secure_env_response(response)
+    );
     if let Err(err) = stream.write_all(line.as_bytes()) {
         eprintln!("Failed to write socket response: {}", err);
     }
@@ -282,11 +284,9 @@ fn handle_cleanup(app_handle: &AppHandle, session_id: Uuid) {
                     if let (Some(wt_path), Some(branch)) =
                         (&session.worktree_path, &session.worktree_branch)
                     {
-                        if let Err(e) = WorktreeManager::remove_worktree(
-                            wt_path,
-                            &project.repo_path,
-                            branch,
-                        ) {
+                        if let Err(e) =
+                            WorktreeManager::remove_worktree(wt_path, &project.repo_path, branch)
+                        {
                             eprintln!("cleanup: failed to remove worktree: {}", e);
                         }
                     }
@@ -418,8 +418,11 @@ mod tests {
     }
 
     fn make_app_state(tmp: &TempDir) -> AppState {
-        AppState::from_storage(Storage::new(tmp.path().to_path_buf()), crate::emitter::NoopEmitter::new())
-            .unwrap()
+        AppState::from_storage(
+            Storage::new(tmp.path().to_path_buf()),
+            crate::emitter::NoopEmitter::new(),
+        )
+        .unwrap()
     }
 
     fn save_project(state: &AppState, name: &str, repo_path: PathBuf) {
@@ -436,7 +439,12 @@ mod tests {
             staged_session: None,
         };
 
-        state.storage.lock().unwrap().save_project(&project).unwrap();
+        state
+            .storage
+            .lock()
+            .unwrap()
+            .save_project(&project)
+            .unwrap();
     }
 
     #[test]
@@ -470,7 +478,13 @@ mod tests {
         assert!(hooks.get("Notification").is_some());
 
         // Verify new hooks format: each event entry must have a nested "hooks" array
-        for event_name in &["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "Notification"] {
+        for event_name in &[
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolUse",
+            "Stop",
+            "Notification",
+        ] {
             let entries = hooks.get(*event_name).unwrap().as_array().unwrap();
             for entry in entries {
                 assert!(
@@ -578,8 +592,8 @@ mod tests {
 
     #[test]
     fn parses_secure_env_message() {
-        let message = parse_socket_message("secure-env:set|demo-project|OPENAI_API_KEY|req-123")
-            .unwrap();
+        let message =
+            parse_socket_message("secure-env:set|demo-project|OPENAI_API_KEY|req-123").unwrap();
 
         match message {
             SocketMessage::SecureEnv(request) => {
@@ -600,13 +614,17 @@ mod tests {
         save_project(&state, "demo-project", repo_path);
         let emitter = RecordingEmitter::new();
         let (tx, _rx) = std::sync::mpsc::sync_channel(1);
-        let request = crate::secure_env::parse_secure_env_request(
-            "set|demo-project|OPENAI_API_KEY|req-123",
+        let request =
+            crate::secure_env::parse_secure_env_request("set|demo-project|OPENAI_API_KEY|req-123")
+                .unwrap();
+
+        dispatch_secure_env_request(
+            &state,
+            &(emitter.clone() as Arc<dyn EventEmitter>),
+            request,
+            tx,
         )
         .unwrap();
-
-        dispatch_secure_env_request(&state, &(emitter.clone() as Arc<dyn EventEmitter>), request, tx)
-            .unwrap();
 
         let events = emitter.events.lock().unwrap();
         assert_eq!(events.len(), 1);
@@ -665,18 +683,13 @@ mod tests {
         save_project(&state, "demo-project", repo_path);
         let emitter = FailingEmitter::new();
         let (tx, _rx) = std::sync::mpsc::sync_channel(1);
-        let request = crate::secure_env::parse_secure_env_request(
-            "set|demo-project|OPENAI_API_KEY|req-123",
-        )
-        .unwrap();
+        let request =
+            crate::secure_env::parse_secure_env_request("set|demo-project|OPENAI_API_KEY|req-123")
+                .unwrap();
 
-        let response = dispatch_secure_env_request(
-            &state,
-            &(emitter as Arc<dyn EventEmitter>),
-            request,
-            tx,
-        )
-        .unwrap_err();
+        let response =
+            dispatch_secure_env_request(&state, &(emitter as Arc<dyn EventEmitter>), request, tx)
+                .unwrap_err();
 
         assert_eq!(
             response,

--- a/src-tauri/src/token_usage.rs
+++ b/src-tauri/src/token_usage.rs
@@ -56,8 +56,9 @@ fn claude_project_dir(working_dir: &str) -> Result<PathBuf, String> {
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         if (name.contains(&encoded) || encoded.contains(&name))
-            && entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                best = Some(entry.path());
+            && entry.file_type().map(|t| t.is_dir()).unwrap_or(false)
+        {
+            best = Some(entry.path());
         }
     }
 
@@ -109,8 +110,14 @@ fn parse_claude_jsonl(path: &Path) -> Result<Vec<TokenDataPoint>, String> {
             None => continue,
         };
 
-        let input = usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let output = usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let input = usage
+            .get("input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let output = usage
+            .get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         let cache_read = usage
             .get("cache_read_input_tokens")
             .and_then(|v| v.as_u64())
@@ -262,8 +269,14 @@ fn parse_codex_jsonl(path: &Path) -> Result<Vec<TokenDataPoint>, String> {
             None => continue,
         };
 
-        let total_input = usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let total_output = usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let total_input = usage
+            .get("input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let total_output = usage
+            .get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         let cached = usage
             .get("cached_input_tokens")
             .and_then(|v| v.as_u64())
@@ -316,7 +329,11 @@ mod tests {
         let jsonl_path = dir.path().join("test.jsonl");
         let mut f = fs::File::create(&jsonl_path).unwrap();
         // Write a non-assistant entry (should be ignored)
-        writeln!(f, r#"{{"type":"progress","timestamp":"2026-01-01T00:00:00Z"}}"#).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"progress","timestamp":"2026-01-01T00:00:00Z"}}"#
+        )
+        .unwrap();
         // Write an assistant entry with usage
         writeln!(
             f,
@@ -409,9 +426,6 @@ mod tests {
             &jsonl_path,
             "/Users/noel/project"
         ));
-        assert!(!codex_session_matches_cwd(
-            &jsonl_path,
-            "/Users/noel/other"
-        ));
+        assert!(!codex_session_matches_cwd(&jsonl_path, "/Users/noel/other"));
     }
 }

--- a/src-tauri/src/voice/audio_input.rs
+++ b/src-tauri/src/voice/audio_input.rs
@@ -72,8 +72,7 @@ impl AudioInput {
                             resample_buf.push(s);
 
                             if resample_buf.len() >= BLOCK_SIZE {
-                                let chunk: Vec<i16> =
-                                    resample_buf.drain(..BLOCK_SIZE).collect();
+                                let chunk: Vec<i16> = resample_buf.drain(..BLOCK_SIZE).collect();
                                 let _ = sender.try_send(chunk);
                             }
                         }

--- a/src-tauri/src/voice/gain.rs
+++ b/src-tauri/src/voice/gain.rs
@@ -9,6 +9,12 @@ pub struct AutoGain {
     window_size: usize,
 }
 
+impl Default for AutoGain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AutoGain {
     pub fn new() -> Self {
         Self {

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -39,6 +39,17 @@ pub struct VoicePipeline {
     audio_thread: Option<std::thread::JoinHandle<()>>,
 }
 
+struct SpeechContext<'a> {
+    whisper: &'a stt::WhisperStt,
+    tts_engine: &'a mut tts::PiperTts,
+    audio_out: &'a audio_output::AudioOutput,
+    audio_in: &'a mut audio_input::AudioInput,
+    conversation: &'a mut llm::Conversation,
+    vad_engine: &'a mut vad::Vad,
+    emitter: &'a Arc<dyn EventEmitter>,
+    stop: &'a Arc<AtomicBool>,
+}
+
 impl VoicePipeline {
     /// Start the voice pipeline. Downloads models if needed, then begins listening.
     pub async fn start(emitter: Arc<dyn EventEmitter>) -> Result<Self, String> {
@@ -47,7 +58,13 @@ impl VoicePipeline {
         // Ensure models are downloaded
         let dl_emitter = emitter.clone();
         let model_paths = models::ensure_models(|filename, downloaded, total| {
-            let percent = total.map(|t| if t > 0 { ((downloaded * 100) / t).min(100) as u8 } else { 0 });
+            let percent = total.map(|t| {
+                if t > 0 {
+                    ((downloaded * 100) / t).min(100) as u8
+                } else {
+                    0
+                }
+            });
             let payload = serde_json::to_string(&VoiceStateEvent {
                 state: VoiceState::Downloading,
                 filename: Some(filename.to_string()),
@@ -160,12 +177,15 @@ fn run_pipeline(
         let normalized = auto_gain.apply(&chunk);
 
         chunk_count += 1;
-        if chunk_count % 15 == 0 {
+        if chunk_count.is_multiple_of(15) {
             let rms_i16 = (chunk.iter().map(|&s| (s as f32) * (s as f32)).sum::<f32>()
                 / chunk.len() as f32)
                 .sqrt();
             let prob = vad_engine.last_prob();
-            emit_debug(&emitter, &format!("mic rms={:.0} vad prob={:.3}", rms_i16, prob));
+            emit_debug(
+                &emitter,
+                &format!("mic rms={:.0} vad prob={:.3}", rms_i16, prob),
+            );
         }
 
         match vad_engine.process(&normalized)? {
@@ -179,19 +199,23 @@ fn run_pipeline(
                 if in_speech {
                     speech_buffer.extend_from_slice(&normalized);
                     in_speech = false;
-                    emit_debug(&emitter, &format!("speech_end ({:.1}s)", speech_buffer.len() as f32 / 16000.0));
-
-                    process_speech(
-                        &speech_buffer,
-                        &whisper,
-                        &mut tts_engine,
-                        &audio_out,
-                        &mut audio_in,
-                        &mut conversation,
-                        &mut vad_engine,
+                    emit_debug(
                         &emitter,
-                        &stop,
-                    )?;
+                        &format!("speech_end ({:.1}s)", speech_buffer.len() as f32 / 16000.0),
+                    );
+
+                    let mut speech_ctx = SpeechContext {
+                        whisper: &whisper,
+                        tts_engine: &mut tts_engine,
+                        audio_out: &audio_out,
+                        audio_in: &mut audio_in,
+                        conversation: &mut conversation,
+                        vad_engine: &mut vad_engine,
+                        emitter: &emitter,
+                        stop: &stop,
+                    };
+
+                    process_speech(&speech_buffer, &mut speech_ctx)?;
 
                     speech_buffer.clear();
                     if !stop.load(Ordering::Relaxed) {
@@ -211,17 +235,7 @@ fn run_pipeline(
     Ok(())
 }
 
-fn process_speech(
-    audio: &[f32],
-    whisper: &stt::WhisperStt,
-    tts_engine: &mut tts::PiperTts,
-    audio_out: &audio_output::AudioOutput,
-    audio_in: &mut audio_input::AudioInput,
-    conversation: &mut llm::Conversation,
-    vad_engine: &mut vad::Vad,
-    emitter: &Arc<dyn EventEmitter>,
-    stop: &Arc<AtomicBool>,
-) -> Result<(), String> {
+fn process_speech(audio: &[f32], ctx: &mut SpeechContext<'_>) -> Result<(), String> {
     if audio.len() < MIN_SPEECH_SAMPLES {
         return Ok(());
     }
@@ -232,61 +246,67 @@ fn process_speech(
     }
 
     // STT
-    emit_state(emitter, VoiceState::Thinking);
-    let text = whisper.transcribe(audio)?;
+    emit_state(ctx.emitter, VoiceState::Thinking);
+    let text = ctx.whisper.transcribe(audio)?;
     if text.is_empty() {
         return Ok(());
     }
 
     eprintln!("[voice] You: {text}");
-    conversation.add_user(&text);
-    emit_debug(emitter, &format!("stt: \"{}\"", text));
-    let _ = emitter.emit("voice-transcript", &serde_json::json!({"role": "user", "text": text}).to_string());
+    ctx.conversation.add_user(&text);
+    emit_debug(ctx.emitter, &format!("stt: \"{}\"", text));
+    let _ = ctx.emitter.emit(
+        "voice-transcript",
+        &serde_json::json!({"role": "user", "text": text}).to_string(),
+    );
 
     // LLM — need a tokio runtime since we're on a std thread
-    emit_debug(emitter, "llm: streaming...");
+    emit_debug(ctx.emitter, "llm: streaming...");
     let rt = tokio::runtime::Runtime::new()
         .map_err(|e| format!("Failed to create tokio runtime: {e}"))?;
 
     let response = rt.block_on(async {
         let mut full = String::new();
-        llm::stream_response(conversation, &mut |token| {
+        llm::stream_response(ctx.conversation, &mut |token| {
             full.push_str(token);
         })
         .await
         .map(|_| full)
     })?;
 
-    if response.is_empty() || stop.load(Ordering::Relaxed) {
+    if response.is_empty() || ctx.stop.load(Ordering::Relaxed) {
         return Ok(());
     }
 
     eprintln!("[voice] Assistant: {response}");
-    conversation.add_assistant(&response);
-    emit_debug(emitter, "llm: done");
-    let _ = emitter.emit("voice-transcript", &serde_json::json!({"role": "assistant", "text": response}).to_string());
+    ctx.conversation.add_assistant(&response);
+    emit_debug(ctx.emitter, "llm: done");
+    let _ = ctx.emitter.emit(
+        "voice-transcript",
+        &serde_json::json!({"role": "assistant", "text": response}).to_string(),
+    );
 
     // TTS
-    emit_state(emitter, VoiceState::Speaking);
-    emit_debug(emitter, "tts: synthesizing...");
-    audio_in.mute();
+    emit_state(ctx.emitter, VoiceState::Speaking);
+    emit_debug(ctx.emitter, "tts: synthesizing...");
+    ctx.audio_in.mute();
 
-    let tts_sample_rate = tts_engine.sample_rate();
+    let tts_sample_rate = ctx.tts_engine.sample_rate();
     let mut all_samples: Vec<i16> = Vec::new();
-    for chunk_result in tts_engine.synthesize_streaming(&response) {
+    for chunk_result in ctx.tts_engine.synthesize_streaming(&response) {
         match chunk_result {
             Ok(samples) => all_samples.extend_from_slice(&samples),
             Err(e) => eprintln!("[voice] TTS error: {e}"),
         }
     }
-    if !all_samples.is_empty() && !stop.load(Ordering::Relaxed) {
-        audio_out.play_i16(&all_samples, tts_sample_rate)?;
+    if !all_samples.is_empty() && !ctx.stop.load(Ordering::Relaxed) {
+        ctx.audio_out.play_i16(&all_samples, tts_sample_rate)?;
     }
 
-    audio_in.unmute();
-    emit_debug(emitter, "tts: done");
+    ctx.audio_in.unmute();
+    emit_debug(ctx.emitter, "tts: done");
     std::thread::sleep(std::time::Duration::from_millis(300));
-    vad_engine.reset();
+    ctx.vad_engine.reset();
 
     Ok(())
 }

--- a/src-tauri/src/voice/models.rs
+++ b/src-tauri/src/voice/models.rs
@@ -15,6 +15,12 @@ pub struct ModelPaths {
     pub piper_config: PathBuf,
 }
 
+impl Default for ModelPaths {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ModelPaths {
     pub fn new() -> Self {
         let base = models_dir();
@@ -102,15 +108,13 @@ pub async fn ensure_models(
         let mut body = Vec::new();
 
         while let Some(chunk) = stream.next().await {
-            let chunk =
-                chunk.map_err(|e| format!("Failed to read {filename}: {e}"))?;
+            let chunk = chunk.map_err(|e| format!("Failed to read {filename}: {e}"))?;
             downloaded += chunk.len() as u64;
             body.extend_from_slice(&chunk);
             on_progress(&filename, downloaded, total);
         }
 
-        std::fs::write(dest, &body)
-            .map_err(|e| format!("Failed to write {filename}: {e}"))?;
+        std::fs::write(dest, &body).map_err(|e| format!("Failed to write {filename}: {e}"))?;
     }
 
     Ok(paths)

--- a/src-tauri/src/voice/tts.rs
+++ b/src-tauri/src/voice/tts.rs
@@ -68,9 +68,7 @@ impl PiperTts {
             .args(["--ipa", "-q", "-v", "en-us", text])
             .output()
             .map_err(|e| {
-                format!(
-                    "Failed to run espeak-ng (is it installed? brew install espeak-ng): {e}"
-                )
+                format!("Failed to run espeak-ng (is it installed? brew install espeak-ng): {e}")
             })?;
 
         if !output.status.success() {

--- a/src-tauri/src/voice/vad.rs
+++ b/src-tauri/src/voice/vad.rs
@@ -12,7 +12,7 @@ pub enum VadEvent {
 /// Context size prepended to each chunk (last N samples from previous chunk).
 /// Required by Silero VAD ONNX model — without this, probabilities stay near zero.
 const CONTEXT_SIZE: usize = 64;
-const STATE_SIZE: usize = 2 * 1 * 128;
+const STATE_SIZE: usize = 256;
 
 pub struct Vad {
     session: Session,
@@ -63,12 +63,10 @@ impl Vad {
 
         let full_len = input_with_context.len();
 
-        let input_tensor =
-            Tensor::from_array(([1usize, full_len], input_with_context))
-                .map_err(|e| format!("Failed to create input tensor: {e}"))?;
-        let state_tensor =
-            Tensor::from_array(([2usize, 1, 128], self.state.clone()))
-                .map_err(|e| format!("Failed to create state tensor: {e}"))?;
+        let input_tensor = Tensor::from_array(([1usize, full_len], input_with_context))
+            .map_err(|e| format!("Failed to create input tensor: {e}"))?;
+        let state_tensor = Tensor::from_array(([2usize, 1, 128], self.state.clone()))
+            .map_err(|e| format!("Failed to create state tensor: {e}"))?;
         let sr_tensor = Tensor::from_array(((), vec![16000i64]))
             .map_err(|e| format!("Failed to create sr tensor: {e}"))?;
 
@@ -96,7 +94,8 @@ impl Vad {
 
         // Update context: last CONTEXT_SIZE samples from this chunk
         if chunk_len >= CONTEXT_SIZE {
-            self.context.copy_from_slice(&chunk[chunk_len - CONTEXT_SIZE..]);
+            self.context
+                .copy_from_slice(&chunk[chunk_len - CONTEXT_SIZE..]);
         } else {
             let keep = CONTEXT_SIZE - chunk_len;
             self.context.copy_within(chunk_len.., 0);

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -22,7 +22,8 @@ impl WorktreeManager {
         branch_name: &str,
         worktree_dir: &Path,
     ) -> Result<PathBuf, String> {
-        let repo = Repository::open(repo_path).map_err(|e| format!("failed to open repo: {}", e))?;
+        let repo =
+            Repository::open(repo_path).map_err(|e| format!("failed to open repo: {}", e))?;
 
         // Check if the repo has any commits (HEAD exists)
         let head = match repo.head() {
@@ -86,8 +87,8 @@ impl WorktreeManager {
 
     /// Detect the main branch name (main or master) for a repository.
     pub fn detect_main_branch(repo_path: &str) -> Result<String, String> {
-        let repo = Repository::open(repo_path)
-            .map_err(|e| format!("failed to open repo: {}", e))?;
+        let repo =
+            Repository::open(repo_path).map_err(|e| format!("failed to open repo: {}", e))?;
 
         for name in &["main", "master"] {
             if repo.find_branch(name, git2::BranchType::Local).is_ok() {
@@ -96,7 +97,9 @@ impl WorktreeManager {
         }
 
         // Fall back to whatever HEAD points to
-        let head = repo.head().map_err(|e| format!("failed to get HEAD: {}", e))?;
+        let head = repo
+            .head()
+            .map_err(|e| format!("failed to get HEAD: {}", e))?;
         if let Some(shorthand) = head.shorthand() {
             return Ok(shorthand.to_string());
         }
@@ -195,14 +198,18 @@ impl WorktreeManager {
                     .map_err(|e| format!("failed to get existing PR: {}", e))?;
 
                 if view_output.status.success() {
-                    let url = String::from_utf8_lossy(&view_output.stdout).trim().to_string();
+                    let url = String::from_utf8_lossy(&view_output.stdout)
+                        .trim()
+                        .to_string();
                     return Ok(MergeResult::PrCreated(url));
                 }
             }
             return Err(format!("PR creation failed: {}", stderr.trim()));
         }
 
-        let pr_url = String::from_utf8_lossy(&pr_output.stdout).trim().to_string();
+        let pr_url = String::from_utf8_lossy(&pr_output.stdout)
+            .trim()
+            .to_string();
         Ok(MergeResult::PrCreated(pr_url))
     }
 
@@ -224,9 +231,13 @@ impl WorktreeManager {
     }
 
     /// Check if `branch` needs rebasing onto `main_branch` (behind or diverged).
-    pub fn is_branch_behind(repo_path: &str, branch: &str, main_branch: &str) -> Result<bool, String> {
-        let repo = Repository::open(repo_path)
-            .map_err(|e| format!("failed to open repo: {}", e))?;
+    pub fn is_branch_behind(
+        repo_path: &str,
+        branch: &str,
+        main_branch: &str,
+    ) -> Result<bool, String> {
+        let repo =
+            Repository::open(repo_path).map_err(|e| format!("failed to open repo: {}", e))?;
 
         let branch_commit = repo
             .find_branch(branch, git2::BranchType::Local)
@@ -312,8 +323,8 @@ impl WorktreeManager {
         }
 
         // Prune the worktree reference
-        let repo = Repository::open(repo_path)
-            .map_err(|e| format!("failed to open repo: {}", e))?;
+        let repo =
+            Repository::open(repo_path).map_err(|e| format!("failed to open repo: {}", e))?;
 
         if let Ok(wt) = repo.find_worktree(branch_name) {
             let mut prune_opts = git2::WorktreePruneOptions::new();
@@ -347,9 +358,9 @@ mod tests {
         let mut config = repo.config().unwrap();
         config.set_str("user.name", "Test").unwrap();
         config.set_str("user.email", "test@example.com").unwrap();
-        let sig = repo.signature().unwrap_or_else(|_| {
-            git2::Signature::now("Test", "test@example.com").unwrap()
-        });
+        let sig = repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("Test", "test@example.com").unwrap());
 
         // Add .gitignore that excludes .env (matches real projects)
         std::fs::write(tmp.path().join(".gitignore"), ".env\n").unwrap();
@@ -384,12 +395,8 @@ mod tests {
         );
 
         // Remove the worktree
-        WorktreeManager::remove_worktree(
-            wt_path.to_str().unwrap(),
-            &repo_path,
-            "feature-test",
-        )
-        .expect("remove worktree");
+        WorktreeManager::remove_worktree(wt_path.to_str().unwrap(), &repo_path, "feature-test")
+            .expect("remove worktree");
 
         // Verify the directory is gone
         assert!(!wt_path.exists(), "worktree directory should be removed");
@@ -431,7 +438,11 @@ mod tests {
         let (_tmp, repo_path) = setup_test_repo();
         // sync_main on a repo with no remote should succeed (no-op)
         let result = WorktreeManager::sync_main(&repo_path);
-        assert!(result.is_ok(), "sync_main should succeed on local-only repo: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "sync_main should succeed on local-only repo: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -591,13 +602,20 @@ mod tests {
 
         // Add a commit to main so the worktree branch is behind
         let repo = Repository::open(&repo_path).unwrap();
-        let sig = repo.signature().unwrap_or_else(|_| {
-            git2::Signature::now("Test", "test@example.com").unwrap()
-        });
+        let sig = repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("Test", "test@example.com").unwrap());
         let head = repo.head().unwrap().peel_to_commit().unwrap();
         let tree = head.tree().unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "new commit on main", &tree, &[&head])
-            .unwrap();
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            "new commit on main",
+            &tree,
+            &[&head],
+        )
+        .unwrap();
 
         let main = WorktreeManager::detect_main_branch(&repo_path).unwrap();
         assert!(WorktreeManager::is_branch_behind(&repo_path, "behind-test2", &main).unwrap());
@@ -614,9 +632,9 @@ mod tests {
 
         // Add a commit to main
         let repo = Repository::open(&repo_path).unwrap();
-        let sig = repo.signature().unwrap_or_else(|_| {
-            git2::Signature::now("Test", "test@example.com").unwrap()
-        });
+        let sig = repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("Test", "test@example.com").unwrap());
         let head = repo.head().unwrap().peel_to_commit().unwrap();
         let mut index = repo.index().unwrap();
         std::fs::write(Path::new(&repo_path).join("main-file.txt"), "from main").unwrap();
@@ -624,13 +642,14 @@ mod tests {
         index.write().unwrap();
         let tree_id = index.write_tree().unwrap();
         let tree = repo.find_tree(tree_id).unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "main commit", &tree, &[&head]).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "main commit", &tree, &[&head])
+            .unwrap();
 
         // Add a non-conflicting commit to worktree
         let wt_repo = Repository::open(&wt_path).unwrap();
-        let wt_sig = wt_repo.signature().unwrap_or_else(|_| {
-            git2::Signature::now("Test", "test@example.com").unwrap()
-        });
+        let wt_sig = wt_repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("Test", "test@example.com").unwrap());
         let wt_head = wt_repo.head().unwrap().peel_to_commit().unwrap();
         std::fs::write(wt_path.join("wt-file.txt"), "from worktree").unwrap();
         let mut wt_index = wt_repo.index().unwrap();
@@ -638,7 +657,16 @@ mod tests {
         wt_index.write().unwrap();
         let wt_tree_id = wt_index.write_tree().unwrap();
         let wt_tree = wt_repo.find_tree(wt_tree_id).unwrap();
-        wt_repo.commit(Some("HEAD"), &wt_sig, &wt_sig, "wt commit", &wt_tree, &[&wt_head]).unwrap();
+        wt_repo
+            .commit(
+                Some("HEAD"),
+                &wt_sig,
+                &wt_sig,
+                "wt commit",
+                &wt_tree,
+                &[&wt_head],
+            )
+            .unwrap();
 
         let main = WorktreeManager::detect_main_branch(&repo_path).unwrap();
         let result = WorktreeManager::rebase_onto(wt_path.to_str().unwrap(), &main);
@@ -649,5 +677,4 @@ mod tests {
         assert!(wt_path.join("main-file.txt").exists());
         assert!(wt_path.join("wt-file.txt").exists());
     }
-
 }

--- a/src-tauri/tests/integration.rs
+++ b/src-tauri/tests/integration.rs
@@ -91,11 +91,12 @@ fn test_agents_md_lifecycle() {
 
     // Write agents.md in the repo root — this should take priority
     let repo_content = "# Repo-Level Agents\n\nHigher priority content.\n";
-    fs::write(repo_dir.path().join("agents.md"), repo_content)
-        .expect("write repo agents.md");
+    fs::write(repo_dir.path().join("agents.md"), repo_content).expect("write repo agents.md");
 
     // Verify repo-root file takes priority
-    let priority_read = storage.get_agents_md(&project).expect("read priority agents.md");
+    let priority_read = storage
+        .get_agents_md(&project)
+        .expect("read priority agents.md");
     assert_eq!(priority_read, repo_content);
 }
 
@@ -158,7 +159,9 @@ fn test_sessions_persist_across_restarts() {
     storage.save_project(&project).expect("save project");
 
     // Simulate restart: reload from disk
-    let loaded = storage.load_project(project_id).expect("load after restart");
+    let loaded = storage
+        .load_project(project_id)
+        .expect("load after restart");
     assert_eq!(loaded.sessions.len(), 3, "all sessions should persist");
     assert_eq!(loaded.name, "persist-test");
 }
@@ -184,7 +187,9 @@ fn test_no_duplicate_project_names() {
         sessions: vec![],
         staged_session: None,
     };
-    storage.save_project(&project_a).expect("save first project");
+    storage
+        .save_project(&project_a)
+        .expect("save first project");
 
     // Attempting to save another project with the same name should be caught
     // by the command layer. At the storage layer, we verify the invariant
@@ -201,7 +206,9 @@ fn test_no_duplicate_project_names() {
         sessions: vec![],
         staged_session: None,
     };
-    storage.save_project(&project_b).expect("save second project");
+    storage
+        .save_project(&project_b)
+        .expect("save second project");
 
     let projects = storage.list_projects().expect("list projects");
     let count = projects.iter().filter(|p| p.name == "my-project").count();
@@ -231,7 +238,9 @@ fn test_archived_project_name_still_blocks_duplicate_name_checks() {
         sessions: vec![],
         staged_session: None,
     };
-    storage.save_project(&project).expect("save archived project");
+    storage
+        .save_project(&project)
+        .expect("save archived project");
 
     let existing = storage.list_projects().expect("list projects");
     let has_duplicate = existing.iter().any(|p| p.name == "reusable-name");
@@ -252,9 +261,9 @@ fn test_worktrees_persist_across_restarts() {
     let repo_dir = TempDir::new().unwrap();
     let repo_path = repo_dir.path().to_str().unwrap().to_string();
     let repo = git2::Repository::init(&repo_path).expect("init repo");
-    let sig = repo.signature().unwrap_or_else(|_| {
-        git2::Signature::now("Test", "test@example.com").unwrap()
-    });
+    let sig = repo
+        .signature()
+        .unwrap_or_else(|_| git2::Signature::now("Test", "test@example.com").unwrap());
     let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
     let tree = repo.find_tree(tree_id).unwrap();
     repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
@@ -294,9 +303,14 @@ fn test_worktrees_persist_across_restarts() {
     storage.save_project(&project).expect("save project");
 
     // Simulate restart: reload from disk
-    let loaded = storage.load_project(project_id).expect("load after restart");
+    let loaded = storage
+        .load_project(project_id)
+        .expect("load after restart");
     assert_eq!(loaded.sessions.len(), 1, "session should persist");
-    assert!(wt_path.exists(), "worktree should still exist on disk after restart");
+    assert!(
+        wt_path.exists(),
+        "worktree should still exist on disk after restart"
+    );
 }
 
 /// Worktree directories should use project name, not UUID.
@@ -343,13 +357,19 @@ fn test_migrate_worktree_paths_renames_uuid_dir() {
     // UUID dir should be gone, name dir should exist
     assert!(!uuid_wt_dir.exists(), "UUID dir should be removed");
     let name_wt_dir = tmp.path().join("worktrees").join("my-cool-project");
-    assert!(name_wt_dir.join("session-1").exists(), "name dir should exist");
+    assert!(
+        name_wt_dir.join("session-1").exists(),
+        "name dir should exist"
+    );
 
     // Stored paths should be updated
     let loaded = storage.load_project(project_id).expect("load");
     let session = &loaded.sessions[0];
     let expected_path = name_wt_dir.join("session-1").to_str().unwrap().to_string();
-    assert_eq!(session.worktree_path.as_deref(), Some(expected_path.as_str()));
+    assert_eq!(
+        session.worktree_path.as_deref(),
+        Some(expected_path.as_str())
+    );
 }
 
 #[test]
@@ -388,7 +408,9 @@ fn test_migrate_worktree_paths_noop_when_no_uuid_dir() {
     storage.save_project(&project).expect("save project");
 
     // Should not error or change anything
-    storage.migrate_worktree_paths(&project).expect("migrate noop");
+    storage
+        .migrate_worktree_paths(&project)
+        .expect("migrate noop");
 
     assert!(session_wt.exists(), "name dir should still exist");
     let loaded = storage.load_project(project_id).expect("load");
@@ -443,8 +465,12 @@ fn test_migrate_worktree_paths_repairs_stale_paths_after_partial_migration() {
     };
     storage.save_project(&project).expect("save project");
 
-    storage.migrate_worktree_paths(&project).expect("first migrate");
-    let repaired = storage.load_project(project_id).expect("load repaired project");
+    storage
+        .migrate_worktree_paths(&project)
+        .expect("first migrate");
+    let repaired = storage
+        .load_project(project_id)
+        .expect("load repaired project");
     assert_eq!(
         repaired.sessions[0].worktree_path.as_deref(),
         Some(name_session.to_str().unwrap()),
@@ -454,7 +480,9 @@ fn test_migrate_worktree_paths_repairs_stale_paths_after_partial_migration() {
     storage
         .migrate_worktree_paths(&repaired)
         .expect("second migrate should stay idempotent");
-    let rerun = storage.load_project(project_id).expect("load after second migrate");
+    let rerun = storage
+        .load_project(project_id)
+        .expect("load after second migrate");
     assert_eq!(
         rerun.sessions[0].worktree_path.as_deref(),
         Some(name_session.to_str().unwrap()),
@@ -535,9 +563,9 @@ fn test_create_session_uses_project_name_in_path() {
     let repo_dir = TempDir::new().unwrap();
     let repo_path = repo_dir.path().to_str().unwrap().to_string();
     let repo = git2::Repository::init(&repo_path).expect("init repo");
-    let sig = repo.signature().unwrap_or_else(|_| {
-        git2::Signature::now("Test", "test@example.com").unwrap()
-    });
+    let sig = repo
+        .signature()
+        .unwrap_or_else(|_| git2::Signature::now("Test", "test@example.com").unwrap());
     let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
     let tree = repo.find_tree(tree_id).unwrap();
     repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
@@ -558,7 +586,8 @@ fn test_create_session_uses_project_name_in_path() {
     storage.save_project(&project).expect("save project");
 
     // Create worktree using name-based path (what create_session should do)
-    let worktree_dir = tmp.path()
+    let worktree_dir = tmp
+        .path()
         .join("worktrees")
         .join(&project.name)
         .join("session-1");
@@ -601,8 +630,19 @@ fn test_scaffold_project_creates_template_files() {
     assert!(repo_path.join("docs/plans/.gitkeep").exists());
 
     // Verify CLAUDE.md is a symlink to agents.md
-    assert!(repo_path.join("CLAUDE.md").symlink_metadata().unwrap().file_type().is_symlink());
-    assert_eq!(fs::read_link(repo_path.join("CLAUDE.md")).unwrap().to_str().unwrap(), "agents.md");
+    assert!(repo_path
+        .join("CLAUDE.md")
+        .symlink_metadata()
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(
+        fs::read_link(repo_path.join("CLAUDE.md"))
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "agents.md"
+    );
 
     // Verify agents.md contains the project name
     let content = fs::read_to_string(repo_path.join("agents.md")).unwrap();
@@ -634,26 +674,42 @@ fn test_scaffold_initial_commit_contains_template_files() {
     let mut index = repo.index().unwrap();
     index.add_path(std::path::Path::new("agents.md")).unwrap();
     index.add_path(std::path::Path::new("CLAUDE.md")).unwrap();
-    index.add_path(std::path::Path::new("docs/plans/.gitkeep")).unwrap();
+    index
+        .add_path(std::path::Path::new("docs/plans/.gitkeep"))
+        .unwrap();
     index.write().unwrap();
     let tree_id = index.write_tree().unwrap();
     let tree = repo.find_tree(tree_id).unwrap();
-    repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[]).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+        .unwrap();
 
     // Verify the HEAD commit tree contains our files
     let head = repo.head().unwrap().peel_to_commit().unwrap();
     let commit_tree = head.tree().unwrap();
 
     // agents.md and CLAUDE.md should be at root
-    assert!(commit_tree.get_name("agents.md").is_some(), "agents.md missing from commit tree");
-    assert!(commit_tree.get_name("CLAUDE.md").is_some(), "CLAUDE.md missing from commit tree");
+    assert!(
+        commit_tree.get_name("agents.md").is_some(),
+        "agents.md missing from commit tree"
+    );
+    assert!(
+        commit_tree.get_name("CLAUDE.md").is_some(),
+        "CLAUDE.md missing from commit tree"
+    );
 
     // docs/plans/.gitkeep should be nested
-    let docs_entry = commit_tree.get_name("docs").expect("docs/ missing from commit tree");
+    let docs_entry = commit_tree
+        .get_name("docs")
+        .expect("docs/ missing from commit tree");
     let docs_tree = repo.find_tree(docs_entry.id()).unwrap();
-    let plans_entry = docs_tree.get_name("plans").expect("plans/ missing from docs tree");
+    let plans_entry = docs_tree
+        .get_name("plans")
+        .expect("plans/ missing from docs tree");
     let plans_tree = repo.find_tree(plans_entry.id()).unwrap();
-    assert!(plans_tree.get_name(".gitkeep").is_some(), ".gitkeep missing from plans tree");
+    assert!(
+        plans_tree.get_name(".gitkeep").is_some(),
+        ".gitkeep missing from plans tree"
+    );
 
     // Verify agents.md content in the commit
     let agents_entry = commit_tree.get_name("agents.md").unwrap();
@@ -673,8 +729,19 @@ fn test_ensure_claude_md_symlink_creates_when_missing() {
     the_controller_lib::commands::ensure_claude_md_symlink(dir).unwrap();
 
     assert!(dir.join("CLAUDE.md").exists());
-    assert!(dir.join("CLAUDE.md").symlink_metadata().unwrap().file_type().is_symlink());
-    assert_eq!(fs::read_link(dir.join("CLAUDE.md")).unwrap().to_str().unwrap(), "agents.md");
+    assert!(dir
+        .join("CLAUDE.md")
+        .symlink_metadata()
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(
+        fs::read_link(dir.join("CLAUDE.md"))
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "agents.md"
+    );
     // Content should match
     assert_eq!(fs::read_to_string(dir.join("CLAUDE.md")).unwrap(), "# Test");
 }
@@ -690,8 +757,16 @@ fn test_ensure_claude_md_symlink_skips_when_exists() {
     the_controller_lib::commands::ensure_claude_md_symlink(dir).unwrap();
 
     // Should not have been replaced
-    assert!(!dir.join("CLAUDE.md").symlink_metadata().unwrap().file_type().is_symlink());
-    assert_eq!(fs::read_to_string(dir.join("CLAUDE.md")).unwrap(), "# Custom");
+    assert!(!dir
+        .join("CLAUDE.md")
+        .symlink_metadata()
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(
+        fs::read_to_string(dir.join("CLAUDE.md")).unwrap(),
+        "# Custom"
+    );
 }
 
 /// ensure_claude_md_symlink does nothing when agents.md is missing.

--- a/src-tauri/tests/voice_e2e.rs
+++ b/src-tauri/tests/voice_e2e.rs
@@ -20,9 +20,7 @@ fn read_wav_f32(path: &Path) -> Vec<f32> {
                 .map(|s| s.unwrap() as f32 / max_val)
                 .collect()
         }
-        hound::SampleFormat::Float => {
-            reader.samples::<f32>().map(|s| s.unwrap()).collect()
-        }
+        hound::SampleFormat::Float => reader.samples::<f32>().map(|s| s.unwrap()).collect(),
     }
 }
 
@@ -43,14 +41,19 @@ fn test_voice_pipeline_e2e() {
     // 1. Read WAV
     let audio = read_wav_f32(&wav_path);
     assert!(audio.len() > 16000, "WAV too short (need >1s)");
-    println!("WAV: {} samples ({:.1}s)", audio.len(), audio.len() as f32 / 16000.0);
+    println!(
+        "WAV: {} samples ({:.1}s)",
+        audio.len(),
+        audio.len() as f32 / 16000.0
+    );
 
     // 2. Feed through VAD
     let mut vad = the_controller_lib::voice::vad::Vad::new(&paths.silero_vad, 800)
         .expect("Failed to load VAD");
 
     let silence = vec![0.0f32; 8000];
-    let padded: Vec<f32> = silence.iter()
+    let padded: Vec<f32> = silence
+        .iter()
         .chain(audio.iter())
         .chain(silence.iter())
         .copied()
@@ -61,7 +64,9 @@ fn test_voice_pipeline_e2e() {
     let mut in_speech = false;
 
     for chunk in padded.chunks(512) {
-        if chunk.len() < 512 { break; }
+        if chunk.len() < 512 {
+            break;
+        }
         match vad.process(chunk).expect("VAD failed") {
             Some(the_controller_lib::voice::vad::VadEvent::SpeechStart) => {
                 in_speech = true;
@@ -100,25 +105,32 @@ fn test_voice_pipeline_e2e() {
     let mut conv = the_controller_lib::voice::llm::Conversation::new(None);
     conv.add_user(&text);
 
-    let response = rt.block_on(async {
-        let mut full = String::new();
-        the_controller_lib::voice::llm::stream_response(&conv, &mut |token| {
-            full.push_str(token);
+    let response = rt
+        .block_on(async {
+            let mut full = String::new();
+            the_controller_lib::voice::llm::stream_response(&conv, &mut |token| {
+                full.push_str(token);
+            })
+            .await
+            .map(|_| full)
         })
-        .await
-        .map(|_| full)
-    })
-    .expect("LLM failed");
+        .expect("LLM failed");
 
     println!("LLM: \"{}\"", response);
     assert!(!response.is_empty(), "LLM produced empty response");
 
     // 5. TTS
-    let mut tts = the_controller_lib::voice::tts::PiperTts::new(&paths.piper_onnx, &paths.piper_config)
-        .expect("Failed to load TTS");
+    let mut tts =
+        the_controller_lib::voice::tts::PiperTts::new(&paths.piper_onnx, &paths.piper_config)
+            .expect("Failed to load TTS");
 
     let tts_audio = tts.synthesize(&response).expect("TTS failed");
-    println!("TTS: {} samples ({:.1}s at {}Hz)", tts_audio.len(), tts_audio.len() as f32 / tts.sample_rate() as f32, tts.sample_rate());
+    println!(
+        "TTS: {} samples ({:.1}s at {}Hz)",
+        tts_audio.len(),
+        tts_audio.len() as f32 / tts.sample_rate() as f32,
+        tts.sample_rate()
+    );
     assert!(!tts_audio.is_empty(), "TTS produced no audio");
 
     println!("\n=== E2E PASS: WAV → VAD → STT → LLM → TTS ===");

--- a/src/lib/ci-workflow.test.ts
+++ b/src/lib/ci-workflow.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("CI workflow", () => {
+  it("installs Linux audio headers needed by Rust voice dependencies", () => {
+    const workflow = readFileSync(resolve(process.cwd(), ".github/workflows/ci.yml"), "utf8");
+
+    expect(workflow).toMatch(/apt-get install -y[\s\S]*libasound2-dev/);
+  });
+});


### PR DESCRIPTION
## Summary
- restore the GitHub Actions Rust job after the voice-mode audio dependency changes
- add a workflow regression test for the Linux ALSA package requirement
- clean up the voice Rust code so clippy passes again

## Testing
- npx svelte-check --tsconfig ./tsconfig.json
- npx vitest run
- npm run build
- cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml