### PR TITLE
feat: kanban board for tracking issues

### DIFF
--- a/docs/plans/2026-04-22-kanban-board-design.md
+++ b/docs/plans/2026-04-22-kanban-board-design.md
@@ -1,0 +1,140 @@
+# Kanban Board for Tracking Issues (Issue #537)
+
+## Definition
+
+A full-screen kanban board view for visualising and moving GitHub issues across lifecycle columns. Cards are dragged between columns to update status; status is persisted on GitHub as a `status:*` label.
+
+## Constraints
+
+- **Status source:** GitHub labels (`status:backlog`, `status:todo`, `status:in-progress`, `status:in-review`, `status:done`). No GitHub Projects v2 integration, no local status store.
+- **UI placement:** New full-screen view, reachable via a hotkey. Sits alongside `TerminalManager` / `AgentDashboard` as a third workspace-level view, gated by an extension to the `WorkspaceMode` enum.
+- **Backend reuse:** Use existing `list_github_issues`, `add_github_label`, `remove_github_label`. No new Tauri commands unless strictly needed.
+- **Per-user ordering:** Local only — the GitHub label model has no concept of within-column order, so ordering is stored in a local JSON file keyed by `(repo_path, column)`.
+- **Virtualization:** Columns with >50 cards are virtualized.
+- **No new heavy deps:** Prefer native HTML5 drag/drop over adding a library like `svelte-dnd-action`. If the native API is too limited for the acceptance criteria, reassess during implementation and surface the tradeoff.
+
+## Architecture
+
+### Workspace mode extension
+
+Add `"kanban"` to `WorkspaceMode` in `stores.ts`. `App.svelte` renders `<KanbanBoard />` when `workspaceMode === "kanban"`, mirroring the existing `AgentDashboard` branch.
+
+```ts
+export type WorkspaceMode = "development" | "agents" | "kanban";
+```
+
+Hotkey: add a new action `{ type: "toggle-kanban-view" }` and wire an ambient-mode binding in `HotkeyManager.svelte` (proposed: `k`). Update `HotkeyHelp.svelte` and `WorkspaceModePicker.svelte` to expose the new mode.
+
+### New components
+
+- `src/lib/KanbanBoard.svelte` — top-level view. Loads issues for the focused project via `list_github_issues`, groups them into columns, renders the filter bar and columns.
+- `src/lib/kanban/KanbanColumn.svelte` — single column. Handles drop targets, virtualization, empty state.
+- `src/lib/kanban/KanbanCard.svelte` — single issue card. Renders title, `#number`, labels, assignee avatar, and is draggable.
+- `src/lib/kanban/KanbanFilterBar.svelte` — filter chips for assignee / label / milestone.
+
+### Pure logic modules (unit-tested)
+
+- `src/lib/kanban/columns.ts` — column definitions, label ↔ column mapping, `columnForIssue(issue)` helper.
+- `src/lib/kanban/filter.ts` — `applyFilters(issues, filters)`.
+- `src/lib/kanban/ordering.ts` — `applyOrdering(issues, orderMap)`, move/reorder helpers. Per-user order stored in a local JSON file via two small Tauri commands `kanban_load_order` / `kanban_save_order` (file path: `<app-data>/kanban-order.json`).
+
+Keeping the logic pure means filter, ordering, and column-mapping behaviour can be validated with Vitest unit tests that don't need a DOM or a running backend.
+
+### Data model
+
+`GithubIssue` in `stores.ts` already carries `labels: { name: string }[]`. Extend it as needed for assignee/milestone surfacing:
+
+```ts
+export interface GithubIssue {
+  number: number;
+  title: string;
+  url: string;
+  body?: string | null;
+  labels: { name: string }[];
+  assignees?: { login: string; avatarUrl?: string }[]; // new
+  milestone?: { title: string } | null;                // new
+}
+```
+
+`list_github_issues` backend command (in `commands/github.rs`) already shells out to `gh issue list --json ...`. Add `assignees` and `milestone` to the `--json` fields and the Rust struct. Parsing-only change, no new command.
+
+### Column → label mapping
+
+| Column       | Label                 | Empty-state copy                    |
+| ------------ | --------------------- | ----------------------------------- |
+| Backlog      | `status:backlog`      | "No backlog items"                  |
+| To Do        | `status:todo`         | "Nothing queued"                    |
+| In Progress  | `status:in-progress`* | "Nothing in progress"               |
+| In Review    | `status:in-review`    | "Nothing awaiting review"           |
+| Done         | `status:done`         | "Nothing done yet"                  |
+
+*Only the `status:in-progress` label maps to "In Progress". The bare `in-progress` label used elsewhere in the app is unrelated and ignored by the board.
+
+Issues with no status label default to **Backlog** in the view but are not auto-labelled — labelling happens on first drag.
+
+### Drag-and-drop
+
+Native HTML5 DnD:
+
+1. `dragstart` on card writes `issue.number` to `dataTransfer`.
+2. `dragover` on column sets `dropEffect = "move"` and highlights the column.
+3. `drop` on column calls `moveIssue(issue, fromColumn, toColumn)`:
+   - Optimistically update UI state.
+   - Call `remove_github_label` for the old `status:*` label (if any).
+   - Call `add_github_label` for the new `status:*` label.
+   - On failure: revert UI state and surface a toast.
+
+Ordering within a column is captured from the drop position (index in the column's card list) and persisted to the local order file keyed by `${repoPath}:${column}`.
+
+### Filtering
+
+`KanbanFilterBar` owns three selections: assignees (set), labels (set, excluding `status:*`), milestone (single). `applyFilters` intersects them; empty selection means "any". Filters apply across all columns simultaneously.
+
+### Virtualization
+
+For columns where `cards.length > 50`, render via a lightweight windowed list. Implement with a scroll container + computed visible slice (no external lib). If this turns out to be fiddly during implementation, switch to `@tanstack/svelte-virtual` and flag the dep addition.
+
+### Persistence boundary
+
+| Concern                   | Where it lives                                    |
+| ------------------------- | ------------------------------------------------- |
+| Column (status)           | GitHub label on the issue                         |
+| Within-column order       | Local JSON: `<app-data>/kanban-order.json`        |
+| Filter selection          | Component-local state; not persisted              |
+
+## Validation
+
+Per CLAUDE.md: for each unit below, reverting the implementation must make the test fail, and re-applying it must make it pass.
+
+### Unit tests (Vitest)
+
+- `columns.test.ts` — `columnForIssue` mapping across all five columns and the unlabelled-defaults-to-Backlog case.
+- `filter.test.ts` — intersection of assignee/label/milestone selections, empty-selection semantics.
+- `ordering.test.ts` — move-within-column, move-across-columns, load/save round-trip.
+
+### Component tests (Vitest + Testing Library)
+
+- `KanbanCard.test.ts` — renders title, number, labels, assignee; click opens issue URL.
+- `KanbanColumn.test.ts` — empty state, >50 cards triggers virtualization branch.
+
+### E2E test (Playwright, from the issue's acceptance criteria)
+
+`e2e/kanban.spec.ts`:
+
+1. Seed: create three issues via `create_github_issue`, one labelled `status:backlog`.
+2. Open the kanban view (`k` hotkey).
+3. Drag the seeded issue Backlog → To Do → In Progress → In Review → Done.
+4. Reload the view.
+5. Assert the issue is still in Done (status persisted via GitHub label).
+
+E2E is skipped in CI without network / `gh` auth; runs locally via `pnpm test:e2e`.
+
+## Out of scope (per issue)
+
+WIP limits, swimlanes, multi-board views, real-time collaboration cursors — track as follow-ups if needed. Per-project configurable column sets also deferred to a follow-up.
+
+## Open questions
+
+- **Hotkey choice:** `k` for kanban is free per current `HotkeyHelp`. Confirm during implementation.
+- **Assignee avatar URL:** `gh issue list --json assignees` returns login but not avatarUrl by default — may need a fallback to `https://github.com/<login>.png`.
+- **Label color for new `status:*` labels:** align with Catppuccin palette already used elsewhere (e.g. `F9E2AF` for in-progress). Define once in `columns.ts`.

--- a/docs/plans/2026-04-22-kanban-board-implementation.md
+++ b/docs/plans/2026-04-22-kanban-board-implementation.md
@@ -1,0 +1,127 @@
+# Kanban Board Implementation Plan (Issue #537)
+
+Single bundled PR. See `2026-04-22-kanban-board-design.md` for the design.
+
+## Task structure (CLAUDE.md)
+
+- **Definition:** add a full-screen kanban view that groups GitHub issues by `status:*` label, supports drag/drop to change status, filtering, per-user within-column ordering, virtualization, and an E2E test.
+- **Constraints:** GitHub labels as the status source; reuse existing Tauri GitHub commands; native HTML5 DnD (no new DnD dep); per-user order persisted in local JSON via two new Tauri commands.
+- **Validation:** revert-must-fail unit tests for `columns.ts` / `filter.ts` / `ordering.ts`; component tests for `KanbanCard` / `KanbanColumn`; one E2E test covering the issue's acceptance criterion (create → drag across all columns → reload → status persists).
+
+## Step sequence
+
+Each step ends in a state where `pnpm test` and `cargo test` pass.
+
+### 1. Pure logic modules (TDD)
+
+Create `src/lib/kanban/` with three modules plus their tests. No UI yet.
+
+- `columns.ts`: `Column` type, `COLUMNS` ordered list, `LABEL_BY_COLUMN`, `columnForIssue(issue): Column` (unlabelled → `Backlog`).
+- `filter.ts`: `Filters` type `{ assignees: Set<string>, labels: Set<string>, milestone: string | null }`, `applyFilters(issues, filters): GithubIssue[]`. `status:*` labels excluded from the `labels` set.
+- `ordering.ts`: `OrderMap = Record<string, number[]>` (key `${repoPath}:${column}` → issue numbers), `applyOrdering(issues, column, repoPath, orderMap)`, `moveIssue(orderMap, fromKey, toKey, issueNumber, toIndex)`.
+
+Write `columns.test.ts`, `filter.test.ts`, `ordering.test.ts` first and make them red, then implement.
+
+### 2. Backend: extend `list_github_issues` + add order-file commands
+
+In `src-tauri/src/commands/github.rs`:
+
+- Extend `GithubIssue` struct with `assignees: Vec<Assignee>` and `milestone: Option<Milestone>`.
+- Extend the `gh issue list --json` arg string to include `assignees,milestone`.
+- `Assignee { login: String, avatar_url: Option<String> }` — `gh` returns `login` only by default; frontend falls back to `https://github.com/<login>.png`.
+
+New file `src-tauri/src/commands/kanban.rs`:
+
+- `kanban_load_order(app: AppHandle) -> Result<serde_json::Value, String>` — read `<app_data_dir>/kanban-order.json`, return `{}` if missing.
+- `kanban_save_order(app: AppHandle, order: serde_json::Value) -> Result<(), String>` — atomic write (tmp + rename) to the same path.
+
+Wire both in `lib.rs` `invoke_handler`.
+
+Rust tests: `kanban::tests` round-trips save/load through a tempdir.
+
+Mirror the new `GithubIssue` fields in `src/lib/stores.ts`.
+
+### 3. Workspace mode + hotkey + empty board shell
+
+- Add `"kanban"` to `WorkspaceMode` in `stores.ts`.
+- Add `{ type: "toggle-kanban-view" }` to `HotkeyAction`.
+- In `HotkeyManager.svelte`: bind `k` in ambient mode to toggle between `development` and `kanban` via `workspaceMode.update(m => m === "kanban" ? "development" : "kanban")`.
+- Update `HotkeyHelp.svelte` (help table) and `WorkspaceModePicker.svelte` (picker entry).
+- Create `src/lib/KanbanBoard.svelte` that only renders a titled empty shell for now.
+- In `App.svelte`, extend the workspace-mode branch: `{:else if workspaceModeState.current === "kanban"} <KanbanBoard />`.
+
+Component test: `KanbanBoard.test.ts` — renders 5 column headers in order.
+
+### 4. Columns, cards, load data
+
+- `src/lib/kanban/KanbanColumn.svelte`: props `{ column: Column, issues: GithubIssue[] }`, renders header + card list + empty-state copy.
+- `src/lib/kanban/KanbanCard.svelte`: props `{ issue: GithubIssue }`, renders `#number`, title, non-`status:*` labels, assignee avatars (`avatarUrl ?? https://github.com/${login}.png`). Click → `openUrl(issue.url)`.
+- `KanbanBoard.svelte` loads issues via `command<GithubIssue[]>("list_github_issues", { repoPath })` using the focused project's `repo_path`, groups via `columnForIssue`, renders five `KanbanColumn`s.
+- Loading / error states parallel `IssuesModal`.
+
+Component tests: `KanbanCard.test.ts`, `KanbanColumn.test.ts`.
+
+### 5. Drag-and-drop to change status
+
+- Cards: `draggable="true"`, `dragstart` sets `e.dataTransfer.setData("text/plain", String(issue.number))` and a module-level `draggingIssueRef` for the full object.
+- Columns: `dragover` → `e.preventDefault(); dropEffect="move"` + `isDropTarget` flag; `dragleave` clears the flag; `drop` reads the issue number and calls `moveIssue`.
+- `moveIssue(issue, fromColumn, toColumn)` in `KanbanBoard.svelte`:
+  1. Optimistic local state update.
+  2. `await command("remove_github_label", { repoPath, issueNumber, label: LABEL_BY_COLUMN[fromColumn] })` when the old label exists on the issue.
+  3. `await command("add_github_label", { repoPath, issueNumber, label: LABEL_BY_COLUMN[toColumn], description, color })`.
+  4. On rejection: revert local state, `showToast(String(e), "error")`.
+- Persist updated `OrderMap` via `kanban_save_order` on every successful drop.
+
+No new component tests for DnD — covered by E2E.
+
+### 6. Filter bar
+
+- `src/lib/kanban/KanbanFilterBar.svelte`: three controls (assignees multi-select, labels multi-select excluding `status:*`, milestone single-select), derived from the current issue set.
+- `KanbanBoard.svelte`: state `filters: Filters`, pass filtered list via `applyFilters` to each column.
+
+No new tests — `filter.ts` is already unit-tested and the wiring is thin.
+
+### 7. Per-user ordering
+
+- `KanbanBoard.svelte` on mount: `orderMap = await command("kanban_load_order")`.
+- Render issues per column via `applyOrdering(issuesForColumn, column, repoPath, orderMap)`.
+- On drop, compute the target index from the drop Y position relative to the column's card elements, call `moveIssue` in `ordering.ts`, then `kanban_save_order`.
+
+### 8. Virtualization
+
+- Inside `KanbanColumn.svelte`: if `issues.length > 50`, render via a windowed list. Implementation: fixed card height constant, compute `startIndex`/`endIndex` from `scrollTop`, render a padded spacer above and below.
+- Component test: asserts that only ~visible slice is rendered when `issues.length === 200`.
+
+### 9. E2E test
+
+`e2e/kanban.spec.ts`:
+
+1. Launch app (reuse existing Playwright harness in `e2e/`).
+2. Seed an issue via `create_github_issue` on a test repo (or a test double — match the convention used in existing e2e specs).
+3. Press `k` to open the board.
+4. Drag the seeded card Backlog → To Do → In Progress → In Review → Done, asserting its column between each drag.
+5. Reload, press `k`, assert it's still in Done.
+
+If the existing e2e harness doesn't support `gh`-backed state, gate this spec behind the same env flag other gh-dependent e2e specs use.
+
+### 10. Polish
+
+- Catppuccin palette on column headers (match existing tones in `app.css`).
+- Keyboard affordance on cards: `Enter` opens the issue URL, even without a keyboard-DnD menu.
+- `HotkeyHelp` entry for `k`.
+
+## Risk / fallback checkpoints
+
+- **Native HTML5 DnD feels wrong** (e.g. can't scroll the column while dragging): switch to `svelte-dnd-action`, add to `package.json`, flag in the PR.
+- **Virtualization math gets fiddly**: swap to `@tanstack/svelte-virtual`, same — flag the dep addition.
+- **`gh issue list --json assignees,milestone` returns unexpected shape**: adjust Rust struct; run one manual `gh` call against `kwannoel/the-controller` to confirm the JSON shape before wiring the frontend.
+
+## Out of scope (to reiterate)
+
+WIP limits, swimlanes, multi-board views, real-time collaboration cursors, per-project configurable column sets. All follow-ups.
+
+## PR
+
+Title: `feat: kanban board for tracking issues`
+
+Body must contain `closes #537`.

--- a/e2e/specs/kanban.spec.ts
+++ b/e2e/specs/kanban.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * User story: A user opens the Kanban workspace mode and sees all five
+ * lifecycle columns ready for issues to be placed in them.
+ *
+ * Actor:   User with the app loaded
+ * Action:  Presses Space then 'k' to switch to the Kanban workspace
+ * Outcome: Board renders with Backlog / To Do / In Progress / In Review / Done
+ *
+ * Scope: covers the workspace-mode wiring and column scaffold. Drag-and-drop
+ * against live GitHub labels + reload-persistence would require an issue
+ * fixture pipeline; those are deferred behind the same `gh`-auth gate used by
+ * other GitHub-touching specs.
+ */
+test("kanban mode renders all five columns", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".sidebar")).toBeVisible({ timeout: 10_000 });
+
+  // Focus a project so the board has somewhere to load issues from.
+  await page.keyboard.press("j");
+  await page.waitForTimeout(100);
+
+  // Enter workspace-mode picker and select kanban.
+  await page.keyboard.press("Space");
+  await expect(page.locator(".picker")).toBeVisible({ timeout: 3_000 });
+  await page.keyboard.press("k");
+
+  const board = page.locator('[data-testid="kanban-board"]');
+  await expect(board).toBeVisible({ timeout: 5_000 });
+
+  const expected = ["backlog", "todo", "in-progress", "in-review", "done"];
+  for (const col of expected) {
+    await expect(
+      page.locator(`[data-testid="kanban-column-${col}"]`),
+    ).toBeVisible();
+  }
+
+  // Switch back to development mode so we don't leave state for other specs.
+  await page.keyboard.press("Space");
+  await page.keyboard.press("d");
+});

--- a/src-tauri/src/auto_worker.rs
+++ b/src-tauri/src/auto_worker.rs
@@ -979,6 +979,8 @@ mod tests {
                     name: l.to_string(),
                 })
                 .collect(),
+            assignees: vec![],
+            milestone: None,
         }
     }
 

--- a/src-tauri/src/bin/server.rs
+++ b/src-tauri/src/bin/server.rs
@@ -10,9 +10,7 @@ use axum::{
 };
 use serde_json::Value;
 use std::sync::Arc;
-use the_controller_lib::{
-    config, emitter::WsBroadcastEmitter, state::AppState,
-};
+use the_controller_lib::{config, emitter::WsBroadcastEmitter, state::AppState};
 
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -874,7 +874,11 @@ pub(crate) async fn stage_session_core(
         }
 
         // Check if this specific session is already staged
-        if let Some(existing) = project.staged_sessions.iter().find(|s| s.session_id == session_id) {
+        if let Some(existing) = project
+            .staged_sessions
+            .iter()
+            .find(|s| s.session_id == session_id)
+        {
             #[cfg(unix)]
             let alive = unsafe { libc::kill(existing.pid as i32, 0) } == 0;
             #[cfg(not(unix))]
@@ -1125,7 +1129,11 @@ pub async fn stage_session(
 }
 
 #[tauri::command]
-pub fn unstage_session(state: State<AppState>, project_id: String, session_id: String) -> Result<(), String> {
+pub fn unstage_session(
+    state: State<AppState>,
+    project_id: String,
+    session_id: String,
+) -> Result<(), String> {
     let project_uuid = Uuid::parse_str(&project_id).map_err(|e| e.to_string())?;
     let session_uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
@@ -1424,10 +1432,7 @@ pub async fn kanban_load_order(app: AppHandle) -> Result<serde_json::Value, Stri
 }
 
 #[tauri::command]
-pub async fn kanban_save_order(
-    app: AppHandle,
-    order: serde_json::Value,
-) -> Result<(), String> {
+pub async fn kanban_save_order(app: AppHandle, order: serde_json::Value) -> Result<(), String> {
     kanban::kanban_save_order(app, order).await
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,6 +11,7 @@ use crate::token_usage::{self, TokenDataPoint};
 use crate::worktree::WorktreeManager;
 
 mod github;
+mod kanban;
 mod media;
 
 /// Create a `CLAUDE.md` symlink pointing to `agents.md` in the given directory,
@@ -1415,6 +1416,19 @@ pub async fn list_github_issues(
     state: State<'_, AppState>,
 ) -> Result<Vec<crate::models::GithubIssue>, String> {
     github::list_github_issues(repo_path, state).await
+}
+
+#[tauri::command]
+pub async fn kanban_load_order(app: AppHandle) -> Result<serde_json::Value, String> {
+    kanban::kanban_load_order(app).await
+}
+
+#[tauri::command]
+pub async fn kanban_save_order(
+    app: AppHandle,
+    order: serde_json::Value,
+) -> Result<(), String> {
+    kanban::kanban_save_order(app, order).await
 }
 
 #[tauri::command]
@@ -3133,6 +3147,8 @@ mod tests {
                     name: (*label).to_string(),
                 })
                 .collect(),
+            assignees: vec![],
+            milestone: None,
         }
     }
 

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -142,7 +142,10 @@ pub(crate) async fn list_github_issues(
     Ok(issues)
 }
 
-pub(crate) async fn generate_issue_body(repo_path: String, title: String) -> Result<String, String> {
+pub(crate) async fn generate_issue_body(
+    repo_path: String,
+    title: String,
+) -> Result<String, String> {
     let prompt = format!(
         "Write a concise GitHub issue body for an issue titled: \"{}\". \
          Include a Summary section and a Details section. \

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -196,7 +196,7 @@ pub(crate) async fn create_github_issue(
         labels: vec![],
         assignees: vec![],
         milestone: None,
-};
+    };
 
     if let Ok(mut cache) = state.issue_cache.lock() {
         cache.add_issue(&repo_path, issue.clone());

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -75,7 +75,7 @@ async fn fetch_github_issues(repo_path: String) -> Result<Vec<GithubIssue>, Stri
             "--repo",
             &nwo,
             "--json",
-            "number,title,url,body,labels",
+            "number,title,url,body,labels,assignees,milestone",
             "--limit",
             "50",
         ])
@@ -194,7 +194,9 @@ pub(crate) async fn create_github_issue(
         url,
         body: Some(body),
         labels: vec![],
-    };
+        assignees: vec![],
+        milestone: None,
+};
 
     if let Ok(mut cache) = state.issue_cache.lock() {
         cache.add_issue(&repo_path, issue.clone());

--- a/src-tauri/src/commands/kanban.rs
+++ b/src-tauri/src/commands/kanban.rs
@@ -11,10 +11,10 @@ fn order_file(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
         .path()
         .app_data_dir()
-        .map_err(|e| format!("app_data_dir unavailable: {}", e))?;
+        .map_err(|e| format!("app_data_dir unavailable: {e}"))?;
     if !dir.exists() {
         std::fs::create_dir_all(&dir)
-            .map_err(|e| format!("failed to create app_data_dir: {}", e))?;
+            .map_err(|e| format!("failed to create app_data_dir: {e}"))?;
     }
     Ok(order_file_in(&dir))
 }
@@ -23,29 +23,25 @@ fn load_order_from(path: &Path) -> Result<Value, String> {
     if !path.exists() {
         return Ok(Value::Object(Default::default()));
     }
-    let bytes = std::fs::read(path)
-        .map_err(|e| format!("failed to read kanban-order.json: {}", e))?;
+    let bytes =
+        std::fs::read(path).map_err(|e| format!("failed to read kanban-order.json: {e}"))?;
     if bytes.is_empty() {
         return Ok(Value::Object(Default::default()));
     }
-    serde_json::from_slice(&bytes)
-        .map_err(|e| format!("failed to parse kanban-order.json: {}", e))
+    serde_json::from_slice(&bytes).map_err(|e| format!("failed to parse kanban-order.json: {e}"))
 }
 
 fn save_order_to(path: &Path, order: &Value) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| "invalid order file path".to_string())?;
-    std::fs::create_dir_all(parent)
-        .map_err(|e| format!("failed to create parent dir: {}", e))?;
+    std::fs::create_dir_all(parent).map_err(|e| format!("failed to create parent dir: {e}"))?;
 
     let tmp = parent.join(".kanban-order.json.tmp");
-    let bytes = serde_json::to_vec_pretty(order)
-        .map_err(|e| format!("failed to serialize order: {}", e))?;
-    std::fs::write(&tmp, &bytes)
-        .map_err(|e| format!("failed to write tmp order: {}", e))?;
-    std::fs::rename(&tmp, path)
-        .map_err(|e| format!("failed to rename tmp order: {}", e))?;
+    let bytes =
+        serde_json::to_vec_pretty(order).map_err(|e| format!("failed to serialize order: {e}"))?;
+    std::fs::write(&tmp, &bytes).map_err(|e| format!("failed to write tmp order: {e}"))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("failed to rename tmp order: {e}"))?;
     Ok(())
 }
 
@@ -53,14 +49,14 @@ pub(crate) async fn kanban_load_order(app: AppHandle) -> Result<Value, String> {
     let path = order_file(&app)?;
     tokio::task::spawn_blocking(move || load_order_from(&path))
         .await
-        .map_err(|e| format!("spawn_blocking failed: {}", e))?
+        .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
 pub(crate) async fn kanban_save_order(app: AppHandle, order: Value) -> Result<(), String> {
     let path = order_file(&app)?;
     tokio::task::spawn_blocking(move || save_order_to(&path, &order))
         .await
-        .map_err(|e| format!("spawn_blocking failed: {}", e))?
+        .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/kanban.rs
+++ b/src-tauri/src/commands/kanban.rs
@@ -1,0 +1,118 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+fn order_file_in(dir: &Path) -> PathBuf {
+    dir.join("kanban-order.json")
+}
+
+fn order_file(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir unavailable: {}", e))?;
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("failed to create app_data_dir: {}", e))?;
+    }
+    Ok(order_file_in(&dir))
+}
+
+fn load_order_from(path: &Path) -> Result<Value, String> {
+    if !path.exists() {
+        return Ok(Value::Object(Default::default()));
+    }
+    let bytes = std::fs::read(path)
+        .map_err(|e| format!("failed to read kanban-order.json: {}", e))?;
+    if bytes.is_empty() {
+        return Ok(Value::Object(Default::default()));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| format!("failed to parse kanban-order.json: {}", e))
+}
+
+fn save_order_to(path: &Path, order: &Value) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "invalid order file path".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("failed to create parent dir: {}", e))?;
+
+    let tmp = parent.join(".kanban-order.json.tmp");
+    let bytes = serde_json::to_vec_pretty(order)
+        .map_err(|e| format!("failed to serialize order: {}", e))?;
+    std::fs::write(&tmp, &bytes)
+        .map_err(|e| format!("failed to write tmp order: {}", e))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| format!("failed to rename tmp order: {}", e))?;
+    Ok(())
+}
+
+pub(crate) async fn kanban_load_order(app: AppHandle) -> Result<Value, String> {
+    let path = order_file(&app)?;
+    tokio::task::spawn_blocking(move || load_order_from(&path))
+        .await
+        .map_err(|e| format!("spawn_blocking failed: {}", e))?
+}
+
+pub(crate) async fn kanban_save_order(app: AppHandle, order: Value) -> Result<(), String> {
+    let path = order_file(&app)?;
+    tokio::task::spawn_blocking(move || save_order_to(&path, &order))
+        .await
+        .map_err(|e| format!("spawn_blocking failed: {}", e))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_returns_empty_object_when_file_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = order_file_in(dir.path());
+        assert_eq!(load_order_from(&path).unwrap(), json!({}));
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = order_file_in(dir.path());
+        let payload = json!({
+            "/tmp/repo:todo": [3, 1, 2],
+            "/tmp/repo:done": [9],
+        });
+        save_order_to(&path, &payload).unwrap();
+        let loaded = load_order_from(&path).unwrap();
+        assert_eq!(loaded, payload);
+    }
+
+    #[test]
+    fn save_uses_atomic_rename_no_tmp_leftover() {
+        let dir = TempDir::new().unwrap();
+        let path = order_file_in(dir.path());
+        save_order_to(&path, &json!({"k": [1]})).unwrap();
+        let tmp = dir.path().join(".kanban-order.json.tmp");
+        assert!(!tmp.exists(), "tmp file should have been renamed");
+    }
+
+    #[test]
+    fn save_overwrites_existing() {
+        let dir = TempDir::new().unwrap();
+        let path = order_file_in(dir.path());
+        save_order_to(&path, &json!({"a": [1]})).unwrap();
+        save_order_to(&path, &json!({"a": [2, 3]})).unwrap();
+        let loaded = load_order_from(&path).unwrap();
+        assert_eq!(loaded, json!({"a": [2, 3]}));
+    }
+
+    #[test]
+    fn load_empty_file_returns_empty_object() {
+        let dir = TempDir::new().unwrap();
+        let path = order_file_in(dir.path());
+        std::fs::write(&path, b"").unwrap();
+        assert_eq!(load_order_from(&path).unwrap(), json!({}));
+    }
+}

--- a/src-tauri/src/commands/kanban.rs
+++ b/src-tauri/src/commands/kanban.rs
@@ -13,8 +13,7 @@ fn order_file(app: &AppHandle) -> Result<PathBuf, String> {
         .app_data_dir()
         .map_err(|e| format!("app_data_dir unavailable: {e}"))?;
     if !dir.exists() {
-        std::fs::create_dir_all(&dir)
-            .map_err(|e| format!("failed to create app_data_dir: {e}"))?;
+        std::fs::create_dir_all(&dir).map_err(|e| format!("failed to create app_data_dir: {e}"))?;
     }
     Ok(order_file_in(&dir))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,8 @@ pub fn run() {
             commands::generate_project_names,
             commands::scaffold_project,
             commands::list_github_issues,
+            commands::kanban_load_order,
+            commands::kanban_save_order,
             commands::list_assigned_issues,
             commands::generate_issue_body,
             commands::create_github_issue,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -107,6 +107,10 @@ pub struct GithubIssue {
     #[serde(default)]
     pub body: Option<String>,
     pub labels: Vec<GithubLabel>,
+    #[serde(default)]
+    pub assignees: Vec<GithubAssignee>,
+    #[serde(default)]
+    pub milestone: Option<GithubMilestone>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,6 +121,13 @@ pub struct GithubLabel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GithubAssignee {
     pub login: String,
+    #[serde(default, rename = "avatarUrl", skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GithubMilestone {
+    pub title: String,
 }
 
 /// An open issue that has at least one assignee.
@@ -362,7 +373,9 @@ mod tests {
                 url: "https://github.com/kwannoel/the-controller/issues/22".to_string(),
                 body: None,
                 labels: vec![],
-            }),
+                assignees: vec![],
+                milestone: None,
+}),
             initial_prompt: None,
             done_commits: vec![],
             auto_worker_session: false,
@@ -453,7 +466,9 @@ mod tests {
                     name: "priority".to_string(),
                 },
             ],
-        };
+            assignees: vec![],
+            milestone: None,
+};
         let json = serde_json::to_string(&issue).unwrap();
         let deserialized: GithubIssue = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.labels.len(), 2);
@@ -611,6 +626,7 @@ mod tests {
             url: "https://github.com/owner/repo/issues/42".to_string(),
             assignees: vec![GithubAssignee {
                 login: "alice".to_string(),
+                avatar_url: None,
             }],
             updated_at: "2026-03-01T12:00:00Z".to_string(),
             labels: vec![GithubLabel {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -16,7 +16,11 @@ pub struct Project {
     #[serde(default)]
     pub prompts: Vec<SavedPrompt>,
     /// Sessions staged as separate Controller instances.
-    #[serde(default, alias = "staged_session", deserialize_with = "deserialize_staged_sessions")]
+    #[serde(
+        default,
+        alias = "staged_session",
+        deserialize_with = "deserialize_staged_sessions"
+    )]
     pub staged_sessions: Vec<StagedSession>,
 }
 
@@ -375,7 +379,7 @@ mod tests {
                 labels: vec![],
                 assignees: vec![],
                 milestone: None,
-}),
+            }),
             initial_prompt: None,
             done_commits: vec![],
             auto_worker_session: false,
@@ -468,7 +472,7 @@ mod tests {
             ],
             assignees: vec![],
             milestone: None,
-};
+        };
         let json = serde_json::to_string(&issue).unwrap();
         let deserialized: GithubIssue = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.labels.len(), 2);
@@ -806,8 +810,16 @@ mod tests {
             prompts: vec![],
             sessions: vec![],
             staged_sessions: vec![
-                StagedSession { session_id: Uuid::new_v4(), pid: 1001, port: 2420 },
-                StagedSession { session_id: Uuid::new_v4(), pid: 1002, port: 2421 },
+                StagedSession {
+                    session_id: Uuid::new_v4(),
+                    pid: 1001,
+                    port: 2420,
+                },
+                StagedSession {
+                    session_id: Uuid::new_v4(),
+                    pid: 1002,
+                    port: 2421,
+                },
             ],
         };
         let json = serde_json::to_string(&project).expect("serialize");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -138,7 +138,7 @@ mod tests {
             labels: vec![],
             assignees: vec![],
             milestone: None,
-}];
+        }];
         cache.insert("/some/repo".to_string(), issues.clone());
         let entry = cache.get("/some/repo").unwrap();
         assert_eq!(entry.issues.len(), 1);
@@ -177,7 +177,7 @@ mod tests {
             labels: vec![],
             assignees: vec![],
             milestone: None,
-};
+        };
         cache.add_issue("/repo", issue);
         let entry = cache.get("/repo").unwrap();
         assert_eq!(entry.issues.len(), 1);
@@ -195,7 +195,7 @@ mod tests {
             labels: vec![],
             assignees: vec![],
             milestone: None,
-};
+        };
         cache.add_issue("/repo", issue);
         assert!(cache.get("/repo").is_none());
     }
@@ -213,7 +213,7 @@ mod tests {
                 labels: vec![],
                 assignees: vec![],
                 milestone: None,
-}],
+            }],
         );
         cache.add_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
@@ -234,7 +234,7 @@ mod tests {
                 labels: vec![],
                 assignees: vec![],
                 milestone: None,
-}],
+            }],
         );
         cache.add_label("/repo", 1, "triaged");
         cache.add_label("/repo", 1, "triaged");
@@ -257,7 +257,7 @@ mod tests {
                 }],
                 assignees: vec![],
                 milestone: None,
-}],
+            }],
         );
         cache.remove_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
@@ -278,7 +278,7 @@ mod tests {
                     labels: vec![],
                     assignees: vec![],
                     milestone: None,
-},
+                },
                 GithubIssue {
                     number: 2,
                     title: "Second".to_string(),
@@ -287,7 +287,7 @@ mod tests {
                     labels: vec![],
                     assignees: vec![],
                     milestone: None,
-},
+                },
             ],
         );
         cache.remove_issue("/repo", 1);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -136,7 +136,9 @@ mod tests {
             url: "https://github.com/owner/repo/issues/1".to_string(),
             body: None,
             labels: vec![],
-        }];
+            assignees: vec![],
+            milestone: None,
+}];
         cache.insert("/some/repo".to_string(), issues.clone());
         let entry = cache.get("/some/repo").unwrap();
         assert_eq!(entry.issues.len(), 1);
@@ -173,7 +175,9 @@ mod tests {
             url: "https://github.com/o/r/issues/5".to_string(),
             body: None,
             labels: vec![],
-        };
+            assignees: vec![],
+            milestone: None,
+};
         cache.add_issue("/repo", issue);
         let entry = cache.get("/repo").unwrap();
         assert_eq!(entry.issues.len(), 1);
@@ -189,7 +193,9 @@ mod tests {
             url: "https://github.com/o/r/issues/5".to_string(),
             body: None,
             labels: vec![],
-        };
+            assignees: vec![],
+            milestone: None,
+};
         cache.add_issue("/repo", issue);
         assert!(cache.get("/repo").is_none());
     }
@@ -205,7 +211,9 @@ mod tests {
                 url: "https://github.com/o/r/issues/1".to_string(),
                 body: None,
                 labels: vec![],
-            }],
+                assignees: vec![],
+                milestone: None,
+}],
         );
         cache.add_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
@@ -224,7 +232,9 @@ mod tests {
                 url: "https://github.com/o/r/issues/1".to_string(),
                 body: None,
                 labels: vec![],
-            }],
+                assignees: vec![],
+                milestone: None,
+}],
         );
         cache.add_label("/repo", 1, "triaged");
         cache.add_label("/repo", 1, "triaged");
@@ -245,7 +255,9 @@ mod tests {
                 labels: vec![GithubLabel {
                     name: "in-progress".to_string(),
                 }],
-            }],
+                assignees: vec![],
+                milestone: None,
+}],
         );
         cache.remove_label("/repo", 1, "in-progress");
         let entry = cache.get("/repo").unwrap();
@@ -264,14 +276,18 @@ mod tests {
                     url: "https://github.com/o/r/issues/1".to_string(),
                     body: None,
                     labels: vec![],
-                },
+                    assignees: vec![],
+                    milestone: None,
+},
                 GithubIssue {
                     number: 2,
                     title: "Second".to_string(),
                     url: "https://github.com/o/r/issues/2".to_string(),
                     body: None,
                     labels: vec![],
-                },
+                    assignees: vec![],
+                    milestone: None,
+},
             ],
         );
         cache.remove_issue("/repo", 1);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,6 +18,7 @@
   import KeystrokeVisualizer from "./lib/KeystrokeVisualizer.svelte";
   import WorkspaceModePicker from "./lib/WorkspaceModePicker.svelte";
   import AgentDashboard from "./lib/AgentDashboard.svelte";
+  import KanbanBoard from "./lib/KanbanBoard.svelte";
   import { refreshProjectsFromBackend } from "./lib/project-listing";
   import { showToast } from "./lib/toast";
   import { appConfig, onboardingComplete, hotkeyAction, showKeyHints, sidebarVisible, workspaceModePickerVisible, workspaceMode, focusTarget, projects, sessionStatuses, activeSessionId, expandedProjects, dispatchHotkeyAction, focusTerminalSoon, selectedSessionProvider, type Config, type GithubIssue, type Project, type SavedPrompt, type SessionStatus } from "./lib/stores";
@@ -374,6 +375,8 @@
       <main class="terminal-area">
         {#if workspaceModeState.current === "agents"}
           <AgentDashboard />
+        {:else if workspaceModeState.current === "kanban"}
+          <KanbanBoard />
         {:else}
           <TerminalManager />
         {/if}

--- a/src/lib/HotkeyManager.svelte
+++ b/src/lib/HotkeyManager.svelte
@@ -99,6 +99,12 @@
       if (newFocus !== currentFocus) focusTarget.set(newFocus);
       return;
     }
+    if (key === "k") {
+      workspaceMode.set("kanban");
+      const newFocus = focusForModeSwitch(currentFocus, "kanban", activeId, projectList);
+      if (newFocus !== currentFocus) focusTarget.set(newFocus);
+      return;
+    }
     // Any other key (including Escape) cancels
   }
 

--- a/src/lib/IssuesModal.svelte
+++ b/src/lib/IssuesModal.svelte
@@ -294,7 +294,7 @@
           <span class="hub-key">c</span>
           <span>Create issue</span>
         </button>
-        <button class="hub-option" onclick={enterFind}>
+        <button class="hub-option" onclick={() => enterFind()}>
           <span class="hub-key">f</span>
           <span>Find issues</span>
         </button>

--- a/src/lib/KanbanBoard.svelte
+++ b/src/lib/KanbanBoard.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+  import { fromStore } from "svelte/store";
+  import { command } from "$lib/backend";
+  import { projects, focusTarget, type GithubIssue } from "./stores";
+  import { showToast } from "./toast";
+  import {
+    COLUMNS,
+    columnForIssue,
+    LABEL_BY_COLUMN,
+    LABEL_COLOR,
+    type Column,
+  } from "./kanban/columns";
+  import { applyOrdering, moveIssue, orderKey, type OrderMap } from "./kanban/ordering";
+  import { applyFilters, type Filters } from "./kanban/filter";
+  import KanbanColumn from "./kanban/KanbanColumn.svelte";
+  import KanbanFilterBar from "./kanban/KanbanFilterBar.svelte";
+
+  const projectsState = fromStore(projects);
+  const focusTargetState = fromStore(focusTarget);
+
+  let focusedProject = $derived.by(() => {
+    const f = focusTargetState.current;
+    if (!f || !("projectId" in f)) return null;
+    return projectsState.current.find((p) => p.id === f.projectId) ?? null;
+  });
+
+  let repoPath = $derived(focusedProject?.repo_path ?? null);
+
+  let issues: GithubIssue[] = $state([]);
+  let loading = $state(false);
+  let error: string | null = $state(null);
+  let orderMap: OrderMap = $state({});
+  let draggingIssue: GithubIssue | null = $state(null);
+  let filters: Filters = $state({
+    assignees: new Set(),
+    labels: new Set(),
+    milestone: null,
+  });
+
+  let filteredIssues = $derived(applyFilters(issues, filters));
+
+  let issuesByColumn = $derived.by(() => {
+    const repo = repoPath ?? "";
+    const grouped: Record<Column, GithubIssue[]> = {
+      backlog: [],
+      todo: [],
+      "in-progress": [],
+      "in-review": [],
+      done: [],
+    };
+    for (const issue of filteredIssues) {
+      grouped[columnForIssue(issue)].push(issue);
+    }
+    for (const col of COLUMNS) {
+      grouped[col] = applyOrdering(grouped[col], col, repo, orderMap);
+    }
+    return grouped;
+  });
+
+  $effect(() => {
+    const path = repoPath;
+    if (!path) {
+      issues = [];
+      error = null;
+      return;
+    }
+    loadIssues(path);
+  });
+
+  $effect(() => {
+    loadOrder();
+  });
+
+  async function loadIssues(path: string) {
+    loading = true;
+    error = null;
+    try {
+      issues = await command<GithubIssue[]>("list_github_issues", {
+        repoPath: path,
+      });
+    } catch (e) {
+      error = String(e);
+      issues = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadOrder() {
+    try {
+      const loaded = await command<unknown>("kanban_load_order");
+      orderMap =
+        loaded && typeof loaded === "object" ? (loaded as OrderMap) : {};
+    } catch {
+      orderMap = {};
+    }
+  }
+
+  async function saveOrder(next: OrderMap) {
+    try {
+      await command("kanban_save_order", { order: next });
+    } catch (e) {
+      showToast(`Failed to save order: ${e}`, "error");
+    }
+  }
+
+  function onDragStart(issue: GithubIssue) {
+    draggingIssue = issue;
+  }
+
+  function onDragEnd() {
+    draggingIssue = null;
+  }
+
+  async function onDrop(toColumn: Column, toIndex: number) {
+    const issue = draggingIssue;
+    const repo = repoPath;
+    draggingIssue = null;
+    if (!issue || !repo) return;
+
+    const fromColumn = columnForIssue(issue);
+    const fromKey = orderKey(repo, fromColumn);
+    const toKey = orderKey(repo, toColumn);
+
+    const previousIssues = issues;
+    const previousOrder = orderMap;
+
+    // Optimistic update.
+    orderMap = moveIssue(orderMap, fromKey, toKey, issue.number, toIndex);
+    if (fromColumn !== toColumn) {
+      issues = issues.map((i) => {
+        if (i.number !== issue.number) return i;
+        const withoutStatus = i.labels.filter(
+          (l) => l.name !== LABEL_BY_COLUMN[fromColumn],
+        );
+        return {
+          ...i,
+          labels: [...withoutStatus, { name: LABEL_BY_COLUMN[toColumn] }],
+        };
+      });
+    }
+
+    try {
+      if (fromColumn !== toColumn) {
+        const hasFromLabel = previousIssues
+          .find((i) => i.number === issue.number)
+          ?.labels.some((l) => l.name === LABEL_BY_COLUMN[fromColumn]);
+        if (hasFromLabel) {
+          await command("remove_github_label", {
+            repoPath: repo,
+            issueNumber: issue.number,
+            label: LABEL_BY_COLUMN[fromColumn],
+          });
+        }
+        await command("add_github_label", {
+          repoPath: repo,
+          issueNumber: issue.number,
+          label: LABEL_BY_COLUMN[toColumn],
+          description: `Kanban column: ${toColumn}`,
+          color: LABEL_COLOR[toColumn],
+        });
+      }
+      await saveOrder(orderMap);
+    } catch (e) {
+      issues = previousIssues;
+      orderMap = previousOrder;
+      showToast(`Failed to move issue: ${e}`, "error");
+    }
+  }
+</script>
+
+<div class="kanban-board" data-testid="kanban-board">
+  <header class="board-header">
+    <h1>Kanban</h1>
+    {#if focusedProject}
+      <span class="board-project">{focusedProject.name}</span>
+    {:else}
+      <span class="board-project board-project--muted">Focus a project to load its board</span>
+    {/if}
+    {#if loading}<span class="board-status">Loading...</span>{/if}
+    {#if error}<span class="board-status board-status--error">{error}</span>{/if}
+  </header>
+  <KanbanFilterBar
+    {issues}
+    {filters}
+    onchange={(next) => (filters = next)}
+  />
+  <div class="columns">
+    {#each COLUMNS as column (column)}
+      <KanbanColumn
+        {column}
+        issues={issuesByColumn[column]}
+        ondragstart={onDragStart}
+        ondragend={onDragEnd}
+        ondrop={onDrop}
+      />
+    {/each}
+  </div>
+</div>
+
+<style>
+  .kanban-board {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    background: var(--bg-void);
+    color: var(--text-primary);
+    overflow: hidden;
+  }
+
+  .board-header {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    padding: 16px 20px 12px;
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .board-header h1 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .board-project {
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+
+  .board-project--muted {
+    font-style: italic;
+  }
+
+  .board-status {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-left: auto;
+  }
+
+  .board-status--error {
+    color: var(--color-danger, #f38ba8);
+  }
+
+  .columns {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(220px, 1fr));
+    gap: 12px;
+    padding: 12px;
+    overflow-x: auto;
+    flex: 1;
+    min-height: 0;
+  }
+</style>

--- a/src/lib/KanbanBoard.svelte
+++ b/src/lib/KanbanBoard.svelte
@@ -239,7 +239,7 @@
   }
 
   .board-status--error {
-    color: var(--color-danger, #f38ba8);
+    color: var(--status-error);
   }
 
   .columns {

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -448,7 +448,7 @@
 
 <aside class="sidebar" bind:this={sidebarEl}>
   <div class="sidebar-header">
-    <h2>{{ development: "Development", agents: "Agents" }[currentMode]}</h2>
+    <h2>{{ development: "Development", agents: "Agents", kanban: "Kanban" }[currentMode]}</h2>
   </div>
 
   <div class="project-list">

--- a/src/lib/WorkspaceModePicker.svelte
+++ b/src/lib/WorkspaceModePicker.svelte
@@ -8,6 +8,7 @@
   const modes: { key: string; id: WorkspaceMode; label: string }[] = [
     { key: "d", id: "development", label: "Development" },
     { key: "a", id: "agents", label: "Agents" },
+    { key: "k", id: "kanban", label: "Kanban" },
   ];
 </script>
 

--- a/src/lib/kanban/KanbanCard.svelte
+++ b/src/lib/kanban/KanbanCard.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { openUrl } from "@tauri-apps/plugin-opener";
+  import type { GithubIssue } from "../stores";
+  import { isStatusLabel } from "./columns";
+
+  interface Props {
+    issue: GithubIssue;
+    ondragstart?: (issue: GithubIssue) => void;
+    ondragend?: () => void;
+  }
+
+  let { issue, ondragstart, ondragend }: Props = $props();
+
+  let nonStatusLabels = $derived(
+    issue.labels.filter((l) => !isStatusLabel(l.name)),
+  );
+
+  function avatarUrl(login: string, explicit?: string): string {
+    return explicit ?? `https://github.com/${login}.png`;
+  }
+
+  function onClick() {
+    openUrl(issue.url).catch(() => {});
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  }
+
+  function onDragStart(e: DragEvent) {
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(issue.number));
+    }
+    ondragstart?.(issue);
+  }
+
+  function onDragEnd() {
+    ondragend?.();
+  }
+</script>
+
+<div
+  class="kanban-card"
+  draggable="true"
+  role="button"
+  tabindex="0"
+  onclick={onClick}
+  onkeydown={onKeydown}
+  ondragstart={onDragStart}
+  ondragend={onDragEnd}
+  data-issue-number={issue.number}
+>
+  <header class="card-header">
+    <span class="card-number">#{issue.number}</span>
+    {#if issue.assignees && issue.assignees.length > 0}
+      <div class="avatars">
+        {#each issue.assignees.slice(0, 3) as a (a.login)}
+          <img
+            class="avatar"
+            src={avatarUrl(a.login, a.avatarUrl)}
+            alt={a.login}
+            title={a.login}
+          />
+        {/each}
+      </div>
+    {/if}
+  </header>
+  <p class="card-title">{issue.title}</p>
+  {#if nonStatusLabels.length > 0}
+    <div class="card-labels">
+      {#each nonStatusLabels as label (label.name)}
+        <span class="label-chip">{label.name}</span>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .kanban-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px;
+    background: var(--bg-void);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    cursor: grab;
+    color: var(--text-primary);
+    text-align: left;
+    user-select: none;
+  }
+
+  .kanban-card:hover {
+    border-color: var(--text-emphasis);
+  }
+
+  .kanban-card:active {
+    cursor: grabbing;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .card-number {
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+  }
+
+  .card-title {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.35;
+  }
+
+  .avatars {
+    display: inline-flex;
+    gap: 2px;
+  }
+
+  .avatar {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--bg-elevated);
+  }
+
+  .card-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .label-chip {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 10px;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-default);
+  }
+</style>

--- a/src/lib/kanban/KanbanColumn.svelte
+++ b/src/lib/kanban/KanbanColumn.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import type { GithubIssue } from "../stores";
+  import type { Column } from "./columns";
+  import { COLUMN_TITLES, EMPTY_STATE } from "./columns";
+  import KanbanCard from "./KanbanCard.svelte";
+
+  interface Props {
+    column: Column;
+    issues: GithubIssue[];
+    ondragstart?: (issue: GithubIssue) => void;
+    ondragend?: () => void;
+    ondrop?: (column: Column, toIndex: number) => void;
+  }
+
+  let { column, issues, ondragstart, ondragend, ondrop }: Props = $props();
+
+  let isOver = $state(false);
+  let bodyEl: HTMLDivElement | undefined = $state();
+
+  const VIRTUALIZE_THRESHOLD = 50;
+  const CARD_HEIGHT = 80;
+
+  let scrollTop = $state(0);
+  let viewportHeight = $state(0);
+
+  let useVirtual = $derived(issues.length > VIRTUALIZE_THRESHOLD);
+  let startIndex = $derived(
+    useVirtual ? Math.max(0, Math.floor(scrollTop / CARD_HEIGHT) - 3) : 0,
+  );
+  let endIndex = $derived(
+    useVirtual
+      ? Math.min(
+          issues.length,
+          Math.ceil((scrollTop + viewportHeight) / CARD_HEIGHT) + 3,
+        )
+      : issues.length,
+  );
+  let visibleIssues = $derived(
+    useVirtual ? issues.slice(startIndex, endIndex) : issues,
+  );
+  let topSpacer = $derived(useVirtual ? startIndex * CARD_HEIGHT : 0);
+  let bottomSpacer = $derived(
+    useVirtual ? (issues.length - endIndex) * CARD_HEIGHT : 0,
+  );
+
+  function onScroll(e: Event) {
+    if (!useVirtual) return;
+    const el = e.currentTarget as HTMLDivElement;
+    scrollTop = el.scrollTop;
+    viewportHeight = el.clientHeight;
+  }
+
+  function onDragOver(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+    isOver = true;
+  }
+
+  function onDragLeave() {
+    isOver = false;
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    isOver = false;
+    if (!bodyEl) return;
+    const y = e.clientY - bodyEl.getBoundingClientRect().top + bodyEl.scrollTop;
+    const toIndex = Math.max(0, Math.floor(y / CARD_HEIGHT));
+    ondrop?.(column, Math.min(toIndex, issues.length));
+  }
+</script>
+
+<section
+  class="column"
+  class:drop-target={isOver}
+  data-column={column}
+  data-testid="kanban-column-{column}"
+>
+  <header class="column-header">
+    <span class="column-title">{COLUMN_TITLES[column]}</span>
+    <span class="column-count">{issues.length}</span>
+  </header>
+  <div
+    class="column-body"
+    bind:this={bodyEl}
+    onscroll={onScroll}
+    ondragover={onDragOver}
+    ondragleave={onDragLeave}
+    ondrop={onDrop}
+    role="list"
+  >
+    {#if issues.length === 0}
+      <p class="empty-state">{EMPTY_STATE[column]}</p>
+    {:else}
+      {#if topSpacer > 0}
+        <div class="spacer" style="height: {topSpacer}px"></div>
+      {/if}
+      {#each visibleIssues as issue (issue.number)}
+        <KanbanCard {issue} {ondragstart} {ondragend} />
+      {/each}
+      {#if bottomSpacer > 0}
+        <div class="spacer" style="height: {bottomSpacer}px"></div>
+      {/if}
+    {/if}
+  </div>
+</section>
+
+<style>
+  .column {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: 8px;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .column.drop-target {
+    border-color: var(--text-emphasis);
+    background: color-mix(in srgb, var(--bg-elevated) 85%, var(--text-emphasis) 15%);
+  }
+
+  .column-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--border-default);
+    color: var(--text-primary);
+  }
+
+  .column-count {
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-weight: 400;
+  }
+
+  .column-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .empty-state {
+    margin: 0;
+    padding: 16px 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-style: italic;
+    text-align: center;
+  }
+
+  .spacer {
+    flex-shrink: 0;
+  }
+</style>

--- a/src/lib/kanban/KanbanFilterBar.svelte
+++ b/src/lib/kanban/KanbanFilterBar.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import type { GithubIssue } from "../stores";
+  import { isStatusLabel } from "./columns";
+  import type { Filters } from "./filter";
+
+  interface Props {
+    issues: GithubIssue[];
+    filters: Filters;
+    onchange: (next: Filters) => void;
+  }
+
+  let { issues, filters, onchange }: Props = $props();
+
+  let assigneeOptions = $derived.by(() => {
+    const set = new Set<string>();
+    for (const issue of issues) {
+      for (const a of issue.assignees ?? []) set.add(a.login);
+    }
+    return [...set].sort();
+  });
+
+  let labelOptions = $derived.by(() => {
+    const set = new Set<string>();
+    for (const issue of issues) {
+      for (const l of issue.labels) {
+        if (!isStatusLabel(l.name)) set.add(l.name);
+      }
+    }
+    return [...set].sort();
+  });
+
+  let milestoneOptions = $derived.by(() => {
+    const set = new Set<string>();
+    for (const issue of issues) {
+      const m = issue.milestone?.title;
+      if (m) set.add(m);
+    }
+    return [...set].sort();
+  });
+
+  function toggleAssignee(login: string) {
+    const next = new Set(filters.assignees);
+    if (next.has(login)) next.delete(login);
+    else next.add(login);
+    onchange({ ...filters, assignees: next });
+  }
+
+  function toggleLabel(name: string) {
+    const next = new Set(filters.labels);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    onchange({ ...filters, labels: next });
+  }
+
+  function selectMilestone(e: Event) {
+    const v = (e.currentTarget as HTMLSelectElement).value;
+    onchange({ ...filters, milestone: v === "" ? null : v });
+  }
+
+  function clearAll() {
+    onchange({ assignees: new Set(), labels: new Set(), milestone: null });
+  }
+
+  let hasActive = $derived(
+    filters.assignees.size > 0 ||
+      filters.labels.size > 0 ||
+      filters.milestone !== null,
+  );
+</script>
+
+<div class="filter-bar" data-testid="kanban-filter-bar">
+  {#if assigneeOptions.length > 0}
+    <div class="filter-group">
+      <span class="filter-label">Assignee</span>
+      {#each assigneeOptions as login (login)}
+        <button
+          type="button"
+          class="chip"
+          class:active={filters.assignees.has(login)}
+          onclick={() => toggleAssignee(login)}
+        >{login}</button>
+      {/each}
+    </div>
+  {/if}
+
+  {#if labelOptions.length > 0}
+    <div class="filter-group">
+      <span class="filter-label">Label</span>
+      {#each labelOptions as name (name)}
+        <button
+          type="button"
+          class="chip"
+          class:active={filters.labels.has(name)}
+          onclick={() => toggleLabel(name)}
+        >{name}</button>
+      {/each}
+    </div>
+  {/if}
+
+  {#if milestoneOptions.length > 0}
+    <div class="filter-group">
+      <span class="filter-label">Milestone</span>
+      <select onchange={selectMilestone} value={filters.milestone ?? ""}>
+        <option value="">Any</option>
+        {#each milestoneOptions as title (title)}
+          <option value={title}>{title}</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
+  {#if hasActive}
+    <button type="button" class="clear-btn" onclick={clearAll}>Clear filters</button>
+  {/if}
+</div>
+
+<style>
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 20px;
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-elevated);
+  }
+
+  .filter-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .filter-label {
+    font-size: 11px;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-right: 4px;
+  }
+
+  .chip {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    border: 1px solid var(--border-default);
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .chip.active {
+    background: var(--text-emphasis);
+    color: var(--bg-void);
+    border-color: var(--text-emphasis);
+  }
+
+  select {
+    font-size: 11px;
+    padding: 2px 6px;
+    background: var(--bg-void);
+    border: 1px solid var(--border-default);
+    color: var(--text-primary);
+    border-radius: 4px;
+  }
+
+  .clear-btn {
+    margin-left: auto;
+    font-size: 11px;
+    padding: 2px 8px;
+    border: 1px solid var(--border-default);
+    background: transparent;
+    color: var(--text-secondary);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+</style>

--- a/src/lib/kanban/columns.test.ts
+++ b/src/lib/kanban/columns.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import type { GithubIssue } from "../stores";
+import {
+  COLUMNS,
+  LABEL_BY_COLUMN,
+  columnForIssue,
+  type Column,
+} from "./columns";
+
+function issue(labels: string[]): GithubIssue {
+  return {
+    number: 1,
+    title: "t",
+    url: "https://x",
+    labels: labels.map((name) => ({ name })),
+  };
+}
+
+describe("COLUMNS", () => {
+  it("has the five columns in left-to-right order", () => {
+    expect(COLUMNS).toEqual([
+      "backlog",
+      "todo",
+      "in-progress",
+      "in-review",
+      "done",
+    ] satisfies Column[]);
+  });
+
+  it("has a status:* label for every column", () => {
+    for (const c of COLUMNS) {
+      expect(LABEL_BY_COLUMN[c]).toMatch(/^status:/);
+    }
+  });
+});
+
+describe("columnForIssue", () => {
+  it("maps each status:* label to its column", () => {
+    for (const c of COLUMNS) {
+      expect(columnForIssue(issue([LABEL_BY_COLUMN[c]]))).toBe(c);
+    }
+  });
+
+  it("defaults to backlog when no status label is present", () => {
+    expect(columnForIssue(issue([]))).toBe("backlog");
+    expect(columnForIssue(issue(["priority:high", "complexity:low"]))).toBe(
+      "backlog",
+    );
+  });
+
+  it("ignores non-status labels even if they look similar", () => {
+    expect(columnForIssue(issue(["in-progress"]))).toBe("backlog");
+  });
+
+  it("when multiple status labels are set, prefers the rightmost column", () => {
+    const i = issue([
+      LABEL_BY_COLUMN["todo"],
+      LABEL_BY_COLUMN["done"],
+      LABEL_BY_COLUMN["in-progress"],
+    ]);
+    expect(columnForIssue(i)).toBe("done");
+  });
+});

--- a/src/lib/kanban/columns.ts
+++ b/src/lib/kanban/columns.ts
@@ -1,0 +1,74 @@
+import type { GithubIssue } from "../stores";
+
+export type Column =
+  | "backlog"
+  | "todo"
+  | "in-progress"
+  | "in-review"
+  | "done";
+
+export const COLUMNS: readonly Column[] = [
+  "backlog",
+  "todo",
+  "in-progress",
+  "in-review",
+  "done",
+] as const;
+
+export const COLUMN_TITLES: Record<Column, string> = {
+  backlog: "Backlog",
+  todo: "To Do",
+  "in-progress": "In Progress",
+  "in-review": "In Review",
+  done: "Done",
+};
+
+export const LABEL_BY_COLUMN: Record<Column, string> = {
+  backlog: "status:backlog",
+  todo: "status:todo",
+  "in-progress": "status:in-progress",
+  "in-review": "status:in-review",
+  done: "status:done",
+};
+
+export const COLUMN_BY_LABEL: Record<string, Column> = Object.fromEntries(
+  (Object.entries(LABEL_BY_COLUMN) as [Column, string][]).map(([c, l]) => [
+    l,
+    c,
+  ]),
+);
+
+export const EMPTY_STATE: Record<Column, string> = {
+  backlog: "No backlog items",
+  todo: "Nothing queued",
+  "in-progress": "Nothing in progress",
+  "in-review": "Nothing awaiting review",
+  done: "Nothing done yet",
+};
+
+export const LABEL_COLOR: Record<Column, string> = {
+  backlog: "9399B2",
+  todo: "89B4FA",
+  "in-progress": "F9E2AF",
+  "in-review": "CBA6F7",
+  done: "A6E3A1",
+};
+
+export function columnForIssue(issue: GithubIssue): Column {
+  let best: Column = "backlog";
+  let bestIdx = -1;
+  for (const { name } of issue.labels) {
+    const c = COLUMN_BY_LABEL[name];
+    if (!c) continue;
+    const idx = COLUMNS.indexOf(c);
+    if (idx > bestIdx) {
+      best = c;
+      bestIdx = idx;
+    }
+  }
+  return best;
+}
+
+export function isStatusLabel(name: string): boolean {
+  return name.startsWith("status:");
+}

--- a/src/lib/kanban/filter.test.ts
+++ b/src/lib/kanban/filter.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import type { GithubIssue } from "../stores";
+import { applyFilters, type Filters } from "./filter";
+
+function issue(
+  number: number,
+  labels: string[],
+  assignees: string[] = [],
+  milestone: string | null = null,
+): GithubIssue {
+  return {
+    number,
+    title: `issue ${number}`,
+    url: `https://x/${number}`,
+    labels: labels.map((name) => ({ name })),
+    assignees: assignees.map((login) => ({ login })),
+    milestone: milestone ? { title: milestone } : null,
+  };
+}
+
+const empty: Filters = {
+  assignees: new Set(),
+  labels: new Set(),
+  milestone: null,
+};
+
+describe("applyFilters", () => {
+  const issues: GithubIssue[] = [
+    issue(1, ["bug"], ["alice"], "v1"),
+    issue(2, ["feature"], ["bob"], "v1"),
+    issue(3, ["bug", "priority:high"], ["alice", "bob"], "v2"),
+    issue(4, [], [], null),
+  ];
+
+  it("returns all issues when filters are empty", () => {
+    expect(applyFilters(issues, empty).map((i) => i.number)).toEqual([
+      1, 2, 3, 4,
+    ]);
+  });
+
+  it("filters by assignee (any-of within the set)", () => {
+    const f: Filters = { ...empty, assignees: new Set(["alice"]) };
+    expect(applyFilters(issues, f).map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  it("filters by label (all-of within the set)", () => {
+    const f: Filters = {
+      ...empty,
+      labels: new Set(["bug", "priority:high"]),
+    };
+    expect(applyFilters(issues, f).map((i) => i.number)).toEqual([3]);
+  });
+
+  it("filters by milestone (exact match)", () => {
+    const f: Filters = { ...empty, milestone: "v2" };
+    expect(applyFilters(issues, f).map((i) => i.number)).toEqual([3]);
+  });
+
+  it("intersects assignee + label + milestone", () => {
+    const f: Filters = {
+      assignees: new Set(["alice"]),
+      labels: new Set(["bug"]),
+      milestone: "v1",
+    };
+    expect(applyFilters(issues, f).map((i) => i.number)).toEqual([1]);
+  });
+
+  it("status:* labels in the filter set are ignored", () => {
+    const f: Filters = { ...empty, labels: new Set(["status:done"]) };
+    expect(applyFilters(issues, f).map((i) => i.number)).toEqual([
+      1, 2, 3, 4,
+    ]);
+  });
+});

--- a/src/lib/kanban/filter.ts
+++ b/src/lib/kanban/filter.ts
@@ -1,0 +1,39 @@
+import type { GithubIssue } from "../stores";
+import { isStatusLabel } from "./columns";
+
+export interface Filters {
+  assignees: Set<string>;
+  labels: Set<string>;
+  milestone: string | null;
+}
+
+export function applyFilters(
+  issues: GithubIssue[],
+  filters: Filters,
+): GithubIssue[] {
+  const wantLabels = new Set(
+    [...filters.labels].filter((l) => !isStatusLabel(l)),
+  );
+  const wantAssignees = filters.assignees;
+  const wantMilestone = filters.milestone;
+
+  return issues.filter((issue) => {
+    if (wantAssignees.size > 0) {
+      const logins = (issue.assignees ?? []).map((a) => a.login);
+      if (!logins.some((l) => wantAssignees.has(l))) return false;
+    }
+
+    if (wantLabels.size > 0) {
+      const names = new Set(issue.labels.map((l) => l.name));
+      for (const want of wantLabels) {
+        if (!names.has(want)) return false;
+      }
+    }
+
+    if (wantMilestone !== null) {
+      if ((issue.milestone?.title ?? null) !== wantMilestone) return false;
+    }
+
+    return true;
+  });
+}

--- a/src/lib/kanban/ordering.test.ts
+++ b/src/lib/kanban/ordering.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import type { GithubIssue } from "../stores";
+import {
+  applyOrdering,
+  moveIssue,
+  orderKey,
+  type OrderMap,
+} from "./ordering";
+
+function issue(n: number): GithubIssue {
+  return {
+    number: n,
+    title: `issue ${n}`,
+    url: `https://x/${n}`,
+    labels: [],
+  };
+}
+
+const repo = "/tmp/repo";
+
+describe("orderKey", () => {
+  it("combines repoPath and column", () => {
+    expect(orderKey(repo, "todo")).toBe(`${repo}:todo`);
+  });
+});
+
+describe("applyOrdering", () => {
+  it("returns input order when no saved order exists", () => {
+    const issues = [issue(3), issue(1), issue(2)];
+    expect(
+      applyOrdering(issues, "todo", repo, {}).map((i) => i.number),
+    ).toEqual([3, 1, 2]);
+  });
+
+  it("orders by saved sequence, then appends new issues at the end", () => {
+    const issues = [issue(1), issue(2), issue(3), issue(4)];
+    const order: OrderMap = { [orderKey(repo, "todo")]: [3, 1] };
+    expect(
+      applyOrdering(issues, "todo", repo, order).map((i) => i.number),
+    ).toEqual([3, 1, 2, 4]);
+  });
+
+  it("drops stale numbers that are no longer in the input", () => {
+    const issues = [issue(1), issue(2)];
+    const order: OrderMap = { [orderKey(repo, "todo")]: [99, 1, 100, 2] };
+    expect(
+      applyOrdering(issues, "todo", repo, order).map((i) => i.number),
+    ).toEqual([1, 2]);
+  });
+});
+
+describe("moveIssue", () => {
+  it("reorders within a column", () => {
+    const order: OrderMap = { [orderKey(repo, "todo")]: [1, 2, 3] };
+    const next = moveIssue(
+      order,
+      orderKey(repo, "todo"),
+      orderKey(repo, "todo"),
+      3,
+      0,
+    );
+    expect(next[orderKey(repo, "todo")]).toEqual([3, 1, 2]);
+  });
+
+  it("moves across columns", () => {
+    const order: OrderMap = {
+      [orderKey(repo, "todo")]: [1, 2, 3],
+      [orderKey(repo, "done")]: [9],
+    };
+    const next = moveIssue(
+      order,
+      orderKey(repo, "todo"),
+      orderKey(repo, "done"),
+      2,
+      0,
+    );
+    expect(next[orderKey(repo, "todo")]).toEqual([1, 3]);
+    expect(next[orderKey(repo, "done")]).toEqual([2, 9]);
+  });
+
+  it("inserts at the end when toIndex exceeds length", () => {
+    const order: OrderMap = {
+      [orderKey(repo, "todo")]: [1, 2],
+      [orderKey(repo, "done")]: [],
+    };
+    const next = moveIssue(
+      order,
+      orderKey(repo, "todo"),
+      orderKey(repo, "done"),
+      1,
+      99,
+    );
+    expect(next[orderKey(repo, "done")]).toEqual([1]);
+  });
+
+  it("does not mutate the input map", () => {
+    const order: OrderMap = { [orderKey(repo, "todo")]: [1, 2] };
+    const snapshot = JSON.stringify(order);
+    moveIssue(
+      order,
+      orderKey(repo, "todo"),
+      orderKey(repo, "todo"),
+      2,
+      0,
+    );
+    expect(JSON.stringify(order)).toBe(snapshot);
+  });
+});

--- a/src/lib/kanban/ordering.ts
+++ b/src/lib/kanban/ordering.ts
@@ -1,0 +1,66 @@
+import type { GithubIssue } from "../stores";
+import type { Column } from "./columns";
+
+export type OrderMap = Record<string, number[]>;
+
+export function orderKey(repoPath: string, column: Column): string {
+  return `${repoPath}:${column}`;
+}
+
+export function applyOrdering(
+  issues: GithubIssue[],
+  column: Column,
+  repoPath: string,
+  orderMap: OrderMap,
+): GithubIssue[] {
+  const key = orderKey(repoPath, column);
+  const saved = orderMap[key];
+  if (!saved || saved.length === 0) return [...issues];
+
+  const byNumber = new Map(issues.map((i) => [i.number, i]));
+  const ordered: GithubIssue[] = [];
+  const placed = new Set<number>();
+
+  for (const n of saved) {
+    const issue = byNumber.get(n);
+    if (issue && !placed.has(n)) {
+      ordered.push(issue);
+      placed.add(n);
+    }
+  }
+
+  for (const issue of issues) {
+    if (!placed.has(issue.number)) ordered.push(issue);
+  }
+
+  return ordered;
+}
+
+export function moveIssue(
+  orderMap: OrderMap,
+  fromKey: string,
+  toKey: string,
+  issueNumber: number,
+  toIndex: number,
+): OrderMap {
+  const next: OrderMap = { ...orderMap };
+  const fromList = [...(next[fromKey] ?? [])].filter(
+    (n) => n !== issueNumber,
+  );
+  next[fromKey] = fromList;
+
+  const toListBase =
+    fromKey === toKey
+      ? fromList
+      : [...(next[toKey] ?? [])].filter((n) => n !== issueNumber);
+  const clampedIndex = Math.max(0, Math.min(toIndex, toListBase.length));
+  const toList = [
+    ...toListBase.slice(0, clampedIndex),
+    issueNumber,
+    ...toListBase.slice(clampedIndex),
+  ];
+  next[toKey] = toList;
+  if (fromKey === toKey) next[fromKey] = toList;
+
+  return next;
+}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -6,6 +6,8 @@ export interface GithubIssue {
   url: string;
   body?: string | null;
   labels: { name: string }[];
+  assignees?: { login: string; avatarUrl?: string }[];
+  milestone?: { title: string } | null;
 }
 
 export interface AssignedIssue {
@@ -130,7 +132,8 @@ export interface Config {
 
 export type WorkspaceMode =
   | "development"
-  | "agents";
+  | "agents"
+  | "kanban";
 export const workspaceMode = writable<WorkspaceMode>("development");
 export const workspaceModePickerVisible = writable<boolean>(false);
 export type SessionProvider = "claude" | "codex";

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -6,7 +6,7 @@ vi.mock('$lib/backend', () => ({
   listen: vi.fn(() => () => {}),
 }));
 
-if (!Range.prototype.getClientRects) {
+if (typeof Range !== 'undefined' && !Range.prototype.getClientRects) {
   Range.prototype.getClientRects = function getClientRects() {
     return {
       length: 0,


### PR DESCRIPTION
## Summary

- New Kanban workspace mode (Space → k) renders a full-screen board with Backlog / To Do / In Progress / In Review / Done columns backed by `status:*` GitHub labels.
- Cards drag between columns, filters apply across assignee / label / milestone, and per-user within-column order persists locally via two new Tauri commands (`kanban_load_order` / `kanban_save_order`).
- Logic extracted into pure modules (`src/lib/kanban/{columns,filter,ordering}.ts`) with 20 Vitest unit tests and 5 Rust round-trip tests.

Design + implementation plans checked in at `docs/plans/2026-04-22-kanban-board-{design,implementation}.md`.

## Test plan

- [x] `pnpm vitest run src/lib/kanban/` — 20/20 green
- [x] `cd src-tauri && cargo test --lib` — 288/288 green
- [x] `pnpm svelte-check` — no new errors (one pre-existing IssuesModal error untouched)
- [ ] Launch `pnpm tauri dev`, press Space → k, verify the board renders and a card can be dragged between columns against a real repo

Drag-and-drop + reload-persistence E2E against live GitHub labels is deferred until the repo has a GitHub-issue fixture pipeline; `e2e/specs/kanban.spec.ts` currently covers the mode-switch and column scaffold.

closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)