### PR TITLE
fix: guard against key repeat spam and add toast tests

### DIFF
--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -444,6 +444,9 @@
     // Ignore modifier-only keypresses
     if (["Shift", "Control", "Alt", "Meta"].includes(e.key)) return;
 
+    // Ignore held-down key repeats to prevent toast/action spam
+    if (e.repeat) return;
+
     // Cmd+S/Cmd+Shift+S: full window screenshot (shift = preview)
     // Cmd+D/Cmd+Shift+D: cropped screenshot (shift = preview)
     if (e.metaKey && (e.key === "s" || e.key === "d")) {

--- a/src/lib/HotkeyManager.test.ts
+++ b/src/lib/HotkeyManager.test.ts
@@ -3,7 +3,12 @@ import { render, cleanup } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { command } from '$lib/backend';
 import { projects, activeSessionId, hotkeyAction, focusTarget, sidebarVisible, expandedProjects, workspaceMode, workspaceModePickerVisible, selectedSessionProvider, activeNote, noteEntries, type Project, type SessionConfig } from './stores';
+import { showToast } from './toast';
 import HotkeyManager from './HotkeyManager.svelte';
+
+vi.mock('./toast', () => ({
+  showToast: vi.fn(),
+}));
 
 function makeSession(id: string, label: string, kind = 'claude'): SessionConfig {
   return {
@@ -512,6 +517,34 @@ describe('HotkeyManager', () => {
       expect(get(selectedSessionProvider)).toBe('codex');
       pressMetaKey('t');
       expect(get(selectedSessionProvider)).toBe('claude');
+    });
+
+    it('c with no projects shows "no projects" toast', () => {
+      projects.set([]);
+      focusTarget.set(null);
+      pressKey('c');
+      expect(showToast).toHaveBeenCalledWith(
+        "No projects yet — press 'f' to find a directory or 'n' to create a new project",
+        'error',
+      );
+      expect(get(hotkeyAction)).toBeNull();
+    });
+
+    it('c with projects but no focus shows "select a project" toast', () => {
+      projects.set([testProject]);
+      focusTarget.set(null);
+      pressKey('c');
+      expect(showToast).toHaveBeenCalledWith(
+        "Select a project first (j/k to navigate, or 'f' to find a directory)",
+        'error',
+      );
+      expect(get(hotkeyAction)).toBeNull();
+    });
+
+    it('held key repeat does not fire hotkeys', () => {
+      focusTarget.set({ type: 'project', projectId: 'proj-1' });
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', repeat: true, bubbles: true }));
+      expect(get(hotkeyAction)).toBeNull();
     });
 
     it('Cmd+T does not toggle while typing in an input', () => {


### PR DESCRIPTION
## Summary
- Address Copilot review comments from PR #452
- Add `e.repeat` guard in `onKeydown` to prevent toast spam when holding keys
- Add tests for toast messages when pressing `c` without a selected project (no projects vs. projects exist but none focused)

## Test plan
- [x] All 277 frontend tests pass
- [x] All Rust tests pass
- [x] New tests cover: no-projects toast, no-focus toast, held-key repeat guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)