### PR TITLE
fix: show toast when creating session without a selected project

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -20,6 +20,7 @@
     type FocusTarget,
   } from "./stores";
   import { toggleKeystrokeVisualizer, pushKeystroke } from "./keystroke-visualizer";
+  import { showToast } from "./toast";
   import { buildKeyMap, type CommandId } from "./commands";
   import { focusForModeSwitch } from "./focus-helpers";
 
@@ -282,7 +283,14 @@
         return true;
       case "create-session": {
         const project = getFocusedProject();
-        if (!project) return true;
+        if (!project) {
+          if (projectList.length === 0) {
+            showToast("No projects yet — press 'f' to find a directory or 'n' to create a new project", "error");
+          } else {
+            showToast("Select a project first (j/k to navigate, or 'f' to find a directory)", "error");
+          }
+          return true;
+        }
         dispatchAction({ type: "create-session", projectId: project.id, kind: currentSessionProvider });
         return true;
       }


### PR DESCRIPTION
## Why

When the app starts and no project is selected, pressing `c` to create a session fails silently — nothing happens, no feedback. This is confusing for new users who don't know they need to select a project first.

## What

Show an error toast guiding the user when they try to create a session without a focused project:
- **No projects exist**: "No projects yet — press 'f' to find a directory or 'n' to create a new project"
- **Projects exist but none focused**: "Select a project first (j/k to navigate, or 'f' to find a directory)"

## Screenshots
<img width="1189" height="770" alt="Screenshot 2026-03-13 at 11 03 09 PM" src="https://github.com/user-attachments/assets/64bce28e-9580-4d99-8956-a90934c49a5b" />


## Test plan
- [ ] Start the app with no projects, press `c` — verify toast appears
- [ ] Start the app with projects but none focused, press `c` — verify toast appears
- [ ] Select a project, press `c` — verify session is created normally (no toast)