### PR TITLE
fix: run generate_issue_body in project's repo dir

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1425,8 +1425,8 @@ pub async fn list_assigned_issues(
 }
 
 #[tauri::command]
-pub async fn generate_issue_body(title: String) -> Result<String, String> {
-    github::generate_issue_body(title).await
+pub async fn generate_issue_body(repo_path: String, title: String) -> Result<String, String> {
+    github::generate_issue_body(repo_path, title).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -142,7 +142,7 @@ pub(crate) async fn list_github_issues(
     Ok(issues)
 }
 
-pub(crate) async fn generate_issue_body(title: String) -> Result<String, String> {
+pub(crate) async fn generate_issue_body(repo_path: String, title: String) -> Result<String, String> {
     let prompt = format!(
         "Write a concise GitHub issue body for an issue titled: \"{}\". \
          Include a Summary section and a Details section. \
@@ -151,6 +151,7 @@ pub(crate) async fn generate_issue_body(title: String) -> Result<String, String>
     );
     let output = tokio::process::Command::new("claude")
         .args(["--print", &prompt])
+        .current_dir(&repo_path)
         .env_remove("CLAUDECODE")
         .output()
         .await

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -121,7 +121,7 @@
 
     try {
       showToast("Generating issue description...", "info");
-      const body = await command<string>("generate_issue_body", { title });
+      const body = await command<string>("generate_issue_body", { repoPath, title });
 
       showToast("Creating issue...", "info");
       const issue = await command<GithubIssue>("create_github_issue", {


### PR DESCRIPTION
## Summary

Issue creation via the `c` command in the IssuesModal was generating bodies that described the-controller's code instead of the actual target project. Root cause: `generate_issue_body` invoked `claude --print` without setting a working directory, so claude loaded whatever `CLAUDE.md` was in the Tauri app's cwd (typically the-controller).

The destination repo (`gh issue create --repo <nwo>`) was already correct — only the generated body text was wrong.

Fix: thread `repo_path` through to `generate_issue_body` and set `current_dir` on the claude subprocess.

## Test plan

- [ ] Focus a non-the-controller project, press `i` then `c`, create an issue — verify the body reflects that project's context, not the-controller's
- [x] `cargo test` passes (283/283)

🤖 Generated with [Claude Code](https://claude.com/claude-code)