### PR TITLE
chore: add project pre-commit hook mirroring CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mirrors .github/workflows/ci.yml so local commits match CI.
+# Runs from the worktree root regardless of where `git commit` was invoked.
+cd "$(git rev-parse --show-toplevel)"
+
+# Git exports GIT_DIR/GIT_INDEX_FILE/etc. into hooks; subprocess `git`
+# calls inside tests would otherwise target the parent repo instead of
+# their tmp repos, breaking any test that shells out to git.
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_EXEC_PATH \
+      GIT_AUTHOR_DATE GIT_COMMITTER_DATE GIT_EDITOR GIT_REFLOG_ACTION
+
+echo "[pre-commit] pnpm check"
+pnpm check
+
+echo "[pre-commit] pnpm test"
+pnpm test
+
+echo "[pre-commit] cargo +stable fmt --check"
+(cd src-tauri && cargo +stable fmt --check)
+
+echo "[pre-commit] cargo +stable clippy -- -D warnings"
+(cd src-tauri && cargo +stable clippy -- -D warnings)
+
+echo "[pre-commit] cargo +stable test"
+# --test-threads=1 works around a shared-env-var flake between scaffold
+# tests and worktree tests; see followup issue.
+(cd src-tauri && cargo +stable test -- --test-threads=1)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:e2e": "npx playwright test --project=e2e",
     "demo": "npx playwright test --project=demo",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-commit` that runs the same checks as `.github/workflows/ci.yml` — `pnpm check`, `pnpm test`, `cargo +stable fmt --check`, `cargo +stable clippy -- -D warnings`, `cargo +stable test`
- Adds a `prepare` script to `package.json` that sets `core.hooksPath=.githooks` automatically after `pnpm install`, so every fresh clone and new worktree picks the hook up without any manual setup
- Pins cargo steps to `+stable` to match CI's `dtolnay/rust-toolchain@stable`
- Runs `cargo test` single-threaded to dodge a pre-existing shared-env-var flake between scaffold and worktree tests (followup issue recommended)
- Clears `GIT_DIR`/`GIT_INDEX_FILE`/etc. before running checks — git exports them into hook environments, and subprocess `git` calls inside tests would otherwise target the parent repo rather than their tmp repos

## Test plan
- [x] Fresh `pnpm install` in this worktree auto-set `core.hooksPath` to `.githooks`
- [x] `git commit` on this branch triggered the hook; all five checks ran and passed
- [ ] Verify on a teammate's fresh clone that `pnpm install` alone activates the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)